### PR TITLE
chore: bump rc version to 2.0.0-rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 dependencies = [
  "darling",
  "heck",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.11", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.11", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.12", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.12", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -34,7 +34,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.11 --features registry
+cargo add oxana@2.0.0-rc.12 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> No runtime or API code changes—only version strings and documentation for the next RC publish.
> 
> **Overview**
> Bumps the workspace release candidate from **2.0.0-rc.11** to **2.0.0-rc.12** across `oxana`, `oxana-macros`, and `oxana-web`.
> 
> Updates root `Cargo.toml` workspace dependency pins, each crate’s `version` in its `Cargo.toml`, matching entries in `Cargo.lock`, and the Quick Start `cargo add` example in `oxana/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11258f1d659a9aa21ecd2382644f1b7ff9b4aaba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->