### PR TITLE
refactor: unify executor single-job and batch paths

### DIFF
--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -38,48 +38,7 @@ pub async fn run<DT>(
 where
     DT: Send + Sync + Clone + 'static,
 {
-    if !worker.should_resume() {
-        envelope.meta.state = None;
-    }
-    config.storage.internal.set_started_at(envelope).await?;
-    let policy = execution_policy(&worker, 0, envelope);
-    let names = ExecutionNames {
-        job: worker.job_name(),
-        worker: worker.worker_name(),
-    };
-
-    tracing::info!(
-        job_id = envelope.id,
-        queue = envelope.queue,
-        job = names.job,
-        worker = names.worker,
-        latency_ms = envelope.meta.latency_millis(),
-        "Job started"
-    );
-    let start = std::time::Instant::now();
-    let job_contexts = vec![job_context(&config.storage, envelope)];
-
-    let result = run_process(worker, job_contexts, envelope).await;
-
-    let duration = start.elapsed();
-    let duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
-    let is_err = !matches!(result, ExecutionResult::NotPanic(Ok(_)));
-    tracing::info!(
-        job_id = envelope.id,
-        queue = envelope.queue,
-        job = names.job,
-        worker = names.worker,
-        success = !is_err,
-        duration = duration_ms,
-        retries = envelope.meta.retries,
-        "Job finished"
-    );
-
-    let result = finish_job_result(config.as_ref(), result, envelope, &policy, names).await;
-    Ok(ExecutionOutcome {
-        result,
-        duration_ms,
-    })
+    run_batch(config, worker, std::slice::from_mut(envelope)).await
 }
 
 pub async fn run_batch<DT>(
@@ -132,13 +91,24 @@ where
         worker: worker.worker_name(),
     };
 
-    tracing::info!(
-        batch_size = envelopes.len(),
-        queue = queue,
-        job = names.job,
-        worker = names.worker,
-        "Job batch started"
-    );
+    if envelopes.len() == 1 {
+        tracing::info!(
+            job_id = first_envelope.id,
+            queue = queue,
+            job = names.job,
+            worker = names.worker,
+            latency_ms = first_envelope.meta.latency_millis(),
+            "Job started"
+        );
+    } else {
+        tracing::info!(
+            batch_size = envelopes.len(),
+            queue = queue,
+            job = names.job,
+            worker = names.worker,
+            "Job batch started"
+        );
+    }
     let start = std::time::Instant::now();
     let job_contexts = job_contexts(&config.storage, envelopes);
 
@@ -147,15 +117,28 @@ where
     let duration = start.elapsed();
     let duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
     let is_err = !matches!(result, ExecutionResult::NotPanic(Ok(_)));
-    tracing::info!(
-        batch_size = envelopes.len(),
-        queue = queue,
-        job = names.job,
-        worker = names.worker,
-        success = !is_err,
-        duration = duration_ms,
-        "Job batch finished"
-    );
+    if envelopes.len() == 1 {
+        tracing::info!(
+            job_id = first_envelope.id,
+            queue = queue,
+            job = names.job,
+            worker = names.worker,
+            success = !is_err,
+            duration = duration_ms,
+            retries = first_envelope.meta.retries,
+            "Job finished"
+        );
+    } else {
+        tracing::info!(
+            batch_size = envelopes.len(),
+            queue = queue,
+            job = names.job,
+            worker = names.worker,
+            success = !is_err,
+            duration = duration_ms,
+            "Job batch finished"
+        );
+    }
 
     let result = finish_batch_result(config.as_ref(), result, envelopes, &policies, names).await;
     Ok(ExecutionOutcome {
@@ -204,66 +187,6 @@ fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
     }
 }
 
-async fn finish_job_result<DT>(
-    config: &Runtime<DT>,
-    result: ExecutionResult,
-    envelope: &JobEnvelope,
-    policy: &JobExecutionPolicy,
-    names: ExecutionNames,
-) -> Result<(), ExecutionError>
-where
-    DT: Send + Sync + Clone + 'static,
-{
-    match result {
-        ExecutionResult::NotPanic(Ok(())) => {
-            if let Err(e) = config.storage.internal.finish_with_success(envelope).await {
-                tracing::error!("Failed to finish job: {}", e);
-            }
-            Ok(())
-        }
-        ExecutionResult::NotPanic(Err(e)) => {
-            let retry_delay = retry_delay(config, e.as_ref(), envelope, policy);
-
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_error(e.as_ref());
-
-            tracing::error!(
-                job_id = envelope.id,
-                queue = envelope.queue,
-                job = names.job,
-                worker = names.worker,
-                "Job failed"
-            );
-
-            handle_err(
-                config,
-                &e.to_string(),
-                envelope,
-                retry_delay,
-                policy.max_retries,
-            )
-            .await;
-
-            Err(ExecutionError::NotPanic)
-        }
-        ExecutionResult::Panic(panic_msg) => {
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
-
-            handle_err(
-                config,
-                &panic_msg,
-                envelope,
-                policy.retry_delay,
-                policy.max_retries,
-            )
-            .await;
-
-            Err(ExecutionError::Panic())
-        }
-    }
-}
-
 async fn finish_batch_result<DT>(
     config: &Runtime<DT>,
     result: ExecutionResult,
@@ -291,13 +214,23 @@ where
             sentry_core::capture_error(e.as_ref());
 
             if let Some(envelope) = envelopes.first() {
-                tracing::error!(
-                    batch_size = envelopes.len(),
-                    queue = envelope.queue,
-                    job = names.job,
-                    worker = names.worker,
-                    "Job batch failed"
-                );
+                if envelopes.len() == 1 {
+                    tracing::error!(
+                        job_id = envelope.id,
+                        queue = envelope.queue,
+                        job = names.job,
+                        worker = names.worker,
+                        "Job failed"
+                    );
+                } else {
+                    tracing::error!(
+                        batch_size = envelopes.len(),
+                        queue = envelope.queue,
+                        job = names.job,
+                        worker = names.worker,
+                        "Job batch failed"
+                    );
+                }
             }
 
             let err_msg = e.to_string();

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -648,12 +648,6 @@ impl StorageInternal {
         self.update_job(&envelope).await
     }
 
-    pub async fn set_started_at(&self, envelope: &mut JobEnvelope) -> Result<(), OxanaError> {
-        envelope.meta.started_at = Some(chrono::Utc::now().timestamp_micros());
-        self.update_job(envelope).await?;
-        Ok(())
-    }
-
     pub async fn set_started_at_batch(
         &self,
         envelopes: &mut [JobEnvelope],
@@ -3430,33 +3424,6 @@ mod tests {
         assert_eq!(retried, 2);
         assert_eq!(storage.retries_count().await?, 0);
         assert_eq!(storage.enqueued_count(&queue).await?, 2);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_set_started_at() -> TestResult {
-        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
-        let queue = random_string();
-
-        let mut envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
-        assert!(envelope.meta.started_at.is_none());
-
-        storage.enqueue(envelope.clone()).await?;
-
-        let before = chrono::Utc::now().timestamp_micros();
-        storage.set_started_at(&mut envelope).await?;
-        let after = chrono::Utc::now().timestamp_micros();
-
-        let started_at = envelope.meta.started_at.expect("started_at should be set");
-        assert!(started_at >= before);
-        assert!(started_at <= after);
-
-        let persisted = storage
-            .get_job(&envelope.id)
-            .await?
-            .expect("job should exist");
-        assert_eq!(persisted.meta.started_at, Some(started_at));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

`executor::run` was behaviorally `executor::run_batch` specialized to one envelope, and `finish_job_result` duplicated `finish_batch_result` verbatim (policy computation, sentry capture, `retry_delay` override, `handle_err` logic). This makes the single-job path a one-line wrapper over the batch path and deletes the duplicated finish function — **100 net LOC removed** and one less parallel code path to keep in sync by hand.

- `run` now delegates via `run_batch(config, worker, std::slice::from_mut(envelope))`
- `finish_job_result` deleted; everything routes through `finish_batch_result`
- Single-job log lines are preserved byte-identical via a `len() == 1` branch at the started/finished/failed log sites (`job_id`/`latency_ms`/`retries` vs `batch_size`)
- `StorageInternal::set_started_at` removed — its only caller was the old single-job path, and `set_started_at_batch` is equivalent for one envelope (same timestamp stamping, same HSET on the jobs hash)

No public API impact: `executor` is a private module, `storage.internal` is `pub(crate)`.

Behavioral note: a genuine batch that happens to contain exactly one envelope now logs "Job started"/"Job finished" (with `job_id` and `retries`) instead of "Job batch started" with `batch_size=1`.

## Verification

- `cargo test` — 130 passed across 3 suites (including `standard`, `batch`, and `retry` integration suites)
- `cargo clippy --all-features --workspace` — clean
- Ran the `minimal` and `batch` examples on this branch and on `main` against a scratch Redis DB and diffed normalized log output — executor tracing lines are field-for-field identical on both paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the core job execution and Redis finish/retry path; behavior is intended to match prior single-job flows, with a small observability change when a batch has exactly one envelope.
> 
> **Overview**
> **Unifies job execution** so `executor::run` is a thin wrapper around `run_batch` via `std::slice::from_mut(envelope)`, removing the duplicated single-job setup, timing, and finish logic (~100 LOC).
> 
> **Completion and storage** no longer use `finish_job_result`; success, failure, panic, Sentry, and retries all go through `finish_batch_result`. `StorageInternal::set_started_at` is dropped in favor of `set_started_at_batch` for every run (including one job).
> 
> **Logging** branches on `envelopes.len() == 1` at start, finish, and failure so single-job traces keep `job_id`, `latency_ms`, and `retries` instead of `batch_size`. A true batch of one envelope now emits the single-job messages rather than `batch_size=1` batch lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53facf1b7d1ffd2c2efdc3fe7c3bb0d8a22ec21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->