### PR TITLE
Stabilize the CI benchmark environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
 
     services:
       redis:
-        image: redis
+        image: redis:8
+        command: redis-server --save "" --appendonly no
         ports:
           - 6379:6379
-        options: --entrypoint redis-server
 
     env:
       CARGO_TERM_COLOR: always
@@ -48,6 +48,8 @@ jobs:
 
       - name: Benchmark
         run: cargo bench
+        env:
+          RUST_LOG: "off"
 
       - name: Publish
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

- run benchmarks with logging disabled
- use Redis 8 for CI services
- disable Redis RDB and AOF persistence during CI

## Verification

- parsed the workflow as YAML
- ran git diff --check
- smoke-tested the benchmark against Redis with persistence disabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes with no application code or production behavior impact.
> 
> **Overview**
> **CI benchmark stability** in `.github/workflows/test.yml`: the Redis service is pinned to **`redis:8`** and started with **`redis-server --save "" --appendonly no`** so RDB/AOF persistence is off during tests/benches (replacing the generic `redis` image and `--entrypoint redis-server` options).
> 
> The **Benchmark** step sets **`RUST_LOG: "off"`** so `cargo bench` does not inherit the job-wide `RUST_LOG: trace`, reducing log noise and timing variance in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc295a82e1f5e5ebc645c458d7591c9a1e67ed12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->