### PR TITLE
chore: bump rc version to 2.0.0-rc.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,7 +1087,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 dependencies = [
  "darling",
  "heck",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.13", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.13", path = "oxana-macros" }
+oxana = { version = "2.0.0-rc.14", path = "oxana" }
+oxana-macros = { version = "2.0.0-rc.14", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -34,7 +34,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.13 --features registry
+cargo add oxana@2.0.0-rc.14 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary
- Bump `oxana`, `oxana-macros`, and `oxana-web` from `2.0.0-rc.13` to `2.0.0-rc.14`.
- Refresh `Cargo.lock` for the workspace package versions.
- Update the README install example to reference `2.0.0-rc.14`.

## Verification
- `cargo check --all`
- `cargo test` — 131 passed across 3 suites

## Review
Pre-Landing Review: No issues found.
No frontend files changed — design review skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or API code changes—only version strings and lockfile metadata.
> 
> **Overview**
> Bumps the workspace release candidate from **2.0.0-rc.13** to **2.0.0-rc.14** across `oxana`, `oxana-macros`, and `oxana-web`.
> 
> Updates workspace `Cargo.toml` dependency pins, each crate’s package version, `Cargo.lock`, and the README `cargo add` example so install docs match the new tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4670a0042cab5b3b484ffa3f47fd74c4cdd7c4c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->