### PR TITLE
refactor: make metric flushes data-driven

### DIFF
--- a/oxana/src/coordinator.rs
+++ b/oxana/src/coordinator.rs
@@ -218,7 +218,7 @@ where
     {
         Ok(job) => job,
         Err(e) => {
-            let err_msg = format!("Invalid job: {} - {}", &envelope.job.name, e);
+            let err_msg = format!("Invalid job: {} - {}", envelope.job.name, e);
             tracing::error!("{}", err_msg);
             if let Err(e) = config.storage.internal.kill(&envelope, err_msg).await {
                 #[cfg(feature = "sentry")]

--- a/oxana/src/metrics.rs
+++ b/oxana/src/metrics.rs
@@ -42,6 +42,15 @@ pub(crate) const METRIC_SUCCESSFUL_EXECUTIONS: &str = "xs";
 pub(crate) const METRIC_FAILED_EXECUTIONS: &str = "xf";
 pub(crate) const METRIC_PANICKED_EXECUTIONS: &str = "xpn";
 pub(crate) const METRIC_EXECUTION_MS: &str = "ms";
+pub(crate) const JOB_METRIC_KEYS: [&str; 7] = [
+    METRIC_PROCESSED_JOBS,
+    METRIC_FAILED_JOBS,
+    METRIC_PANICKED_JOBS,
+    METRIC_SUCCESSFUL_EXECUTIONS,
+    METRIC_FAILED_EXECUTIONS,
+    METRIC_PANICKED_EXECUTIONS,
+    METRIC_EXECUTION_MS,
+];
 pub(crate) const QUEUE_METRIC_PROCESSED_JOBS: &str = "p";
 pub(crate) const QUEUE_METRIC_SUCCEEDED_JOBS: &str = "s";
 pub(crate) const QUEUE_METRIC_FAILED_JOBS: &str = "f";
@@ -295,6 +304,15 @@ pub(crate) struct QueueCounterTotals {
 }
 
 impl QueueCounterTotals {
+    pub(crate) fn increments(&self) -> impl Iterator<Item = (&'static str, u64)> {
+        [
+            (QUEUE_METRIC_PROCESSED_JOBS, self.processed),
+            (QUEUE_METRIC_SUCCEEDED_JOBS, self.succeeded),
+            (QUEUE_METRIC_FAILED_JOBS, self.failed),
+        ]
+        .into_iter()
+    }
+
     fn add_metric(&mut self, metric: &str, value: u64) {
         match metric {
             QUEUE_METRIC_PROCESSED_JOBS => {
@@ -389,6 +407,21 @@ pub(crate) struct PendingJobMetrics {
     pub(crate) panicked_executions: u64,
     pub(crate) execution_ms: u64,
     pub(crate) histogram: [u64; HISTOGRAM_BUCKET_COUNT],
+}
+
+impl PendingJobMetrics {
+    pub(crate) fn increments(&self) -> impl Iterator<Item = (&'static str, u64)> {
+        [
+            (METRIC_PROCESSED_JOBS, self.processed),
+            (METRIC_FAILED_JOBS, self.failed),
+            (METRIC_PANICKED_JOBS, self.panicked),
+            (METRIC_SUCCESSFUL_EXECUTIONS, self.successful_executions),
+            (METRIC_FAILED_EXECUTIONS, self.failed_executions),
+            (METRIC_PANICKED_EXECUTIONS, self.panicked_executions),
+            (METRIC_EXECUTION_MS, self.execution_ms),
+        ]
+        .into_iter()
+    }
 }
 
 #[derive(Default)]
@@ -628,17 +661,10 @@ pub(crate) fn histogram_buckets_from_counts(
 
 fn split_metric_field(field: &str) -> Option<(MetricIdentity, &str)> {
     let (identity_key, metric) = field.rsplit_once('|')?;
-    match metric {
-        METRIC_PROCESSED_JOBS
-        | METRIC_FAILED_JOBS
-        | METRIC_PANICKED_JOBS
-        | METRIC_SUCCESSFUL_EXECUTIONS
-        | METRIC_FAILED_EXECUTIONS
-        | METRIC_PANICKED_EXECUTIONS
-        | METRIC_EXECUTION_MS => {
-            MetricIdentity::from_field_key(identity_key).map(|id| (id, metric))
-        }
-        _ => None,
+    if JOB_METRIC_KEYS.contains(&metric) {
+        MetricIdentity::from_field_key(identity_key).map(|id| (id, metric))
+    } else {
+        None
     }
 }
 
@@ -692,6 +718,46 @@ mod tests {
             args,
             vec![
                 "OVERFLOW", "SAT", "INCRBY", "u16", "#0", "2", "INCRBY", "u16", "#13", "70000",
+            ]
+        );
+    }
+
+    #[test]
+    fn metric_increment_iterators_preserve_key_order() {
+        let job_metrics = PendingJobMetrics {
+            processed: 1,
+            failed: 2,
+            panicked: 3,
+            successful_executions: 4,
+            failed_executions: 5,
+            panicked_executions: 6,
+            execution_ms: 7,
+            ..PendingJobMetrics::default()
+        };
+        let increments = job_metrics.increments().collect::<Vec<_>>();
+        assert_eq!(
+            increments.iter().map(|(key, _)| *key).collect::<Vec<_>>(),
+            JOB_METRIC_KEYS
+        );
+        assert_eq!(
+            increments
+                .iter()
+                .map(|(_, value)| *value)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5, 6, 7]
+        );
+
+        let queue_counters = QueueCounterTotals {
+            processed: 8,
+            succeeded: 9,
+            failed: 10,
+        };
+        assert_eq!(
+            queue_counters.increments().collect::<Vec<_>>(),
+            vec![
+                (QUEUE_METRIC_PROCESSED_JOBS, 8),
+                (QUEUE_METRIC_SUCCEEDED_JOBS, 9),
+                (QUEUE_METRIC_FAILED_JOBS, 10),
             ]
         );
     }

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -12,17 +12,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     OxanaError,
     job_envelope::{JobConflictStrategy, JobEnvelope, JobId},
-    metrics::{
-        HISTOGRAM_BUCKET_COUNT, JobMetricsBuffer, JobMetricsDetail, JobMetricsQuery,
-        JobMetricsSnapshot, METRIC_EXECUTION_MS, METRIC_FAILED_EXECUTIONS, METRIC_FAILED_JOBS,
-        METRIC_PANICKED_EXECUTIONS, METRIC_PANICKED_JOBS, METRIC_PROCESSED_JOBS,
-        METRIC_SUCCESSFUL_EXECUTIONS, METRICS_RETENTION_SECS, MetricIdentity,
-        QUEUE_METRIC_FAILED_JOBS, QUEUE_METRIC_PROCESSED_JOBS, QUEUE_METRIC_SUCCEEDED_JOBS,
-        QUEUE_RATE_WINDOW_MINUTES, QueueCounterTotals, QueueLengthMetricsSnapshot,
-        aggregate_counter_hashes, aggregate_queue_counter_hashes, histogram_bitfield_fetch_args,
-        histogram_bitfield_increment_args, histogram_buckets_from_counts, metric_minutes,
-        queue_length_series_from_hashes, queue_metric_field,
-    },
+    metrics::*,
     queue::{QueueRuntimeConfig, QueueState},
     result_collector::QueueResultStats,
     stats::{
@@ -301,7 +291,7 @@ impl StorageInternal {
             .scan_keys_w_conn(redis, &self.namespace_queue(pattern))
             .await?;
         // remove namespace prefix from beginning of each key
-        let prefix = format!("{}:", &self.keys.queue_prefix);
+        let prefix = format!("{}:", self.keys.queue_prefix);
         let queues = queue_keys
             .into_iter()
             .filter_map(|key| key.strip_prefix(&prefix).map(ToOwned::to_owned))
@@ -1447,37 +1437,16 @@ impl StorageInternal {
         let mut has_commands = false;
 
         for (queue, queue_stats) in stats {
-            if queue_stats.processed > 0 {
-                pipe.hincr(
-                    &self.keys.stats,
-                    format!("{queue}:processed"),
-                    queue_stats.processed,
-                );
-                has_commands = true;
-            }
-            if queue_stats.succeeded > 0 {
-                pipe.hincr(
-                    &self.keys.stats,
-                    format!("{queue}:succeeded"),
-                    queue_stats.succeeded,
-                );
-                has_commands = true;
-            }
-            if queue_stats.panicked > 0 {
-                pipe.hincr(
-                    &self.keys.stats,
-                    format!("{queue}:panicked"),
-                    queue_stats.panicked,
-                );
-                has_commands = true;
-            }
-            if queue_stats.failed > 0 {
-                pipe.hincr(
-                    &self.keys.stats,
-                    format!("{queue}:failed"),
-                    queue_stats.failed,
-                );
-                has_commands = true;
+            for (stat_name, value) in [
+                ("processed", queue_stats.processed),
+                ("succeeded", queue_stats.succeeded),
+                ("panicked", queue_stats.panicked),
+                ("failed", queue_stats.failed),
+            ] {
+                if value > 0 {
+                    pipe.hincr(&self.keys.stats, format!("{queue}:{stat_name}"), value);
+                    has_commands = true;
+                }
             }
         }
 
@@ -1556,62 +1525,14 @@ impl StorageInternal {
 
         for (minute, identity, metrics) in buffer.records() {
             let counter_key = self.metrics_counter_key(minute);
-            let processed_field = identity.metric_field(METRIC_PROCESSED_JOBS);
-            let failed_field = identity.metric_field(METRIC_FAILED_JOBS);
-            let panicked_field = identity.metric_field(METRIC_PANICKED_JOBS);
-            let successful_executions_field = identity.metric_field(METRIC_SUCCESSFUL_EXECUTIONS);
-            let failed_executions_field = identity.metric_field(METRIC_FAILED_EXECUTIONS);
-            let panicked_executions_field = identity.metric_field(METRIC_PANICKED_EXECUTIONS);
-            let execution_ms_field = identity.metric_field(METRIC_EXECUTION_MS);
-
-            if metrics.processed > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    processed_field,
-                    redis_metric_increment(metrics.processed),
-                );
-            }
-            if metrics.failed > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    failed_field,
-                    redis_metric_increment(metrics.failed),
-                );
-            }
-            if metrics.panicked > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    panicked_field,
-                    redis_metric_increment(metrics.panicked),
-                );
-            }
-            if metrics.successful_executions > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    successful_executions_field,
-                    redis_metric_increment(metrics.successful_executions),
-                );
-            }
-            if metrics.failed_executions > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    failed_executions_field,
-                    redis_metric_increment(metrics.failed_executions),
-                );
-            }
-            if metrics.panicked_executions > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    panicked_executions_field,
-                    redis_metric_increment(metrics.panicked_executions),
-                );
-            }
-            if metrics.execution_ms > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    execution_ms_field,
-                    redis_metric_increment(metrics.execution_ms),
-                );
+            for (metric, value) in metrics.increments() {
+                if value > 0 {
+                    pipe.hincr(
+                        &counter_key,
+                        identity.metric_field(metric),
+                        redis_metric_increment(value),
+                    );
+                }
             }
             pipe.expire(&counter_key, METRICS_RETENTION_SECS);
 
