### PR TITLE
feat: add enqueue_list API

### DIFF
--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -137,6 +137,65 @@ impl Storage {
         self.enqueue_in(queue, job, 0).await
     }
 
+    /// Enqueues multiple jobs to the same queue for immediate processing.
+    ///
+    /// The returned job IDs are in the same order as the input jobs. Unique-job
+    /// conflict handling is the same as [`enqueue`](Self::enqueue): skipped jobs
+    /// return their existing deterministic job ID, and replace conflicts update
+    /// the stored job before enqueueing it again.
+    ///
+    /// # Arguments
+    ///
+    /// * `queue` - The queue to enqueue the jobs to
+    /// * `jobs` - The jobs to enqueue (each must implement [`Job`])
+    ///
+    /// # Returns
+    ///
+    /// A vector of [`JobId`]s that can be used to track the jobs, or an
+    /// [`OxanaError`] if the operation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use oxana::{Storage, Queue, Job};
+    ///
+    /// async fn example(storage: &Storage) -> Result<(), oxana::OxanaError> {
+    ///     let job_ids = storage
+    ///         .enqueue_list(
+    ///             MyQueue,
+    ///             vec![
+    ///                 MyJob { data: "first" },
+    ///                 MyJob { data: "second" },
+    ///             ],
+    ///         )
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn enqueue_list<T, Jobs>(
+        &self,
+        queue: impl Queue,
+        jobs: Jobs,
+    ) -> Result<Vec<JobId>, OxanaError>
+    where
+        T: Job + 'static,
+        Jobs: IntoIterator<Item = T>,
+    {
+        let queue_key = queue.key();
+        let envelopes = jobs
+            .into_iter()
+            .map(|job| JobEnvelope::new(queue_key.clone(), job))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        tracing::trace!(
+            queue = queue_key,
+            count = envelopes.len(),
+            "Enqueuing job list"
+        );
+
+        self.internal.enqueue_list(envelopes).await
+    }
+
     /// Enqueues a job to be processed after a specified delay.
     ///
     /// # Arguments

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -310,12 +310,27 @@ impl StorageInternal {
             .await
     }
 
