### PR TITLE
Support unique IDs for cron jobs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ rust-version = "1.75"
 
 [workspace.dependencies]
 oxana = { version = "2.0.1", path = "oxana" }
-oxana-macros = { version = "2.0.1", path = "oxana-macros" }
+oxana-macros = { version = "=2.0.1", path = "oxana-macros" }

--- a/oxana-macros/src/job.rs
+++ b/oxana-macros/src/job.rs
@@ -138,11 +138,16 @@ pub fn expand_derive_job(input: DeriveInput) -> TokenStream {
     };
 
     let on_conflict = match &args.on_conflict {
-        Some(on_conflict) => quote! {
-            fn on_conflict(&self) -> oxana::JobConflictStrategy {
-                oxana::JobConflictStrategy::#on_conflict
+        Some(on_conflict) => {
+            let replaces_on_conflict = on_conflict == "Replace";
+            quote! {
+                const REPLACES_ON_CONFLICT: bool = #replaces_on_conflict;
+
+                fn on_conflict(&self) -> oxana::JobConflictStrategy {
+                    oxana::JobConflictStrategy::#on_conflict
+                }
             }
-        },
+        }
         None => quote!(),
     };
 

--- a/oxana-macros/src/worker.rs
+++ b/oxana-macros/src/worker.rs
@@ -104,9 +104,18 @@ pub fn expand_derive_worker(input: DeriveInput) -> TokenStream {
 
     let worker_impl = expand_worker_impl(struct_ident, &type_args, &type_error, &args);
     let from_context_impl = expand_from_context_impl(struct_ident, &type_context, &input);
-    let registry_impl = expand_registry(struct_ident, &type_args, &type_context, &args);
+    let registry_impl = expand_registry(struct_ident, &type_args, &args);
+    let cron_conflict_validation = args.cron.as_ref().map_or_else(TokenStream::new, |_| {
+        quote! {
+            const _: () = assert!(
+                !<#type_args as oxana::Job>::REPLACES_ON_CONFLICT,
+                "cron jobs do not support `on_conflict = Replace`; use `Skip`"
+            );
+        }
+    });
 
     quote! {
+        #cron_conflict_validation
         #worker_impl
         #from_context_impl
         #registry_impl
@@ -225,12 +234,7 @@ fn expand_from_context_impl(
     }
 }
 
-fn expand_registry(
-    struct_ident: &Ident,
-    type_args: &TokenStream,
-    type_context: &TokenStream,
-    args: &OxanaArgs,
-) -> TokenStream {
+fn expand_registry(struct_ident: &Ident, type_args: &TokenStream, args: &OxanaArgs) -> TokenStream {
     let component_registry = match &args.registry {
         Some(registry) => quote!(#registry),
         None => quote!(ComponentRegistry),
@@ -243,20 +247,9 @@ fn expand_registry(
                     module_path: module_path!(),
                     type_name: stringify!(#struct_ident),
                     definition: || {
-                        oxana::ComponentDefinition::Worker(oxana::WorkerConfig {
-                            name: <#type_args as oxana::Job>::name().to_owned(),
-                            legacy_names: vec![std::any::type_name::<#struct_ident>().to_owned()],
-                            factory: oxana::job_factory::<#struct_ident, #type_args, #type_context>,
-                            batch_factory: oxana::job_batch_factory::<#struct_ident, #type_args, #type_context>,
-                            batch_config: <#struct_ident as oxana::Worker<#type_args>>::batch_config(),
-                            on_demand: <#type_args as oxana::Job>::on_demand_args_template().map(|args_template| {
-                                oxana::OnDemandJobRegistration {
-                                    args_template,
-                                    enqueue_factory: oxana::job_envelope_factory::<#type_args>,
-                                }
-                            }),
-                            kind: <#struct_ident as oxana::Worker<#type_args>>::to_config(),
-                        })
+                        oxana::ComponentDefinition::WorkerRegistration(
+                            |runtime| runtime.worker::<#struct_ident, #type_args>()
+                        )
                     }
                 })
             }

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -143,6 +143,10 @@ Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers
 |  | `#[oxana(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - schedule periodic jobs |
 |  | `#[oxana(batch_size = 100, batch_timeout_ms = 500)]` - process jobs in batches |
 
+Cron jobs may define a `unique_id` to prevent overlapping occurrences. Their conflict strategy
+must be `Skip`; `on_conflict = Replace` is rejected because replacing an in-flight occurrence can
+corrupt the following occurrence.
+
 For job hooks, `Self::...` resolves to the job type. For worker hooks, `Self::...` resolves to the worker type.
 
 On-demand argument templates infer editable placeholders from field types. Numeric primitives and common numeric ID newtypes named `*Id` or `*ID` are prefilled with `0`.

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -52,7 +52,7 @@ impl RuntimeSettings {
             retry_poll_interval: Duration::from_millis(300),
             schedule_poll_interval: Duration::from_millis(300),
             cron_initial_offset: Duration::from_secs(3),
-            cron_lookahead: Duration::from_secs(30 * 60),
+            cron_lookahead: Duration::from_secs(30),
             cron_tick_interval: Duration::from_secs(1),
             dequeue_timeout: Duration::from_secs(10),
             dispatcher_idle_sleep: Duration::from_secs(1),
@@ -150,21 +150,24 @@ impl<DT> Config<DT> {
             }
         }
 
-        self.registry.register_worker_with(WorkerConfig {
-            name,
-            legacy_names: vec![std::any::type_name::<W>().to_owned()],
-            factory,
-            batch_factory,
-            batch_config,
-            on_demand,
-            kind,
-        });
+        self.registry.register_worker_with(
+            WorkerConfig {
+                name,
+                legacy_names: vec![std::any::type_name::<W>().to_owned()],
+                factory,
+                batch_factory,
+                batch_config,
+                on_demand,
+                kind,
+            },
+            Some(worker_registry::cron_envelope_factory::<A>),
+        );
         self
     }
 
     /// Registers a worker from a [`WorkerConfig`].
     pub fn register_worker_with(&mut self, config: WorkerConfig<DT>) {
-        self.registry.register_worker_with(config);
+        self.registry.register_worker_with(config, None);
     }
 
     /// Returns a catalog of all registered workers.
@@ -365,6 +368,25 @@ mod tests {
     impl_test_worker!(AlphaWorker, AlphaJob);
 
     #[test]
+    #[should_panic(expected = "manual cron worker registration is not supported")]
+    fn manual_cron_worker_config_requires_typed_factory() {
+        let mut config = Config::<()>::new();
+        config.register_worker_with(WorkerConfig {
+            name: PlainJob::name().to_string(),
+            legacy_names: Vec::new(),
+            factory: worker_registry::job_factory::<PlainWorker, PlainJob, ()>,
+            batch_factory: worker_registry::job_batch_factory::<PlainWorker, PlainJob, ()>,
+            batch_config: None,
+            on_demand: None,
+            kind: WorkerConfigKind::Cron {
+                schedule: "*/5 * * * * *".to_string(),
+                queue_key: "default".to_string(),
+                resurrect: true,
+            },
+        });
+    }
+
+    #[test]
     fn worker_registration_accepts_canonical_and_legacy_worker_names() {
         let config = Config::<()>::new().register_worker::<PlainWorker, PlainJob>();
         let job = serde_json::json!({
@@ -478,6 +500,107 @@ mod tests {
             )
             .expect("legacy cron worker name should build");
         assert_eq!(legacy.len(), 1);
+    }
+
+    #[test]
+    fn cron_envelopes_compute_unique_id_from_each_job_instance() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static WORKER_BUILDS: AtomicU64 = AtomicU64::new(0);
+
+        fn next_id() -> u64 {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+            NEXT_ID.fetch_add(1, Ordering::Relaxed)
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
+        struct DynamicCronJob {
+            #[serde(default = "next_id")]
+            id: u64,
+        }
+
+        impl oxana::Job for DynamicCronJob {
+            fn unique_id(&self) -> Option<String> {
+                Some(self.id.to_string())
+            }
+        }
+
+        #[derive(Serialize)]
+        struct DynamicCronQueue;
+
+        impl oxana::Queue for DynamicCronQueue {
+            fn to_config() -> oxana::QueueConfig {
+                oxana::QueueConfig::as_static("dynamic_cron")
+            }
+        }
+
+        struct DynamicCronWorker;
+
+        impl oxana::FromContext<()> for DynamicCronWorker {
+            fn from_context(_ctx: &()) -> Self {
+                WORKER_BUILDS.fetch_add(1, Ordering::Relaxed);
+                Self
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl oxana::Worker<DynamicCronJob> for DynamicCronWorker {
+            type Error = WorkerError;
+
+            async fn run_batch(
+                &self,
+                _jobs: Vec<oxana::BatchItem<DynamicCronJob>>,
+            ) -> Result<(), Self::Error> {
+                Ok(())
+            }
+
+            fn cron_schedule() -> Option<String> {
+                Some("*/5 * * * * *".to_string())
+            }
+
+            fn cron_queue_config() -> Option<oxana::QueueConfig> {
+                Some(<DynamicCronQueue as oxana::Queue>::to_config())
+            }
+        }
+
+        let config = Config::<()>::new().register_worker::<DynamicCronWorker, DynamicCronJob>();
+        let first = config
+            .registry
+            .cron_envelope(DynamicCronJob::name(), 123)
+            .expect("first cron envelope should build")
+            .0;
+        let second = config
+            .registry
+            .cron_envelope(DynamicCronJob::name(), 456)
+            .expect("second cron envelope should build")
+            .0;
+
+        let first_arg_id = first
+            .job
+            .args
+            .get("id")
+            .and_then(serde_json::Value::as_u64)
+            .expect("first cron args should contain an id");
+        let second_arg_id = second
+            .job
+            .args
+            .get("id")
+            .and_then(serde_json::Value::as_u64)
+            .expect("second cron args should contain an id");
+        assert_ne!(first_arg_id, second_arg_id);
+        assert_eq!(
+            first.id,
+            format!("{}/{first_arg_id}", DynamicCronJob::name())
+        );
+        assert_eq!(
+            second.id,
+            format!("{}/{second_arg_id}", DynamicCronJob::name())
+        );
+        assert_eq!(
+            WORKER_BUILDS.load(Ordering::Relaxed),
+            0,
+            "building cron envelopes must not construct workers"
+        );
     }
 
     #[test]

--- a/oxana/src/job_envelope.rs
+++ b/oxana/src/job_envelope.rs
@@ -100,35 +100,49 @@ impl JobEnvelope {
         Ok(Self::new(queue, job)?.with_scheduled_at(scheduled_at))
     }
 
-    pub(crate) fn new_cron(
+    pub(crate) fn new_cron<T: Job + 'static>(
         queue: String,
-        id: String,
-        name: String,
+        occurrence_id: String,
+        job: &T,
         scheduled_at: i64,
         resurrect: bool,
-    ) -> Result<Self, OxanaError> {
+    ) -> Result<(Self, bool), OxanaError> {
         let now = chrono::Utc::now().timestamp_micros();
-        Ok(Self {
-            id: id.clone(),
-            queue,
-            job: JobData {
-                name,
-                args: serde_json::json!({}),
+        let name = T::name().to_string();
+        let on_conflict = job.on_conflict();
+        if matches!(on_conflict, JobConflictStrategy::Replace) {
+            return Err(OxanaError::GenericError(format!(
+                "{name}: cron jobs do not support `on_conflict = Replace`; use `Skip`"
+            )));
+        }
+        let (id, on_conflict, declared_unique) = match job.unique_id() {
+            Some(unique_id) => (format!("{name}/{unique_id}"), on_conflict, true),
+            None => (occurrence_id, JobConflictStrategy::Skip, false),
+        };
+        Ok((
+            Self {
+                id: id.clone(),
+                queue,
+                job: JobData {
+                    name,
+                    args: serde_json::to_value(job)?,
+                },
+                meta: JobMeta {
+                    id,
+                    retries: 0,
+                    unique: true,
+                    on_conflict: Some(on_conflict),
+                    created_at: now,
+                    scheduled_at: scheduled_at.max(now),
+                    started_at: None,
+                    state: None,
+                    resurrect,
+                    error: None,
+                    throttle_cost: None,
+                },
             },
-            meta: JobMeta {
-                id,
-                retries: 0,
-                unique: true,
-                on_conflict: Some(JobConflictStrategy::Skip),
-                created_at: now,
-                scheduled_at: scheduled_at.max(now),
-                started_at: None,
-                state: None,
-                resurrect,
-                error: None,
-                throttle_cost: None,
-            },
-        })
+            declared_unique,
+        ))
     }
 
     pub(crate) fn with_scheduled_at(mut self, scheduled_at: DateTime<Utc>) -> Self {
@@ -333,19 +347,52 @@ mod tests {
 
     #[test]
     fn test_cannot_schedule_cron_in_past() {
+        #[derive(Serialize)]
+        struct CronJob {}
+
+        impl Job for CronJob {}
+
         let past = Utc::now().timestamp_micros() - 3_600_000_000;
         let envelope = JobEnvelope::new_cron(
             "default".to_string(),
             "cron-job-1".to_string(),
-            "CronJob".to_string(),
+            &CronJob {},
             past,
             true,
         )
-        .unwrap();
+        .unwrap()
+        .0;
 
         let drift_micros = Utc::now().timestamp_micros() - envelope.meta.scheduled_at;
         assert!(drift_micros >= 0);
         assert!(drift_micros < 1_000_000);
+    }
+
+    #[test]
+    fn cron_envelope_rejects_replace_conflict() {
+        #[derive(Serialize)]
+        struct ReplaceCronJob {}
+
+        impl Job for ReplaceCronJob {
+            fn on_conflict(&self) -> JobConflictStrategy {
+                JobConflictStrategy::Replace
+            }
+        }
+
+        let error = JobEnvelope::new_cron(
+            "default".to_string(),
+            "CronJob-123".to_string(),
+            &ReplaceCronJob {},
+            Utc::now().timestamp_micros(),
+            true,
+        )
+        .expect_err("replace conflict should be rejected for cron jobs");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cron jobs do not support `on_conflict = Replace`; use `Skip`")
+        );
     }
 
     #[test]

--- a/oxana/src/launcher.rs
+++ b/oxana/src/launcher.rs
@@ -10,7 +10,6 @@ use crate::error::OxanaError;
 use crate::result_collector::Stats;
 use crate::runtime::Runtime;
 use crate::storage::Storage;
-use crate::storage_internal::StorageInternal;
 use crate::worker_registry::CronJob;
 
 pub(crate) async fn run<DT>(
@@ -220,9 +219,7 @@ where
 
     for (name, cron_job) in &runtime.registry.schedules {
         set.spawn(cron_job_loop(
-            runtime.storage.internal.clone(),
-            runtime.cancel_token.clone(),
-            runtime.settings.clone(),
+            Arc::clone(&runtime),
             name.clone(),
             cron_job.clone(),
         ));
@@ -231,20 +228,30 @@ where
     if set.is_empty() {
         runtime.cancel_token.cancelled().await;
     } else {
-        set.join_all().await;
+        while let Some(result) = set.join_next().await {
+            result??;
+        }
     }
     Ok(())
 }
 
-async fn cron_job_loop(
-    storage: StorageInternal,
-    cancel_token: CancellationToken,
-    settings: RuntimeSettings,
+async fn cron_job_loop<DT>(
+    runtime: Arc<Runtime<DT>>,
     job_name: String,
     cron_job: CronJob,
-) -> Result<(), OxanaError> {
+) -> Result<(), OxanaError>
+where
+    DT: Send + Sync + Clone + 'static,
+{
+    let storage = runtime.storage.internal.clone();
+    let registry = runtime.registry.clone();
     storage
-        .cron_job_loop(cancel_token, settings, job_name.clone(), cron_job)
+        .cron_job_loop(
+            runtime.cancel_token.clone(),
+            runtime.settings.clone(),
+            cron_job,
+            |scheduled_at| registry.cron_envelope(&job_name, scheduled_at),
+        )
         .await?;
 
     tracing::trace!("Cron job loop finished for {}", job_name);

--- a/oxana/src/registry.rs
+++ b/oxana/src/registry.rs
@@ -1,6 +1,9 @@
 use crate::{QueueConfig, RuntimeBuilder, worker_registry::WorkerConfig};
 
-pub struct ComponentRegistry<DT> {
+pub struct ComponentRegistry<DT>
+where
+    DT: Clone + Send + Sync + 'static,
+{
     /// `module_path!()`
     pub module_path: &'static str,
     /// `stringify!(MyStruct)`
@@ -8,9 +11,13 @@ pub struct ComponentRegistry<DT> {
     pub definition: fn() -> ComponentDefinition<DT>,
 }
 
-pub enum ComponentDefinition<DT> {
+pub enum ComponentDefinition<DT>
+where
+    DT: Clone + Send + Sync + 'static,
+{
     Queue(QueueConfig),
     Worker(WorkerConfig<DT>),
+    WorkerRegistration(fn(RuntimeBuilder<DT>) -> RuntimeBuilder<DT>),
 }
 
 pub trait RegisterComponents {
@@ -46,6 +53,7 @@ where
             match (component.definition)() {
                 ComponentDefinition::Queue(q) => runtime = runtime.queue_with(q),
                 ComponentDefinition::Worker(w) => runtime = runtime.worker_with(w),
+                ComponentDefinition::WorkerRegistration(register) => runtime = register(runtime),
             }
         }
         runtime

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -227,7 +227,7 @@ where
         self
     }
 
-    /// Sets how far ahead cron occurrences are scheduled. Defaults to 30 minutes.
+    /// Sets how far ahead cron occurrences are scheduled. Defaults to 30 seconds.
     pub fn cron_lookahead(mut self, lookahead: Duration) -> Self {
         self.settings.cron_lookahead = lookahead;
         self

--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -772,7 +772,7 @@ mod tests {
         assert_eq!(settings.retry_poll_interval, Duration::from_millis(300));
         assert_eq!(settings.schedule_poll_interval, Duration::from_millis(300));
         assert_eq!(settings.cron_initial_offset, Duration::from_secs(3));
-        assert_eq!(settings.cron_lookahead, Duration::from_secs(30 * 60));
+        assert_eq!(settings.cron_lookahead, Duration::from_secs(30));
         assert_eq!(settings.cron_tick_interval, Duration::from_secs(1));
         assert_eq!(settings.dequeue_timeout, Duration::from_secs(10));
         assert_eq!(settings.dispatcher_idle_sleep, Duration::from_secs(1));
@@ -824,6 +824,16 @@ mod tests {
         assert_eq!(settings.shutdown_timeout, Duration::from_millis(23));
         assert_eq!(settings.exit_when_processed, Some(24));
         assert_eq!(storage.dead_process_threshold(), Duration::from_millis(12));
+    }
+
+    #[test]
+    fn cron_lookahead_allows_values_above_the_default() {
+        let settings = test_storage()
+            .runtime(())
+            .cron_lookahead(Duration::from_secs(60))
+            .settings();
+
+        assert_eq!(settings.cron_lookahead, Duration::from_secs(60));
     }
 
     #[test]

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -28,6 +28,28 @@ const SCAN_BATCH_SIZE: usize = 500;
 const ENQUEUE_LIST_CHUNK_SIZE: usize = 100;
 const QUEUE_LENGTH_SNAPSHOT_TTL_SECS: i64 = 120;
 
+#[derive(Debug, PartialEq, Eq)]
+enum UniqueCronAction {
+    Enqueue,
+    Wait,
+    Skip,
+}
+
+fn unique_cron_action(
+    existing_job: bool,
+    previously_observed_existing_job: bool,
+    scheduled_at: i64,
+    now: i64,
+) -> UniqueCronAction {
+    if now >= scheduled_at && (existing_job || previously_observed_existing_job) {
+        UniqueCronAction::Skip
+    } else if existing_job {
+        UniqueCronAction::Wait
+    } else {
+        UniqueCronAction::Enqueue
+    }
+}
+
 fn unix_timestamp_secs_f64() -> f64 {
     chrono::Utc::now().timestamp_millis() as f64 / 1000.0
 }
@@ -1850,13 +1872,16 @@ impl StorageInternal {
         }
     }
 
-    pub async fn cron_job_loop(
+    pub async fn cron_job_loop<F>(
         &self,
         cancel_token: CancellationToken,
         settings: crate::config::RuntimeSettings,
-        job_name: String,
         cron_job: CronJob,
-    ) -> Result<(), OxanaError> {
+        mut envelope_factory: F,
+    ) -> Result<(), OxanaError>
+    where
+        F: FnMut(i64) -> Result<(JobEnvelope, bool), OxanaError> + Send,
+    {
         // Clamp instead of panicking: out-of-range offsets overflow both
         // chrono::Duration and the DateTime addition.
         let initial_offset = chrono::Duration::from_std(settings.cron_initial_offset)
@@ -1897,28 +1922,62 @@ impl StorageInternal {
             }
 
             let scheduled_at = next.timestamp_micros();
-            let job_id = format!("{job_name}-{scheduled_at}");
+            let (envelope, declared_unique) = envelope_factory(scheduled_at)?;
 
-            loop {
-                if cancel_token.is_cancelled() {
-                    return Ok(());
+            let should_enqueue = if declared_unique {
+                let mut observed_existing_job = false;
+                loop {
+                    if cancel_token.is_cancelled() {
+                        return Ok(());
+                    }
+                    let action = match self.track_redis_result(
+                        self.get_job(&envelope.id).await,
+                        settings.redis_failure_tolerance,
+                    )? {
+                        Some(existing) => {
+                            let existing_job = existing.is_some();
+                            let action = unique_cron_action(
+                                existing_job,
+                                observed_existing_job,
+                                scheduled_at,
+                                chrono::Utc::now().timestamp_micros(),
+                            );
+                            observed_existing_job |= existing_job;
+                            action
+                        }
+                        None => UniqueCronAction::Wait,
+                    };
+                    match action {
+                        UniqueCronAction::Skip => {
+                            tracing::warn!(
+                                "Unique cron job {} is still active at its next occurrence, skipping",
+                                envelope.id
+                            );
+                            break false;
+                        }
+                        UniqueCronAction::Wait => {
+                            tokio::time::sleep(settings.cron_tick_interval).await;
+                        }
+                        UniqueCronAction::Enqueue => break true,
+                    }
                 }
+            } else {
+                true
+            };
 
-                let envelope = JobEnvelope::new_cron(
-                    cron_job.queue_key.clone(),
-                    job_id.clone(),
-                    job_name.clone(),
-                    scheduled_at,
-                    cron_job.resurrect,
-                )?;
-
-                match self.track_redis_result(
-                    self.enqueue_at(envelope).await,
-                    settings.redis_failure_tolerance,
-                )? {
-                    Some(_) => break,
-                    None => {
-                        tokio::time::sleep(settings.cron_tick_interval).await;
+            if should_enqueue {
+                loop {
+                    if cancel_token.is_cancelled() {
+                        return Ok(());
+                    }
+                    match self.track_redis_result(
+                        self.enqueue_at(envelope.clone()).await,
+                        settings.redis_failure_tolerance,
+                    )? {
+                        Some(_) => break,
+                        None => {
+                            tokio::time::sleep(settings.cron_tick_interval).await;
+                        }
                     }
                 }
             }
@@ -2240,6 +2299,26 @@ mod tests {
 
     impl crate::worker::Job for TestJob {}
 
+    #[test]
+    fn unique_cron_skips_an_observed_occurrence_if_it_vanishes_after_due() {
+        assert_eq!(
+            unique_cron_action(true, false, 2_000, 1_000),
+            UniqueCronAction::Wait
+        );
+        assert_eq!(
+            unique_cron_action(true, true, 2_000, 2_000),
+            UniqueCronAction::Skip
+        );
+        assert_eq!(
+            unique_cron_action(false, false, 2_000, 1_000),
+            UniqueCronAction::Enqueue
+        );
+        assert_eq!(
+            unique_cron_action(false, true, 2_000, 2_000),
+            UniqueCronAction::Skip
+        );
+    }
+
     fn assert_close(actual: f64, expected: f64) {
         assert!(
             (actual - expected).abs() < 1e-9,
@@ -2486,10 +2565,11 @@ mod tests {
         let envelope = JobEnvelope::new_cron(
             queue.clone(),
             "CronWorker-1234567890".to_string(),
-            "CronWorker".to_string(),
+            &TestJob {},
             1234567890,
             true,
-        )?;
+        )?
+        .0;
 
         assert!(envelope.meta.unique);
         assert_eq!(envelope.meta.on_conflict, Some(JobConflictStrategy::Skip));
@@ -3501,6 +3581,40 @@ mod tests {
         assert!(job.meta.scheduled_at <= (after + delay));
         assert_eq!(job.meta.retries, 0);
         assert!(job.meta.error.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_at_unique_skip_keeps_existing_occurrence() -> TestResult {
+        #[derive(Serialize)]
+        struct UniqueTestJob;
+
+        impl crate::worker::Job for UniqueTestJob {
+            fn unique_id(&self) -> Option<String> {
+                Some("singleton".to_string())
+            }
+        }
+
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+        let envelope = JobEnvelope::new(queue, UniqueTestJob)?;
+        let first_at = chrono::Utc::now() + chrono::Duration::seconds(60);
+        let second_at = first_at + chrono::Duration::seconds(60);
+
+        storage
+            .enqueue_at(envelope.clone().with_scheduled_at(first_at))
+            .await?;
+        storage
+            .enqueue_at(envelope.clone().with_scheduled_at(second_at))
+            .await?;
+
+        assert_eq!(storage.scheduled_count().await?, 1);
+        let job = storage
+            .get_job(&envelope.id)
+            .await?
+            .expect("first occurrence should remain scheduled");
+        assert_eq!(job.meta.scheduled_at, first_at.timestamp_micros());
 
         Ok(())
     }

--- a/oxana/src/worker.rs
+++ b/oxana/src/worker.rs
@@ -24,6 +24,9 @@ impl WorkerBatchConfig {
 }
 
 pub trait Job: Send + serde::Serialize {
+    #[doc(hidden)]
+    const REPLACES_ON_CONFLICT: bool = false;
+
     fn name() -> &'static str
     where
         Self: Sized + 'static,
@@ -743,6 +746,7 @@ mod tests {
         struct DefaultQueue;
 
         #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+        #[oxana(unique_id = "test_cron", on_conflict = Skip)]
         struct TestCronJob {}
 
         #[derive(oxana::Worker)]

--- a/oxana/src/worker_registry.rs
+++ b/oxana/src/worker_registry.rs
@@ -9,6 +9,8 @@ use crate::worker::{BoundBatchJob, BoundJob, BoxedProcessable, FromContext, Job,
 pub type JobFactory<DT> = fn(serde_json::Value, &DT) -> Result<BoxedProcessable, OxanaError>;
 pub type JobBatchFactory<DT> = fn(Vec<serde_json::Value>, &DT) -> Result<BatchBuild, OxanaError>;
 pub type JobEnvelopeFactory = fn(String, serde_json::Value) -> Result<JobEnvelope, OxanaError>;
+pub(crate) type CronEnvelopeFactory =
+    fn(String, String, i64, bool) -> Result<(JobEnvelope, bool), OxanaError>;
 
 #[derive(Clone)]
 pub struct OnDemandJobRegistration {
@@ -118,11 +120,27 @@ where
     JobEnvelope::new(queue, job)
 }
 
+pub(crate) fn cron_envelope_factory<A>(
+    queue: String,
+    occurrence_id: String,
+    scheduled_at: i64,
+    resurrect: bool,
+) -> Result<(JobEnvelope, bool), OxanaError>
+where
+    A: Job + serde::de::DeserializeOwned + Send + 'static,
+{
+    let job: A = serde_json::from_value(serde_json::json!({})).map_err(|error| {
+        OxanaError::JobFactoryError(format!("Failed to build job {}: {error}", A::name()))
+    })?;
+    JobEnvelope::new_cron(queue, occurrence_id, &job, scheduled_at, resurrect)
+}
+
 #[derive(Clone)]
 struct WorkerFactories<DT> {
     factory: JobFactory<DT>,
     batch_factory: JobBatchFactory<DT>,
     batch_config: Option<WorkerBatchConfig>,
+    cron_envelope_factory: Option<CronEnvelopeFactory>,
 }
 
 impl<DT> WorkerRegistry<DT> {
@@ -135,13 +153,23 @@ impl<DT> WorkerRegistry<DT> {
         }
     }
 
-    pub fn register_worker_with(&mut self, config: WorkerConfig<DT>) {
+    pub fn register_worker_with(
+        &mut self,
+        config: WorkerConfig<DT>,
+        cron_envelope_factory: Option<CronEnvelopeFactory>,
+    ) {
+        assert!(
+            cron_envelope_factory.is_some()
+                || !matches!(&config.kind, WorkerConfigKind::Cron { .. }),
+            "manual cron worker registration is not supported; use typed worker registration"
+        );
         let name = config.name;
         let legacy_names = config.legacy_names;
         let factories = WorkerFactories {
             factory: config.factory,
             batch_factory: config.batch_factory,
             batch_config: config.batch_config,
+            cron_envelope_factory,
         };
 
         if let Some(alias_target) = self.aliases.remove(&name) {
@@ -223,6 +251,26 @@ impl<DT> WorkerRegistry<DT> {
                 "Failed to build job {name}: {e}"
             ))),
         }
+    }
+
+    pub(crate) fn cron_envelope(
+        &self,
+        name: &str,
+        scheduled_at: i64,
+    ) -> Result<(JobEnvelope, bool), OxanaError> {
+        let cron_job = self.schedules.get(name).ok_or_else(|| {
+            OxanaError::GenericError(format!("Cron job type {name} not registered"))
+        })?;
+        let factory = self
+            .factories_for(name)
+            .and_then(|factories| factories.cron_envelope_factory)
+            .expect("cron workers always have a typed envelope factory");
+        factory(
+            cron_job.queue_key.clone(),
+            format!("{name}-{scheduled_at}"),
+            scheduled_at,
+            cron_job.resurrect,
+        )
     }
 
     pub(crate) fn build_batch(

--- a/oxana/tests/compile_fail.rs
+++ b/oxana/tests/compile_fail.rs
@@ -4,6 +4,7 @@ fn worker_macro_validation_errors() {
     t.compile_fail("tests/ui/batch_size_requires_timeout.rs");
     t.compile_fail("tests/ui/batch_size_zero.rs");
     t.compile_fail("tests/ui/batch_timeout_requires_size.rs");
+    t.compile_fail("tests/ui/cron_replace_conflict.rs");
     t.compile_fail("tests/ui/static_queue_discovery_interval.rs");
 }
 

--- a/oxana/tests/integration/registry.rs
+++ b/oxana/tests/integration/registry.rs
@@ -54,6 +54,18 @@ impl CronWorkerCounter {
     }
 }
 
+#[test]
+fn registry_cron_workers_keep_typed_registration() {
+    let component = oxana::iterate_components::<ComponentRegistry>()
+        .find(|component| component.0.type_name == stringify!(CronWorkerCounter))
+        .expect("cron worker should be present in the component registry");
+
+    assert!(matches!(
+        (component.0.definition)(),
+        oxana::ComponentDefinition::WorkerRegistration(_)
+    ));
+}
+
 #[tokio::test]
 pub async fn test_registry() -> TestResult {
     let redis_pool = setup();

--- a/oxana/tests/ui/cron_replace_conflict.rs
+++ b/oxana/tests/ui/cron_replace_conflict.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct WorkerContext;
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {}
+
+#[derive(Debug, Serialize, Deserialize, oxana::Job)]
+#[oxana(unique_id = "singleton", on_conflict = Replace)]
+struct ReplaceCronJob {}
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(registry = None)]
+struct ReplaceCronQueue;
+
+#[derive(oxana::Worker)]
+#[oxana(registry = None)]
+#[oxana(cron(schedule = "*/5 * * * * *", queue = ReplaceCronQueue))]
+struct ReplaceCronWorker;
+
+impl ReplaceCronWorker {
+    async fn process(
+        &self,
+        _job: ReplaceCronJob,
+        _ctx: &oxana::JobContext,
+    ) -> Result<(), WorkerError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/oxana/tests/ui/cron_replace_conflict.stderr
+++ b/oxana/tests/ui/cron_replace_conflict.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: cron jobs do not support `on_conflict = Replace`; use `Skip`
+  --> tests/ui/cron_replace_conflict.rs:17:10
+   |
+17 | #[derive(oxana::Worker)]
+   |          ^^^^^^^^^^^^^ evaluation of `_` failed here


### PR DESCRIPTION
## Summary

- honor per-occurrence cron job IDs and metadata
- reject Replace conflict handling for cron jobs
- coordinate stable unique IDs safely across runtimes
- default cron lookahead to 30 seconds while preserving explicit overrides

## Validation

- cargo test --workspace (200 passed, 3 ignored)
- cargo clippy --all-features --workspace --all-targets -- -D warnings
- cargo fmt --all
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cron enqueue semantics, unique-job coordination in Redis, and changes the default lookahead window for all deployments; incorrect overlap handling could skip or duplicate scheduled work.
> 
> **Overview**
> Cron scheduling now builds each occurrence through a **typed envelope factory** instead of empty placeholder jobs, so cron runs carry real serialized args and honor each job’s **`unique_id`** and conflict strategy (with per-occurrence IDs when args vary).
> 
> **`on_conflict = Replace` is forbidden for cron** at compile time on `#[oxana(cron(...))]` workers and at runtime in `JobEnvelope::new_cron`, with docs explaining that Replace can corrupt overlapping occurrences. Jobs with a declared unique ID get **wait/skip/enqueue** logic so a still-active run blocks the next tick instead of piling up duplicates.
> 
> The default **`cron_lookahead` drops from 30 minutes to 30 seconds** (explicit `cron_lookahead` overrides still work). Component discovery registers cron workers via **`WorkerRegistration`** closures so typed `register_worker` runs; manual cron `WorkerConfig` without the factory is rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e1d28ee6a5c683b5f312f711af76cf98a91218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->