@@ -1631,26 +1552,14 @@ impl StorageInternal {
         for (minute, queue, metrics) in buffer.queue_records() {
             let counter_key = self.metrics_queue_counter_key(minute);
 
-            if metrics.processed > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    queue_metric_field(queue, QUEUE_METRIC_PROCESSED_JOBS),
-                    redis_metric_increment(metrics.processed),
-                );
-            }
-            if metrics.succeeded > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    queue_metric_field(queue, QUEUE_METRIC_SUCCEEDED_JOBS),
-                    redis_metric_increment(metrics.succeeded),
-                );
-            }
-            if metrics.failed > 0 {
-                pipe.hincr(
-                    &counter_key,
-                    queue_metric_field(queue, QUEUE_METRIC_FAILED_JOBS),
-                    redis_metric_increment(metrics.failed),
-                );
+            for (metric, value) in metrics.increments() {
+                if value > 0 {
+                    pipe.hincr(
+                        &counter_key,
+                        queue_metric_field(queue, metric),
+                        redis_metric_increment(value),
+                    );
+                }
             }
             pipe.expire(&counter_key, METRICS_RETENTION_SECS);
         }
@@ -2212,15 +2121,7 @@ impl StorageInternal {
             return Ok(Vec::new());
         }
 
-        let fields = [
-            identity.metric_field(METRIC_PROCESSED_JOBS),
-            identity.metric_field(METRIC_FAILED_JOBS),
-            identity.metric_field(METRIC_PANICKED_JOBS),
-            identity.metric_field(METRIC_SUCCESSFUL_EXECUTIONS),
-            identity.metric_field(METRIC_FAILED_EXECUTIONS),
-            identity.metric_field(METRIC_PANICKED_EXECUTIONS),
-            identity.metric_field(METRIC_EXECUTION_MS),
-        ];
+        let fields = JOB_METRIC_KEYS.map(|metric| identity.metric_field(metric));
         let mut pipe = redis::pipe();
         for minute in minutes {
             let counter_key = self.metrics_counter_key(*minute);


### PR DESCRIPTION
## Summary

- Centralize the seven job metric keys in one ordered table and expose ordered increment iterators for job and queue counters.
- Drive job metrics, queue counters, result stats, metric validation, and targeted HMGET reads from data instead of duplicated blocks.
- Preserve the public API, Redis field encoding, positive-only writes, expiry behavior, and pipeline command order.

## Test Coverage

```text
JOB_METRIC_KEYS
├── iterator key/value order ........ unit tested
├── metric-field validation ......... aggregation tests
└── targeted HMGET field order ...... Redis integration tests

PendingJobMetrics::increments
└── flush → Redis → job_metrics_for . Redis integration tests

QueueCounterTotals::increments
└── flush → queue rate stats ........ storage integration tests

Result-stat table loop
└── flush → stats readback .......... storage integration tests

Coverage: 7/7 changed paths (100%)
```

One focused iterator-order unit test was added in the existing metrics test module.

## Pre-Landing Review

No issues found in the checklist or independent specialist review.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Scope Drift

Scope Check: CLEAN. The diff implements only the data-driven metrics flush plan and its focused test.

## Plan Completion

- [x] Added the ordered seven-key `JOB_METRIC_KEYS` table.
- [x] Added ordered job and queue increment iterators.
- [x] Converted job, queue, and result-stat flushes to data-driven loops.
- [x] Derived HMGET fields and metric validation from `JOB_METRIC_KEYS`.
- [x] Preserved the field-dispatching `add_metric` match.
- [x] Addressed all 12 plan items: 11 as written and 1 with an equivalent two-tuple result-stat table.

## Verification Results

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-features --workspace` (0 errors; 3 pre-existing warnings in untouched code)
- [x] `cargo test` (131 passed)
- [x] Squashed commit tree matches the verified pre-squash tree exactly

## Test plan

- [x] Job metric field names, values, readback, and TTLs
- [x] Queue counter flush and rate calculations
- [x] Result-stat flush and readback
- [x] Full Rust workspace test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with tests; Redis field names and positive-only increment behavior are unchanged, so observability risk is low.
> 
> **Overview**
> Refactors Oxana’s metrics pipeline so job and queue counters are defined once and reused everywhere Redis is written or read.
> 
> **`JOB_METRIC_KEYS`** holds the seven job metric short keys in a fixed order. **`PendingJobMetrics::increments`** and **`QueueCounterTotals::increments`** expose that order for flushes; **`split_metric_field`** and targeted HMGET field lists now derive from the same table instead of duplicated match arms.
> 
> **`flush_job_metrics`**, queue-counter flushes, **`flush_result_stats`**, and **`metrics_counter_hashes_for`** loop over those iterators/tables (still only **`hincr`** when value &gt; 0). **`storage_internal`** switches to **`metrics::*`** imports. **`coordinator`** drops a redundant borrow in an invalid-job error string.
> 
> A unit test asserts iterator key order matches **`JOB_METRIC_KEYS`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d9fd5cc64b5b579898f12f49bf79c655e124fd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->