### PR TITLE
refactor: prepare fresh benchmark samples

### DIFF
--- a/oxana/benches/concurrency.rs
+++ b/oxana/benches/concurrency.rs
@@ -53,20 +53,27 @@ impl oxana::Queue for QueueOne {
 
 const JOBS_COUNT: u64 = 1000;
 const CONCURRENCY: &[usize] = &[1, 2, 4, 8, 12, 16, 512];
+const SAMPLE_COUNT: u32 = 5;
 
 macro_rules! bench_jobs {
     ($name:ident, $sleep_ms:expr) => {
-        #[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = 1)]
+        #[divan::bench(args = CONCURRENCY, sample_size = 1, sample_count = SAMPLE_COUNT)]
         fn $name(bencher: divan::Bencher, n: usize) {
             let rt = &tokio::runtime::Runtime::new().unwrap();
             let storage = build_storage();
-            rt.block_on(async { setup(&storage, JOBS_COUNT, $sleep_ms).await.unwrap() });
 
-            bencher.bench(|| {
-                rt.block_on(async {
-                    execute(storage.clone(), n, JOBS_COUNT).await.unwrap();
+            bencher
+                .with_inputs(|| {
+                    rt.block_on(async {
+                        setup(&storage, JOBS_COUNT, $sleep_ms).await.unwrap();
+                    });
+                    storage.clone()
                 })
-            });
+                .bench_local_values(|storage| {
+                    rt.block_on(async {
+                        execute(storage, n, JOBS_COUNT).await.unwrap();
+                    })
+                });
         }
     };
 }


### PR DESCRIPTION
## Summary

- collect five independent samples for every benchmark case
- enqueue a fresh 1,000-job workload outside the timed region for each iteration
- preserve the existing benchmark matrix and processing assertions

## Verification

- cargo fmt --all
- cargo clippy --all-features --workspace --all-targets -- -D warnings
- cargo test --lib --no-default-features (90 passed)
- cargo bench -p oxana --bench concurrency (all 28 cases completed with five samples)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark-only changes to `oxana/benches/concurrency.rs`; no production runtime or library behavior is modified.
> 
> **Overview**
> The **concurrency** divan benchmarks now report **five samples** per case (`SAMPLE_COUNT`) instead of a single sample.
> 
> Each timed iteration **re-enqueues 1,000 jobs** in `with_inputs` (outside the measured region), then times only `execute` via `bench_local_values`. Setup no longer runs once before the whole bench loop, so measurements are not tied to one shared queue state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d023a0e0b8b917959943be7dd4d459fd012938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->