### PR TITLE
v2.0.0 chore: release Oxana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,64 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.0-rc]
+## [2.0.0]
 
 **Breaking release.** See [MIGRATION.md](MIGRATION.md) for the 1.x -> 2.x upgrade guide.
 
-### Breaking Changes
+### Major Changes
 
 - Rename the project and crates from Oxanus to Oxana. Use `oxana`, `oxana-macros`, `oxana-web`, and `#[oxana(...)]` in manifests, imports, derive attributes, examples, and dashboard integrations.
-- Move enqueue-time metadata onto `#[derive(oxana::Job)]`. Job identity, conflict handling, resurrection, throttle cost, and on-demand exposure now belong to the job type; runtime registration maps job types to workers, and custom job hooks now resolve `Self` as the job type.
-- Replace the public `Config` setup path with a typed runtime API: keep `Storage` for enqueueing/monitoring, register workers and queues with `storage.runtime(ctx)`, run with `runtime.run()`, drain with `runtime.drain(queue)`, and inspect registrations with `runtime.catalog()`.
-- Route every worker through the batch-capable execution path. Manual worker implementations now provide `process` or `run_batch` (both have defaults; implementing neither compiles but panics at runtime on the first job), while derive users can keep writing `process` for single-job workers or opt into `process_batch`.
-- Drop the `Serialize` supertrait from `Queue`. Static queues no longer need serializable fields; manual dynamic queue implementations must now implement `key()` themselves (the default panics for dynamic queues).
-- Rename the `QueueKind::Dynamic` field `sleep_period` to `discovery_interval`. Code that pattern-matches or constructs `QueueKind::Dynamic` must be updated.
-- Add `'static` bounds to `Storage::enqueue`/`enqueue_in`/`enqueue_at` job parameters and `Job::name()`.
-- Add a required `legacy_names` field to `WorkerConfig` for manual worker registrations (the derive and `register_worker` fill it with the worker's type name).
-- Own job values during execution instead of borrowing them, so job payload types no longer need to implement `Sync`.
-- Simplify structured job progress to cursor/total values. `JobProgress` no longer exposes a separate `processed` field, and `update_progress` tuple helpers now use `(cursor, total)` or `(cursor, total, note)`.
-- Remove unused convenience accessors: `JobMeta::{created_at_millis, scheduled_at_millis, scheduled_at_secs, latency_secs, started_at_secs, started_at_millis}`, `JobMetricsTotals::execution_seconds`, `JobProgressIterator::current_index`, and the never-raised `OxanaError::JobPanicked` variant.
-- Mark `OxanaError` as `#[non_exhaustive]`. Downstream `match` expressions on the error enum must add a wildcard arm; future variant additions will no longer be breaking.
+- Replace the `Config`-first setup flow with a typed runtime API. `Storage` now focuses on enqueueing, scheduling, metrics, and monitoring; `storage.runtime(ctx)` handles queue and worker registration, runtime settings, `run()`, `drain(queue)`, and `catalog()`.
+- Move persisted job identity and enqueue-time metadata onto the job type. Runtime registrations now map job types to workers, while unique IDs, conflict handling, resurrection, retry-state resume, throttle cost, and on-demand exposure are defined by `Job`.
+- Keep a migration path for existing Redis data by registering legacy worker-name aliases, so 2.x runtimes can consume queued, scheduled, retry, and dead jobs written by 1.x workers.
+- Route workers through a batch-capable execution path. Workers now receive owned job values, manual implementations provide `process` or `run_batch`, and job payloads no longer need to implement `Sync`.
+- Simplify queue definitions. Static queues no longer need `Serialize`, dynamic queues use an explicit `discovery_interval`, and manual dynamic queues must provide their own `key()`.
+- Simplify structured progress to cursor/total state. `JobProgress` no longer exposes a separate `processed` field, and progress helpers use `(cursor, total)` or `(cursor, total, note)`.
+- Remove deprecated or unused public surface, including legacy `JobMeta` timestamp helpers, `JobMetricsTotals::execution_seconds`, `JobProgressIterator::current_index`, and the never-raised `OxanaError::JobPanicked` variant. `OxanaError` is now `#[non_exhaustive]`.
 
-### Added
+### New Features
 
-- Add a root MIT license file and README license section.
-- Add batch workers with `#[oxana(batch_size = ..., batch_timeout_ms = ...)]`, `process_batch`, `BatchItem`, and `WorkerBatchConfig` for high-throughput workloads that can process jobs together.
-- Add on-demand jobs: annotate a job with `#[oxana(on_demand)]` to expose it in the web dashboard with editable JSON arguments and type-aware argument templates.
-- Add worker execution metrics, including per-minute success, failure, panic, execution-time, and histogram data through `Storage::job_metrics`, `Storage::job_metrics_for`, and the new `/metrics` dashboard pages.
-- Add queue length history, per-queue processing rates, growth rates, effective drain rates, and ETA estimates to the stats APIs and dashboard.
-- Add `REDIS_STATS_URL`, `build_from_redis_urls`, and `build_from_pools` so counters and metrics can use a separate Redis instance from the primary job store.
-- Add dashboard actions for enqueueing cron jobs immediately and wiping the dead queue.
-- Add structured job progress state with `ctx.state.update_progress(...)`, `ctx.state.progress()`, and dashboard progress bars for long-running jobs.
-- Add `ctx.state.iter_with_progress(...)` and `JobProgressIterator` for resumable iterator-style jobs that should restart from the saved cursor and advance progress as items complete.
-- Show scalar job arguments as compact dashboard pills while preserving raw JSON for complex arguments.
-- Add runtime queue configuration storage for queue state and dynamic concurrency overrides.
-- Add dynamic queue concurrency through `QueueConfig::dynamic_concurrency(...)` and `#[oxana(concurrency = Dynamic(...))]`.
-- Add `Storage::set_queue_concurrency`, `Storage::set_queue_state`, `Storage::pause_queue`, `Storage::unpause_queue`, and `Storage::reset_queue_config` for changing queue runtime behavior without restarting workers.
-- Add dashboard controls for pausing queues and changing dynamic queue concurrency from queue detail pages.
-- Add dynamic concurrency examples, including seeded dynamic tenant queues in the web dashboard example.
-- Add runtime tuning setters for worker heartbeats, resurrection/failover thresholds, retry/schedule/cron polling, dequeue/dispatcher backoff, shutdown timeout, and Redis response timeout.
-- Add a configurable dynamic queue discovery interval through `QueueConfig::discovery_interval(...)` and `#[oxana(discovery_interval_ms = ...)]`.
-
-### Changed
-
-- Register temporary legacy worker-name aliases so 2.x runtimes can consume 1.x queued, scheduled, retry, and dead jobs whose envelopes still use worker type names.
-- Make dashboard queue and metrics views more operationally useful: queue length charts now live with queue stats, tooltips use readable worker labels, zero-value tooltip rows are hidden, and unknown ETAs sort after known drain times.
-- Add a 24-hour window to job metrics views, retain metrics long enough to back it, and downsample long-window chart payloads.
-- Show progress-aware job state and ETA estimates in the dashboard while preserving cursor-only resumable state as raw job state.
-- Reduce Redis pressure by replacing `KEYS` with cursor-based `SCAN`, batching result counter writes, and snapshotting active queue lengths during worker refreshes.
-- Improve on-demand registration so the dashboard can prefill arguments, keep job hooks intact, and choose a sensible default queue.
-- Refresh examples, package metadata, CI paths, documentation references, and dependency versions for the Oxana rename and 2.0 release candidate.
-- Apply runtime queue state and dynamic concurrency changes while dispatchers are running.
-- Clear persisted concurrency overrides when a dynamic queue is set back to its effective default.
-- Treat a dynamic child queue's effective concurrency default as the inherited base queue runtime concurrency.
-- Show dashboard concurrency overrides with the default value struck through.
-
-### Fixed
-
-- Avoid persisting runtime queue config when a queue is only using its default configuration.
-- Clear stale retry and schedule membership when replacing a unique job so the old retry attempt cannot run after the replacement resets the retry counter.
-- Keep worker heartbeats active while graceful shutdown drains in-flight jobs, preventing another process from treating those jobs as abandoned.
+- Add batch workers with `#[oxana(batch_size = ..., batch_timeout_ms = ...)]`, derived `process_batch`, `BatchItem`, and `WorkerBatchConfig`.
+- Add `Storage::enqueue_list` for enqueueing multiple jobs to the same queue in one call while preserving unique-job conflict behavior.
+- Add on-demand dashboard jobs with `#[oxana(on_demand)]`, editable JSON argument templates, and manual enqueueing from the web UI.
+- Add job execution metrics through `Storage::job_metrics`, `Storage::job_metrics_for`, execution-time histograms, and new `/metrics` dashboard pages.
+- Add queue length history, per-queue processing rates, growth rates, effective drain rates, ETA estimates, and sortable queue/metrics dashboard tables.
+- Add 24-hour metrics windows with retention and chart downsampling for longer dashboard views.
+- Add structured progress APIs with `ctx.state.update_progress(...)`, `ctx.state.progress()`, `ctx.state.iter_with_progress(...)`, `JobProgressIterator`, and progress bars/ETAs in the dashboard.
+- Add runtime queue controls with persisted queue state and dynamic concurrency overrides: `QueueConfig::dynamic_concurrency(...)`, `Storage::set_queue_concurrency`, `Storage::set_queue_state`, `pause_queue`, `unpause_queue`, and `reset_queue_config`, plus dashboard controls for supported queues.
+- Add bulk operational actions for recovering jobs: retry all pending retries, revive all dead jobs, wipe the dead queue, enqueue cron jobs immediately, and re-enqueue jobs from dashboard job lists.
+- Add runtime tuning setters for worker heartbeat, resurrection/failover thresholds, Redis failure tolerance, retry/schedule/cron polling, dequeue and dispatcher backoff, throttled queue fallback wait, and shutdown timeout.
+- Add storage builder conveniences, including `Storage::from_env`, `Storage::from_url`, `build_from_redis_urls`, `build_from_pools`, and `REDIS_STATS_URL` for storing counters and metrics separately from the primary job store.
+- Improve Redis-side scalability by using cursor-based scans for queue discovery, batching result counter writes, and snapshotting active queue lengths during worker refreshes.
 
 ## [1.1.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,7 +1050,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.0-rc.14"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.0-rc.14"
+version = "2.0.0"
 dependencies = [
  "darling",
  "heck",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.0-rc.14"
+version = "2.0.0"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.0-rc.14", path = "oxana" }
-oxana-macros = { version = "2.0.0-rc.14", path = "oxana-macros" }
+oxana = { version = "2.0.0", path = "oxana" }
+oxana-macros = { version = "2.0.0", path = "oxana-macros" }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,26 +1,26 @@
-# Migration Guide: 1.x -> 2.x
+# Migration Guide: Oxanus 1.1.1 -> Oxana 2.0.0
 
-Oxana 2.x makes `Storage` a focused enqueueing and monitoring handle, and moves worker setup into a typed runtime built with `storage.runtime(ctx)`. It also changes persisted job identity from worker type names to job type names.
+Oxana 2.0 makes `Storage` a focused enqueueing and monitoring handle, and moves worker setup into a typed runtime built with `storage.runtime(ctx)`. It also changes persisted job identity from worker type names to job type names.
 
-This guide is written for applications already using the 1.x job/worker split.
+This guide is written for applications on Oxanus 1.1.1, the last 1.x release.
 
 ## Before You Upgrade
 
-Plan the Redis migration first. In 1.x, queued job envelopes were registered by `Job::worker_name()`, usually the worker type name. In 2.x, new envelopes are registered by `Job::name()`, which defaults to the job type name.
+Plan the Redis migration first. In Oxanus 1.1.1, queued job envelopes were registered by `Job::worker_name()`, usually the worker type name. In Oxana 2.0, new envelopes are registered by `Job::name()`, which defaults to the job type name.
 
-For consumer compatibility, the 2.x runtime also registers each worker's type name as a temporary legacy alias for its job type. That lets existing enqueued, scheduled, retry, and dead jobs named `FooWorker` deserialize into `FooJob` and run through `FooWorker` after the upgrade.
+For consumer compatibility, the 2.0 runtime also registers each worker's type name as a temporary legacy alias for its job type. That lets existing enqueued, scheduled, retry, and dead jobs named `FooWorker` deserialize into `FooJob` and run through `FooWorker` after the upgrade.
 
-This alias is read-side only. New jobs are still written with job-type identity, and unique job IDs are still prefixed with the new job type name. A unique 1.x job named `FooWorker/id` and a unique 2.x job named `FooJob/id` can therefore coexist during the migration window.
+This alias is read-side only. New jobs are still written with job-type identity, and unique job IDs are still prefixed with the new job type name. A unique 1.1.1 job named `FooWorker/id` and a unique 2.0 job named `FooJob/id` can therefore coexist during the migration window.
 
 Recommended options:
 
-- Stop 1.x producers and workers before starting 2.x if duplicate unique jobs would be harmful.
-- Let the 2.x runtime consume old worker-named jobs through the legacy aliases, or drain queues first if you want a cleaner cutover.
-- Use a new Oxana namespace or Redis database for the 2.x deployment.
+- Stop 1.1.1 producers and workers before starting 2.0 if duplicate unique jobs would be harmful.
+- Let the 2.0 runtime consume old worker-named jobs through the legacy aliases, or drain queues first if you want a cleaner cutover.
+- Use a new Oxana namespace or Redis database for the 2.0 deployment.
 
 ## 1. Update Crate Names And Imports
 
-If your 1.x app still uses the old Oxanus crate names or attributes, rename them to Oxana:
+Oxanus 1.1.1 used the `oxanus`, `oxanus-macros`, and `oxanus-web` crates. Rename them to Oxana:
 
 ```toml
 # Before
@@ -42,11 +42,17 @@ Update Rust paths and macro attributes the same way:
 #[oxana(key = "emails")]
 ```
 
+Also rename public types and modules:
+
+- `oxanus::OxanusError` -> `oxana::OxanaError`
+- `oxanus_web::OxanusWebState` -> `oxana_web::OxanaWebState`
+- `oxanus::...` imports and paths -> `oxana::...`
+
 ## 2. Replace Config With RuntimeBuilder
 
-In 1.x, `Config` carried worker registrations, queue registrations, shutdown settings, the global worker error type, and a storage handle.
+In Oxanus 1.1.1, `Config` carried worker registrations, queue registrations, shutdown settings, the global worker error type, and a storage handle.
 
-In 2.x:
+In Oxana 2.0:
 
 - `Storage` handles enqueueing, scheduling, metrics, and queue monitoring.
 - `RuntimeBuilder<C>` handles context, worker/queue registration, runtime settings, running, draining, and catalogs.
@@ -55,18 +61,18 @@ In 2.x:
 Before:
 
 ```rust
-#[derive(oxana::Registry)]
-struct ComponentRegistry(oxana::ComponentRegistry<AppContext, AppError>);
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<AppContext, AppError>);
 
-let ctx = oxana::ContextValue::new(AppContext { db, mailer });
-let storage = oxana::Storage::builder().build_from_env()?;
+let ctx = oxanus::ContextValue::new(AppContext { db, mailer });
+let storage = oxanus::Storage::builder().build_from_env()?;
 
 let config = ComponentRegistry::build_config(&storage)
     .with_graceful_shutdown(tokio::signal::ctrl_c())
     .exit_when_processed(1);
 
 storage.enqueue(EmailQueue, SendEmailJob { user_id }).await?;
-oxana::run(config, ctx).await?;
+oxanus::run(config, ctx).await?;
 ```
 
 After:
@@ -91,7 +97,7 @@ Manual registration moves the same way:
 
 ```rust
 // Before
-let config = oxana::Config::<AppContext, AppError>::new(&storage)
+let config = oxanus::Config::<AppContext, AppError>::new(&storage)
     .register_queue::<EmailQueue>()
     .register_worker::<SendEmailWorker, SendEmailJob>();
 
@@ -102,11 +108,13 @@ let runtime = storage
     .worker::<SendEmailWorker, SendEmailJob>();
 ```
 
+If you construct `WorkerConfig` manually, update it for the 2.0 registry shape: the `name` should be the job identity, `legacy_names` should include any old worker type names you want the runtime to consume from Redis, and the config now also carries `batch_factory`, `batch_config`, and `on_demand`. The exported helpers `job_factory`, `job_batch_factory`, and `job_envelope_factory` cover the common cases.
+
 ## 3. Move Runtime Settings
 
 Configuration methods that used to live on `Config` now live on the runtime builder:
 
-| 1.x | 2.x |
+| Oxanus 1.1.1 | Oxana 2.0 |
 | --- | --- |
 | `with_graceful_shutdown(fut)` | `shutdown_on(fut)` |
 | `with_graceful_shutdown(tokio::signal::ctrl_c())` | `shutdown_on_ctrl_c()` |
@@ -114,7 +122,7 @@ Configuration methods that used to live on `Config` now live on the runtime buil
 | `exit_when_processed(n)` | `exit_when_processed(n)` |
 | `has_registered_queue` / `has_registered_worker` / `has_registered_worker_type` / `has_registered_cron_worker` / `has_registered_cron_worker_type` | inspect `runtime.catalog()` (`queues`, `workers`, `cron_workers`) |
 
-2.x also exposes runtime tuning on the same builder:
+Oxana 2.0 also exposes runtime tuning on the same builder:
 
 ```rust
 let runtime = storage
@@ -155,8 +163,8 @@ The component registry is now typed only by app context:
 
 ```rust
 // Before
-#[derive(oxana::Registry)]
-struct ComponentRegistry(oxana::ComponentRegistry<AppContext, AppError>);
+#[derive(oxanus::Registry)]
+struct ComponentRegistry(oxanus::ComponentRegistry<AppContext, AppError>);
 
 // After
 #[derive(oxana::Registry)]
@@ -183,31 +191,37 @@ impl SendEmailWorker {
 
 Use `#[oxana(error = AppError)]` only when you need the generated `Worker` impl to expose that concrete error type.
 
-## 5. Remove Job-To-Worker Binding From Jobs
+## 5. Move Job Metadata From Workers To Jobs
 
-Jobs no longer name their worker. The runtime maps each job type to a worker through registration.
-The worker derive still infers `SendEmailWorker` -> `SendEmailJob`; keep using
-`#[oxana(job = CustomJob)]` on the worker when the convention does not match.
+In Oxanus 1.1.1, `#[derive(oxanus::Worker)]` generated both the worker impl and the job impl. Enqueue-time metadata such as `unique_id`, `on_conflict`, `resurrect`, and `throttle_cost` lived on the worker derive.
+
+In Oxana 2.0, job payloads derive or implement `oxana::Job` directly. Move enqueue-time metadata to the job type. The runtime maps each job type to a worker through registration. The worker derive still infers `SendEmailWorker` -> `SendEmailJob`; keep using `#[oxana(job = CustomJob)]` on the worker when the convention does not match.
 
 Before:
 
 ```rust
-#[derive(Debug, serde::Serialize, serde::Deserialize, oxana::Job)]
-#[oxana(worker = SendEmailWorker)]
-#[oxana(unique_id = "send_email:{user_id}")]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct SendEmailJob {
     user_id: i64,
 }
+
+#[derive(oxanus::Worker)]
+#[oxanus(unique_id = "send_email:{user_id}", on_conflict = Replace)]
+struct SendEmailWorker;
 ```
 
 After:
 
 ```rust
 #[derive(Debug, serde::Serialize, serde::Deserialize, oxana::Job)]
-#[oxana(unique_id = "send_email:{user_id}")]
+#[oxana(unique_id = "send_email:{user_id}", on_conflict = Replace)]
 struct SendEmailJob {
     user_id: i64,
 }
+
+#[derive(oxana::Worker)]
+#[oxana(context = AppContext)]
+struct SendEmailWorker;
 
 let runtime = storage
     .runtime(ctx)
@@ -218,7 +232,7 @@ Manual `Job` implementations should remove `worker_name()`:
 
 ```rust
 // Before
-impl oxana::Job for SendEmailJob {
+impl oxanus::Job for SendEmailJob {
     fn worker_name() -> &'static str {
         std::any::type_name::<SendEmailWorker>()
     }
@@ -236,13 +250,16 @@ impl oxana::Job for SendEmailJob {
 }
 ```
 
-Job attributes remain enqueue-time metadata:
+Move these 1.1.1 worker attributes to `#[derive(oxana::Job)]`, using the new `oxana` attribute spelling:
 
 - `#[oxana(unique_id = "...")]`
 - `#[oxana(on_conflict = Skip)]` or `#[oxana(on_conflict = Replace)]`
 - `#[oxana(resurrect = false)]`
-- `#[oxana(resume = false)]`
 - `#[oxana(throttle_cost = 2)]`
+
+Oxana 2.0 also adds these job attributes:
+
+- `#[oxana(resume = false)]`
 - `#[oxana(on_demand)]`
 
 Worker attributes remain execution-time metadata:
@@ -258,7 +275,7 @@ Worker attributes remain execution-time metadata:
 
 ## 6. Update Worker Process Signatures
 
-2.x owns job values during execution. If your handler still borrows the job, take it by value instead.
+Oxana 2.0 owns job values during execution. If your handler still borrows the job, take it by value instead.
 
 ```rust
 // Before
@@ -266,7 +283,7 @@ impl SendEmailWorker {
     async fn process(
         &self,
         _job: &SendEmailJob,
-        _ctx: &oxana::JobContext,
+        _ctx: &oxanus::JobContext,
     ) -> Result<(), AppError> {
         Ok(())
     }
@@ -331,8 +348,8 @@ Static queues no longer need `serde::Serialize`:
 
 ```rust
 // Before
-#[derive(serde::Serialize, oxana::Queue)]
-#[oxana(key = "emails", concurrency = 4)]
+#[derive(serde::Serialize, oxanus::Queue)]
+#[oxanus(key = "emails", concurrency = 4)]
 struct EmailQueue;
 
 // After
@@ -365,6 +382,8 @@ impl oxana::Queue for TenantQueue {
 }
 ```
 
+If you construct `QueueConfig` manually, update `concurrency: usize` to `QueueConcurrency::Fixed(n)` or use `QueueConfig::concurrency(n)`. Use `QueueConfig::dynamic_concurrency(n)` only for queues whose concurrency can be changed at runtime. Code that pattern-matches `QueueKind::Dynamic { sleep_period, .. }` should use `QueueKind::Dynamic { discovery_interval, .. }`.
+
 Manual static queues can use the default `key()` as long as `to_config()` returns a static queue config.
 
 ## 8. Update Drain, Catalog, And Web Dashboard Setup
@@ -373,7 +392,7 @@ Drain now runs through a runtime:
 
 ```rust
 // Before
-let stats = oxana::drain(&config, ctx, EmailQueue).await?;
+let stats = oxanus::drain(&config, ctx, EmailQueue).await?;
 
 // After
 let stats = runtime.drain(EmailQueue).await?;
@@ -392,6 +411,22 @@ let catalog = runtime.catalog();
 For `oxana-web`, build the catalog before consuming the runtime with `run()`:
 
 ```rust
+// Before
+let config = ComponentRegistry::build_config(&storage)
+    .with_graceful_shutdown(tokio::signal::ctrl_c());
+
+let oxanus_state = oxanus_web::OxanusWebState::new(
+    config.storage.clone(),
+    config.catalog(),
+    "/oxanus".to_string(),
+);
+
+let oxanus_router = oxanus_web::router(oxanus_state);
+let app = your_app_router().nest("/oxanus", oxanus_router);
+```
+
+```rust
+// After
 let storage = oxana::Storage::from_env()?;
 let runtime = storage
     .runtime(ctx)
@@ -415,7 +450,7 @@ tokio::spawn(async move {
 });
 ```
 
-Metrics and dashboard labels are keyed by job identity in 2.x. If you used worker type names to query metrics, update those callers to use the registered job name.
+Metrics and dashboard labels are keyed by job identity in Oxana 2.0. If you used worker type names to query metrics, update those callers to use the registered job name.
 
 ## 9. Update Progress State
 
@@ -438,7 +473,7 @@ The existing builder still works:
 let storage = oxana::Storage::builder().build_from_env()?;
 ```
 
-2.x also adds shorter constructors:
+Oxana 2.0 also adds shorter constructors:
 
 ```rust
 let storage = oxana::Storage::from_env()?;
@@ -449,13 +484,17 @@ let storage = oxana::Storage::from_url("redis://127.0.0.1/0")?;
 
 ## Checklist
 
-- Let the 2.x runtime consume old worker-named Redis jobs through legacy aliases, or drain/clear/re-enqueue them for a cleaner cutover.
-- Avoid overlapping 1.x and 2.x producers for unique jobs unless duplicate unique IDs are acceptable during the migration window.
+- Let the Oxana 2.0 runtime consume old worker-named Redis jobs through legacy aliases, or drain/clear/re-enqueue them for a cleaner cutover.
+- Avoid overlapping Oxanus 1.1.1 and Oxana 2.0 producers for unique jobs unless duplicate unique IDs are acceptable during the migration window.
 - Rename any remaining Oxanus crate paths, imports, and macro attributes to Oxana.
-- Replace `ContextValue::new(ctx)`, `Config`, and `oxana::run(config, ctx)` with `storage.runtime(ctx)` and `runtime.run()`.
+- Replace `ContextValue::new(ctx)`, `Config`, and `oxanus::run(config, ctx)` with `storage.runtime(ctx)` and `runtime.run()`.
 - Change `ComponentRegistry<AppContext, AppError>` to `ComponentRegistry<AppContext>`.
 - Move queue and worker registration to the runtime builder.
-- Remove `#[oxana(worker = ...)]` and manual `Job::worker_name()` implementations.
+- Update any manually constructed `WorkerConfig` and `QueueConfig` values to the 2.0 field shapes.
+- Add `#[derive(oxana::Job)]` or a manual `oxana::Job` impl for every job payload.
+- Move 1.1.1 worker-level `unique_id`, `on_conflict`, `resurrect`, and `throttle_cost` attributes to the job type.
+- Remove manual `Job::worker_name()` implementations.
+- Fix any new `'static` bound errors on enqueued or registered job payload types.
 - Ensure worker handlers take owned job values.
 - Remove `Serialize` derives from static queues when they are no longer needed.
 - Move drain, catalog, and web dashboard integration to the runtime API.

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.0-rc.14"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.0-rc.14"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.0-rc.14"
+version = "2.0.0"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -20,6 +20,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 - **Retries** - automatic retry with configurable backoff
 - **Scheduled Jobs** - run jobs at specific times or after delays
 - **Cron Jobs** - periodic jobs using cron expressions
+- **Batch Processing** - process jobs together with size and timeout based batching
 - **Dynamic Queues** - create and manage queues at runtime
 - **Runtime Queue Controls** - pause queues and adjust dynamic concurrency without restarting workers
 - **Throttling** - rate-limit job processing per queue
@@ -34,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.0-rc.14 --features registry
+cargo add oxana@2.0.0 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary

**Release metadata**
- Bump `oxana`, `oxana-macros`, and `oxana-web` from `2.0.0-rc.14` to `2.0.0` in crate manifests, workspace dependencies, and `Cargo.lock`.

**Release docs**
- Promote the changelog entry from release candidate to `2.0.0` and condense it into stable-release sections.
- Refresh the migration guide around `Oxanus 1.1.1 -> Oxana 2.0.0`, including old crate paths, public type renames, runtime setup, job metadata, queue config, dashboard setup, and checklist notes.
- Update the README install command to `cargo add oxana@2.0.0 --features registry`.

## Test Coverage

No new application code paths were added. This is a release metadata and documentation diff.

Tests: 1 -> 1 (+0 new test files)
Coverage gate: skipped, no new code paths.

## Pre-Landing Review

No issues found.

## Design Review

No UI source files changed. Lite design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope Check: CLEAN
Intent: ship the stable Oxana 2.0.0 release from the current release candidate.
Delivered: version metadata, lockfile, changelog, migration guide, and README install command are aligned for `2.0.0`.

## Plan Completion

No plan file detected.

## Verification Results

No plan verification section was available, so browser/manual verification was skipped.

## TODOS

No `TODOS.md` file is present in this repository.

## Test plan

- [x] `cargo test --workspace` — 191 passed, 3 ignored
- [x] `cargo check --all-features --workspace`
- [x] `cargo package --workspace --allow-dirty`
- [x] `git diff --check`

Generated with OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No library or runtime code changes—only version metadata and documentation.
> 
> **Overview**
> Promotes **Oxana 2.0** from `2.0.0-rc.14` to **`2.0.0`** across `oxana`, `oxana-macros`, `oxana-web`, workspace deps, and `Cargo.lock`.
> 
> **CHANGELOG** is reframed for the stable release: the RC heading becomes `2.0.0`, sections are regrouped into **Major Changes** and **New Features** (including newly called-out items like `Storage::enqueue_list` and bulk dashboard recovery actions), without changing the underlying feature set described.
> 
> **MIGRATION.md** is retargeted explicitly at **Oxanus 1.1.1 → Oxana 2.0.0**—clearer Oxanus crate/type renames, expanded `WorkerConfig`/`QueueConfig` notes, job-metadata-on-`Job` guidance, and an updated checklist.
> 
> **README** install line and feature list add **batch processing**; version pins point at `2.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef9f4030158acfbaa5949edf1f53b2ef95ba3f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->