+    pub async fn enqueue_list(
+        &self,
+        envelopes: Vec<JobEnvelope>,
+    ) -> Result<Vec<JobId>, OxanaError> {
+        if envelopes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut redis = self.connection().await?;
+        self.enqueue_list_w_conn(&mut redis, envelopes, JobDestination::Queue)
+            .await
+    }
+
     async fn enqueue_w_conn(
         &self,
         redis: &mut deadpool_redis::Connection,
         envelope: JobEnvelope,
         destination: JobDestination,
     ) -> Result<JobId, OxanaError> {
+        let mut pipe = redis::pipe();
+
         match self.job_enqueue_action(redis, &envelope).await? {
             JobEnqueueAction::Skip => {
                 tracing::warn!("Unique job {} already exists, skipping", envelope.id);
@@ -325,22 +340,89 @@ impl StorageInternal {
             JobEnqueueAction::Replace { existing_queue } => {
                 tracing::warn!("Unique job {} already exists, replacing", envelope.id);
 
-                self.replace_w_conn(redis, &existing_queue, &envelope, destination)
-                    .await?;
+                self.append_replace(&mut pipe, &existing_queue, &envelope, destination)?;
             }
             JobEnqueueAction::Default => {
-                let mut pipe = redis::pipe();
-                pipe.hset(
-                    &self.keys.jobs,
-                    &envelope.id,
-                    serde_json::to_string(&envelope)?,
-                );
-                self.push_to_destination(&mut pipe, &envelope, destination);
-                let _: () = pipe.query_async(&mut *redis).await?;
+                self.append_enqueue(&mut pipe, &envelope, destination)?;
             }
         }
 
+        let _: () = pipe.query_async(&mut *redis).await?;
+
         Ok(envelope.id)
+    }
+
+    async fn enqueue_list_w_conn(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        envelopes: Vec<JobEnvelope>,
+        destination: JobDestination,
+    ) -> Result<Vec<JobId>, OxanaError> {
+        let mut pipe = redis::pipe();
+        let mut has_writes = false;
+        let mut job_ids = Vec::with_capacity(envelopes.len());
+        let mut staged_unique_queues: HashMap<JobId, String> = HashMap::new();
+
+        for envelope in envelopes {
+            let job_id = envelope.id.clone();
+
+            let action = if envelope.meta.unique {
+                match staged_unique_queues.get(&envelope.id) {
+                    Some(existing_queue) => match envelope.meta.on_conflict.as_ref() {
+                        Some(JobConflictStrategy::Replace) => JobEnqueueAction::Replace {
+                            existing_queue: existing_queue.clone(),
+                        },
+                        Some(JobConflictStrategy::Skip) | None => JobEnqueueAction::Skip,
+                    },
+                    None => self.job_enqueue_action(redis, &envelope).await?,
+                }
+            } else {
+                JobEnqueueAction::Default
+            };
+
+            match action {
+                JobEnqueueAction::Skip => {
+                    tracing::warn!("Unique job {} already exists, skipping", envelope.id);
+                }
+                JobEnqueueAction::Replace { existing_queue } => {
+                    tracing::warn!("Unique job {} already exists, replacing", envelope.id);
+
+                    self.append_replace(&mut pipe, &existing_queue, &envelope, destination)?;
+                    staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
+                    has_writes = true;
+                }
+                JobEnqueueAction::Default => {
+                    self.append_enqueue(&mut pipe, &envelope, destination)?;
+                    if envelope.meta.unique {
+                        staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
+                    }
+                    has_writes = true;
+                }
+            }
+
+            job_ids.push(job_id);
+        }
+
+        if has_writes {
+            let _: () = pipe.query_async(&mut *redis).await?;
+        }
+
+        Ok(job_ids)
+    }
+
+    fn append_enqueue(
+        &self,
+        pipe: &mut redis::Pipeline,
+        envelope: &JobEnvelope,
+        destination: JobDestination,
+    ) -> Result<(), OxanaError> {
+        pipe.hset(
+            &self.keys.jobs,
+            &envelope.id,
+            serde_json::to_string(envelope)?,
+        );
+        self.push_to_destination(pipe, envelope, destination);
+        Ok(())
     }
 
     fn push_to_destination(
@@ -391,16 +473,15 @@ impl StorageInternal {
         }
     }
 
-    async fn replace_w_conn(
+    fn append_replace(
         &self,
-        redis: &mut deadpool_redis::Connection,
+        pipe: &mut redis::Pipeline,
         existing_queue: &str,
         envelope: &JobEnvelope,
         destination: JobDestination,
     ) -> Result<(), OxanaError> {
         let old_queue = self.namespace_queue(existing_queue);
 
-        let mut pipe = redis::pipe();
         pipe.hset(
             &self.keys.jobs,
             &envelope.id,
@@ -414,9 +495,8 @@ impl StorageInternal {
             pipe.lrem(self.namespace_queue(&envelope.queue), 0, &envelope.id);
         }
 
-        self.push_to_destination(&mut pipe, envelope, destination);
+        self.push_to_destination(pipe, envelope, destination);
 
-        let _: () = pipe.query_async(&mut *redis).await?;
         Ok(())
     }
 

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -140,6 +140,66 @@ pub async fn test_standard() -> TestResult {
 }
 
 #[tokio::test]
+pub async fn test_enqueue_list() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerRedisSet, WorkerRedisSetJob>()
+        .exit_when_processed(3);
+
+    let key1 = random_string();
+    let key2 = random_string();
+    let key3 = random_string();
+
+    let job_ids = storage
+        .enqueue_list(
+            QueueOne,
+            vec![
+                WorkerRedisSetJob {
+                    key: key1.clone(),
+                    value: "first".to_string(),
+                },
+                WorkerRedisSetJob {
+                    key: key2.clone(),
+                    value: "second".to_string(),
+                },
+                WorkerRedisSetJob {
+                    key: key3.clone(),
+                    value: "third".to_string(),
+                },
+            ],
+        )
+        .await?;
+
+    assert_eq!(job_ids.len(), 3);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 3);
+
+    runtime.run().await?;
+
+    let value1: Option<String> = redis_conn.get(key1).await?;
+    let value2: Option<String> = redis_conn.get(key2).await?;
+    let value3: Option<String> = redis_conn.get(key3).await?;
+
+    assert_eq!(value1, Some("first".to_string()));
+    assert_eq!(value2, Some("second".to_string()));
+    assert_eq!(value3, Some("third".to_string()));
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
 pub async fn test_shutdown_keeps_heartbeat_until_workers_finish() -> TestResult {
     let redis_pool = setup();
     let storage = oxana::Storage::builder()

--- a/oxana/tests/integration/unique.rs
+++ b/oxana/tests/integration/unique.rs
@@ -224,6 +224,108 @@ pub async fn test_unique_skip() -> TestResult {
 }
 
 #[tokio::test]
+pub async fn test_enqueue_list_unique_skip_deduplicates_within_batch() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerUniqueSkip, WorkerUniqueSkipJob>()
+        .exit_when_processed(1);
+    let key = random_string();
+
+    let job_ids = storage
+        .enqueue_list(
+            QueueOne,
+            vec![
+                WorkerUniqueSkipJob {
+                    id: 1,
+                    key: key.clone(),
+                    value: 1,
+                },
+                WorkerUniqueSkipJob {
+                    id: 1,
+                    key: key.clone(),
+                    value: 2,
+                },
+            ],
+        )
+        .await?;
+
+    assert_eq!(job_ids.len(), 2);
+    assert_eq!(job_ids[0], job_ids[1]);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
+
+    runtime.run().await?;
+
+    assert_eq!(storage.dead_count().await?, 0);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    let value: Option<i32> = redis_conn.get(key).await?;
+    assert_eq!(value, Some(1));
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_enqueue_list_unique_replace_deduplicates_within_batch() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerUniqueReplace, WorkerUniqueReplaceJob>()
+        .exit_when_processed(1);
+    let key = random_string();
+
+    let job_ids = storage
+        .enqueue_list(
+            QueueOne,
+            vec![
+                WorkerUniqueReplaceJob {
+                    id: 1,
+                    key: key.clone(),
+                    value: 1,
+                },
+                WorkerUniqueReplaceJob {
+                    id: 1,
+                    key: key.clone(),
+                    value: 2,
+                },
+            ],
+        )
+        .await?;
+
+    assert_eq!(job_ids.len(), 2);
+    assert_eq!(job_ids[0], job_ids[1]);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
+
+    runtime.run().await?;
+
+    assert_eq!(storage.dead_count().await?, 0);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    let value: Option<i32> = redis_conn.get(key).await?;
+    assert_eq!(value, Some(2));
+
+    Ok(())
+}
+
+#[tokio::test]
 pub async fn test_unique_replace_clears_stale_retry_entry() -> TestResult {
     let redis_pool = setup();
     let ctx = WorkerState {


### PR DESCRIPTION
## Summary
- Add public `Storage::enqueue_list(queue, jobs)` for enqueueing multiple same-typed jobs to one queue.
- Batch internal enqueue writes through one Redis pipeline while preserving existing unique job skip/replace behavior.
- Add integration coverage for normal list enqueue and duplicate unique skip/replace jobs within one list.

## Pre-Landing Review
- Reviewed the diff locally. Fixed the duplicate unique-job issue found in `enqueue_list_w_conn` before shipping.

## Test Coverage
- Added integration tests for list enqueue happy path.
- Added regression tests for duplicate unique `Skip` and `Replace` jobs in one batch.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --workspace --all-targets`
- [x] `cargo test -p oxana`
- [x] `git diff --check`

🤖 Generated with OpenAI Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core Redis enqueue path and unique-job conflict handling for batches; behavior is covered by new integration tests but batch semantics are easy to get wrong.
> 
> **Overview**
> Adds **`Storage::enqueue_list`** so callers can enqueue many same-typed jobs to one queue in a single call, with returned **`JobId`s** in input order.
> 
> Internally, batch enqueue uses **one Redis pipeline** per request (shared with refactored single **`enqueue`**, which now builds writes via **`append_enqueue`** / **`append_replace`** instead of per-path inline pipes). **Unique** jobs keep **skip** and **replace** behavior, including **deduplication within the same batch** via in-memory staging so duplicate IDs in one list do not double-enqueue.
> 
> Integration tests cover a three-job happy path and unique **skip** / **replace** duplicates inside one list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db24195feb66b06e7c55aed0e4a8d302aab117cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->