### PR TITLE
fix: chunk enqueue_list Redis pipelines

### DIFF
--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -372,39 +372,32 @@ impl StorageInternal {
 
             for envelope in chunk {
                 let job_id = envelope.id.clone();
+                let action = self
+                    .enqueue_list_action(redis, envelope, &staged_unique_queues)
+                    .await?;
 
-                let action = if envelope.meta.unique {
-                    match staged_unique_queues.get(&envelope.id) {
-                        Some(existing_queue) => match envelope.meta.on_conflict.as_ref() {
-                            Some(JobConflictStrategy::Replace) => JobEnqueueAction::Replace {
-                                existing_queue: existing_queue.clone(),
-                            },
-                            Some(JobConflictStrategy::Skip) | None => JobEnqueueAction::Skip,
-                        },
-                        None => self.job_enqueue_action(redis, envelope).await?,
-                    }
-                } else {
-                    JobEnqueueAction::Default
-                };
-
-                match action {
+                let wrote = match action {
                     JobEnqueueAction::Skip => {
                         tracing::warn!("Unique job {} already exists, skipping", envelope.id);
+                        false
                     }
                     JobEnqueueAction::Replace { existing_queue } => {
                         tracing::warn!("Unique job {} already exists, replacing", envelope.id);
 
                         self.append_replace(&mut pipe, &existing_queue, envelope, destination)?;
-                        staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
-                        has_writes = true;
+                        true
                     }
                     JobEnqueueAction::Default => {
                         self.append_enqueue(&mut pipe, envelope, destination)?;
-                        if envelope.meta.unique {
-                            staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
-                        }
-                        has_writes = true;
+                        true
                     }
+                };
+
+                if wrote {
+                    if envelope.meta.unique {
+                        staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
+                    }
+                    has_writes = true;
                 }
 
                 job_ids.push(job_id);
@@ -416,6 +409,28 @@ impl StorageInternal {
         }
 
         Ok(job_ids)
+    }
+
+    async fn enqueue_list_action(
+        &self,
+        redis: &mut deadpool_redis::Connection,
+        envelope: &JobEnvelope,
+        staged_unique_queues: &HashMap<JobId, String>,
+    ) -> Result<JobEnqueueAction, OxanaError> {
+        if !envelope.meta.unique {
+            return Ok(JobEnqueueAction::Default);
+        }
+
+        let Some(existing_queue) = staged_unique_queues.get(&envelope.id) else {
+            return self.job_enqueue_action(redis, envelope).await;
+        };
+
+        match envelope.meta.on_conflict.as_ref() {
+            Some(JobConflictStrategy::Replace) => Ok(JobEnqueueAction::Replace {
+                existing_queue: existing_queue.clone(),
+            }),
+            Some(JobConflictStrategy::Skip) | None => Ok(JobEnqueueAction::Skip),
+        }
     }
 
     fn append_enqueue(

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -35,10 +35,15 @@ use crate::{
 
 const JOB_EXPIRE_TIME: i64 = 7 * 24 * 3600; // 7 days
 const SCAN_BATCH_SIZE: usize = 500;
+const ENQUEUE_LIST_CHUNK_SIZE: usize = 100;
 const QUEUE_LENGTH_SNAPSHOT_TTL_SECS: i64 = 120;
 
 fn unix_timestamp_secs_f64() -> f64 {
     chrono::Utc::now().timestamp_millis() as f64 / 1000.0
+}
+
+fn enqueue_list_chunks(envelopes: &[JobEnvelope]) -> std::slice::Chunks<'_, JobEnvelope> {
+    envelopes.chunks(ENQUEUE_LIST_CHUNK_SIZE)
 }
 
 #[derive(Clone)]
@@ -358,53 +363,56 @@ impl StorageInternal {
         envelopes: Vec<JobEnvelope>,
         destination: JobDestination,
     ) -> Result<Vec<JobId>, OxanaError> {
-        let mut pipe = redis::pipe();
-        let mut has_writes = false;
         let mut job_ids = Vec::with_capacity(envelopes.len());
         let mut staged_unique_queues: HashMap<JobId, String> = HashMap::new();
 
-        for envelope in envelopes {
-            let job_id = envelope.id.clone();
+        for chunk in enqueue_list_chunks(&envelopes) {
+            let mut pipe = redis::pipe();
+            let mut has_writes = false;
 
-            let action = if envelope.meta.unique {
-                match staged_unique_queues.get(&envelope.id) {
-                    Some(existing_queue) => match envelope.meta.on_conflict.as_ref() {
-                        Some(JobConflictStrategy::Replace) => JobEnqueueAction::Replace {
-                            existing_queue: existing_queue.clone(),
+            for envelope in chunk {
+                let job_id = envelope.id.clone();
+
+                let action = if envelope.meta.unique {
+                    match staged_unique_queues.get(&envelope.id) {
+                        Some(existing_queue) => match envelope.meta.on_conflict.as_ref() {
+                            Some(JobConflictStrategy::Replace) => JobEnqueueAction::Replace {
+                                existing_queue: existing_queue.clone(),
+                            },
+                            Some(JobConflictStrategy::Skip) | None => JobEnqueueAction::Skip,
                         },
-                        Some(JobConflictStrategy::Skip) | None => JobEnqueueAction::Skip,
-                    },
-                    None => self.job_enqueue_action(redis, &envelope).await?,
-                }
-            } else {
-                JobEnqueueAction::Default
-            };
-
-            match action {
-                JobEnqueueAction::Skip => {
-                    tracing::warn!("Unique job {} already exists, skipping", envelope.id);
-                }
-                JobEnqueueAction::Replace { existing_queue } => {
-                    tracing::warn!("Unique job {} already exists, replacing", envelope.id);
-
-                    self.append_replace(&mut pipe, &existing_queue, &envelope, destination)?;
-                    staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
-                    has_writes = true;
-                }
-                JobEnqueueAction::Default => {
-                    self.append_enqueue(&mut pipe, &envelope, destination)?;
-                    if envelope.meta.unique {
-                        staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
+                        None => self.job_enqueue_action(redis, envelope).await?,
                     }
-                    has_writes = true;
+                } else {
+                    JobEnqueueAction::Default
+                };
+
+                match action {
+                    JobEnqueueAction::Skip => {
+                        tracing::warn!("Unique job {} already exists, skipping", envelope.id);
+                    }
+                    JobEnqueueAction::Replace { existing_queue } => {
+                        tracing::warn!("Unique job {} already exists, replacing", envelope.id);
+
+                        self.append_replace(&mut pipe, &existing_queue, envelope, destination)?;
+                        staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
+                        has_writes = true;
+                    }
+                    JobEnqueueAction::Default => {
+                        self.append_enqueue(&mut pipe, envelope, destination)?;
+                        if envelope.meta.unique {
+                            staged_unique_queues.insert(job_id.clone(), envelope.queue.clone());
+                        }
+                        has_writes = true;
+                    }
                 }
+
+                job_ids.push(job_id);
             }
 
-            job_ids.push(job_id);
-        }
-
-        if has_writes {
-            let _: () = pipe.query_async(&mut *redis).await?;
+            if has_writes {
+                let _: () = pipe.query_async(&mut *redis).await?;
+            }
         }
 
         Ok(job_ids)
@@ -2365,6 +2373,23 @@ mod tests {
         );
 
         Ok(latency_micros)
+    }
+
+    #[test]
+    fn enqueue_list_chunks_batches_by_one_hundred() -> TestResult {
+        let queue = random_string();
+        let envelopes = (0..(ENQUEUE_LIST_CHUNK_SIZE * 2 + 1))
+            .map(|_| JobEnvelope::new(queue.clone(), TestJob {}))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let chunk_sizes = enqueue_list_chunks(&envelopes)
+            .map(<[JobEnvelope]>::len)
+            .collect::<Vec<_>>();
+
+        assert_eq!(ENQUEUE_LIST_CHUNK_SIZE, 100);
+        assert_eq!(chunk_sizes, vec![100, 100, 1]);
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/oxana/tests/integration/unique.rs
+++ b/oxana/tests/integration/unique.rs
@@ -275,6 +275,53 @@ pub async fn test_enqueue_list_unique_skip_deduplicates_within_batch() -> TestRe
 }
 
 #[tokio::test]
+pub async fn test_enqueue_list_unique_skip_deduplicates_across_chunks() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerUniqueSkip, WorkerUniqueSkipJob>()
+        .exit_when_processed(100);
+    let duplicate_key = random_string();
+
+    let jobs = (0..101)
+        .map(|idx| WorkerUniqueSkipJob {
+            id: if idx == 100 { 99 } else { idx },
+            key: if idx >= 99 {
+                duplicate_key.clone()
+            } else {
+                random_string()
+            },
+            value: idx,
+        })
+        .collect::<Vec<_>>();
+
+    let job_ids = storage.enqueue_list(QueueOne, jobs).await?;
+
+    assert_eq!(job_ids.len(), 101);
+    assert_eq!(job_ids[99], job_ids[100]);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 100);
+
+    runtime.run().await?;
+
+    assert_eq!(storage.dead_count().await?, 0);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    let value: Option<i32> = redis_conn.get(duplicate_key).await?;
+    assert_eq!(value, Some(99));
+
+    Ok(())
+}
+
+#[tokio::test]
 pub async fn test_enqueue_list_unique_replace_deduplicates_within_batch() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;
@@ -321,6 +368,53 @@ pub async fn test_enqueue_list_unique_replace_deduplicates_within_batch() -> Tes
 
     let value: Option<i32> = redis_conn.get(key).await?;
     assert_eq!(value, Some(2));
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_enqueue_list_unique_replace_deduplicates_across_chunks() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerUniqueReplace, WorkerUniqueReplaceJob>()
+        .exit_when_processed(100);
+    let duplicate_key = random_string();
+
+    let jobs = (0..101)
+        .map(|idx| WorkerUniqueReplaceJob {
+            id: if idx == 100 { 99 } else { idx },
+            key: if idx >= 99 {
+                duplicate_key.clone()
+            } else {
+                random_string()
+            },
+            value: idx,
+        })
+        .collect::<Vec<_>>();
+
+    let job_ids = storage.enqueue_list(QueueOne, jobs).await?;
+
+    assert_eq!(job_ids.len(), 101);
+    assert_eq!(job_ids[99], job_ids[100]);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 100);
+
+    runtime.run().await?;
+
+    assert_eq!(storage.dead_count().await?, 0);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.jobs_count().await?, 0);
+
+    let value: Option<i32> = redis_conn.get(duplicate_key).await?;
+    assert_eq!(value, Some(100));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Chunk `enqueue_list` Redis pipelines into batches of 100 jobs.
- Preserve ordered job IDs and unique-job skip/replace tracking across chunks.
- Add unit coverage for the 100-job chunk boundary.

## Test plan
- `cargo fmt --all`
- `cargo clippy --all-features --workspace`
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core bulk enqueue path and unique-job conflict logic; incorrect cross-chunk staging could duplicate or drop jobs on large batches.
> 
> **Overview**
> **`enqueue_list`** no longer builds one Redis pipeline for the entire batch. It now processes jobs in **chunks of 100**, runs a pipeline per chunk, and still returns **job IDs in input order**.
> 
> Unique-job **skip** and **replace** behavior is preserved **across chunk boundaries** via a `staged_unique_queues` map and a new **`enqueue_list_action`** helper, so duplicates in the same bulk enqueue (e.g. job 99 and 100 with the same unique id) are handled like within-batch dedup.
> 
> Adds a unit test for chunk sizing and integration tests that enqueue **101** jobs with a duplicate straddling the 100-job boundary for both skip and replace strategies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34a24ede1b24e4ad8d964546202d04ca974a7511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->