### PR TITLE
chore: release oxana 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2026-07-30
+
+### Added
+
+- Allow cron jobs to define a `unique_id` with the `Skip` conflict strategy, preventing overlapping occurrences of the same cron job. The unsafe `Replace` strategy is rejected at compile time for cron jobs.
+
 ## [2.0.1] - 2026-07-18
 
 ### Changed
 
 - Update workspace dependencies to their latest compatible releases, including Askama and Askama Web 0.16 for the dashboard.
+- Unify single-job and batch execution paths while preserving single-job logging and behavior.
+- Make metric flushing data-driven and simplify Prometheus metric registration.
 
-## [2.0.0]
+### Fixed
+
+- Order dashboard queues by enqueued count by default so the busiest queues appear first, with deterministic queue-key tie-breaking.
+
+## [2.0.0] - 2026-06-27
 
 **Breaking release.** See [MIGRATION.md](MIGRATION.md) for the 1.x -> 2.x upgrade guide.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "darling",
  "heck",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.0.1", path = "oxana" }
-oxana-macros = { version = "=2.0.1", path = "oxana-macros" }
+oxana = { version = "2.1.0", path = "oxana" }
+oxana-macros = { version = "=2.1.0", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -35,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.0.1 --features registry
+cargo add oxana@2.1.0 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary
- bump all Oxana workspace crates and internal dependency constraints to 2.1.0
- update the lockfile and README installation example
- add 2.1.0 release notes and backfill omitted 2.0.1 changes

## Testing
- cargo check --all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only release; no application or library logic changes in the diff.
> 
> **Overview**
> **Release 2.1.0** — bumps `oxana`, `oxana-macros`, and `oxana-web` from **2.0.1** to **2.1.0** across workspace manifests, `Cargo.lock`, and the README `cargo add` example.
> 
> **CHANGELOG** adds a **2.1.0** section (cron `unique_id` with `Skip`, compile-time rejection of `Replace` for cron) and expands **2.0.1** notes that were missing from the log (execution-path unification, metrics registration, dashboard queue ordering). The **2.0.0** heading gets an explicit release date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c5841b47a81b326d355711bae06827b4e5650e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->