### PR TITLE
Support Conductor cloud development

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,6 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "./scripts/workspace-setup.sh"
+archive = "./scripts/workspace-archive.sh"
+run_mode = "concurrent"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This file provides guidance to any coding agent (Claude, ChatGPT, etc.) when wor
 - `cargo test <test_name>` - Run specific tests by name
 - `cargo bench` - Run benchmarks (uses divan benchmarking framework)
 - `cargo check --all` - Quick syntax and type checking without building
-- `cargo fmt --workspace` - Format the codebase
+- `cargo fmt --all` - Format the codebase (`cargo fmt --all -- --check` to verify only)
 - `cargo clippy --all-features --workspace` - Run Rust linter with extensive warnings enabled
 - `cargo doc` - Generate documentation
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,0 @@
-{
-    "scripts": {
-        "setup": "./scripts/workspace-setup.sh",
-        "archive": "./scripts/workspace-archive.sh"
-    }
-}

--- a/scripts/workspace-archive.sh
+++ b/scripts/workspace-archive.sh
@@ -1,19 +1,39 @@
 #!/bin/bash
 
-set -e -o pipefail
+set -euo pipefail
 
-WORKSPACE_DIR=$(basename "$(pwd)")
-REDIS_DB=$(( ($(echo "$WORKSPACE_DIR" | cksum | cut -d' ' -f1) % 255) + 1 ))
-REDIS_CONTAINER="redis"
+readonly WORKSPACE_DIR="${CONDUCTOR_WORKSPACE_PATH:-$(pwd)}"
+readonly WORKSPACE_NAME="${CONDUCTOR_WORKSPACE_NAME:-$(basename "$WORKSPACE_DIR")}"
+readonly ENV_FILE="$WORKSPACE_DIR/.env.test"
+readonly WORKSPACE_CHECKSUM="$(printf '%s' "$WORKSPACE_NAME" | cksum | cut -d' ' -f1)"
+readonly REDIS_CONTAINER="redis"
+REDIS_DB="$((WORKSPACE_CHECKSUM % 15 + 1))"
 
-echo "Archiving workspace: $WORKSPACE_DIR"
+if [[ -f "$ENV_FILE" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^REDIS_URL=redis://(localhost|127\.0\.0\.1):6379/([0-9]+)$ ]]; then
+      REDIS_DB="${BASH_REMATCH[2]}"
+      break
+    fi
+  done < "$ENV_FILE"
+fi
 
-# Flush Redis database
-if docker ps --format '{{.Names}}' | grep -q "$REDIS_CONTAINER"; then
+echo "Archiving workspace: $WORKSPACE_NAME"
+
+if command -v redis6-cli >/dev/null 2>&1 \
+  && redis6-cli -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+  echo "Flushing Redis database $REDIS_DB..."
+  redis6-cli -h 127.0.0.1 -p 6379 -n "$REDIS_DB" FLUSHDB
+elif command -v redis-cli >/dev/null 2>&1 \
+  && redis-cli -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+  echo "Flushing Redis database $REDIS_DB..."
+  redis-cli -h 127.0.0.1 -p 6379 -n "$REDIS_DB" FLUSHDB
+elif command -v docker >/dev/null 2>&1 \
+  && docker ps --format '{{.Names}}' | grep -qx "$REDIS_CONTAINER"; then
   echo "Flushing Redis database $REDIS_DB..."
   docker exec "$REDIS_CONTAINER" redis-cli -n "$REDIS_DB" FLUSHDB
 else
-  echo "Redis container not running, skipping Redis cleanup"
+  echo "Redis is not running, skipping cleanup"
 fi
 
 echo "Workspace archive complete!"

--- a/scripts/workspace-setup.sh
+++ b/scripts/workspace-setup.sh
@@ -1,22 +1,104 @@
 #!/bin/bash
 
-set -e -o pipefail
+set -euo pipefail
 
-WORKSPACE_DIR=$(basename "$(pwd)")
-REDIS_DB=$(( ($(echo "$WORKSPACE_DIR" | cksum | cut -d' ' -f1) % 255) + 1 ))
+readonly WORKSPACE_DIR="${CONDUCTOR_WORKSPACE_PATH:-$(pwd)}"
+readonly WORKSPACE_NAME="${CONDUCTOR_WORKSPACE_NAME:-$(basename "$WORKSPACE_DIR")}"
+readonly ENV_FILE="$WORKSPACE_DIR/.env.test"
 
-echo "Setting up workspace: $WORKSPACE_DIR"
-echo "Redis database: $REDIS_DB"
+# Redis provides 16 databases by default. Reserve database 0 for development
+# outside Conductor and distribute workspaces over databases 1 through 15.
+readonly WORKSPACE_CHECKSUM="$(printf '%s' "$WORKSPACE_NAME" | cksum | cut -d' ' -f1)"
+readonly GENERATED_REDIS_DB="$((WORKSPACE_CHECKSUM % 15 + 1))"
+REDIS_DB="$GENERATED_REDIS_DB"
 
-ENV_FILE=".env.test"
+local_redis_db_from_env() {
+  local line
 
-if [ -f "$ENV_FILE" ]; then
-  echo "$ENV_FILE already exists, skipping"
-else
-  echo "Creating $ENV_FILE..."
-  echo "REDIS_URL=redis://localhost:6379/${REDIS_DB}" > "$ENV_FILE"
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^REDIS_URL=redis://(localhost|127\.0\.0\.1):6379/([0-9]+)$ ]]; then
+      printf '%s\n' "${BASH_REMATCH[2]}"
+      return
+    fi
+  done < "$ENV_FILE"
+
+  return 1
+}
+
+install_cloud_dependencies() {
+  local -a packages=()
+
+  command -v cargo >/dev/null 2>&1 || packages+=(rust cargo)
+  command -v cc >/dev/null 2>&1 || packages+=(gcc)
+  command -v cargo-fmt >/dev/null 2>&1 || packages+=(rustfmt)
+  command -v cargo-clippy >/dev/null 2>&1 || packages+=(clippy)
+  command -v redis6-server >/dev/null 2>&1 || packages+=(redis6)
+
+  if ((${#packages[@]} > 0)); then
+    echo "Installing cloud development dependencies: ${packages[*]}"
+    sudo dnf install -y "${packages[@]}"
+  fi
+}
+
+start_cloud_redis() {
+  if redis6-cli -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+    echo "Redis is already running"
+    return
+  fi
+
+  local runtime_dir="${TMPDIR:-/tmp}"
+  echo "Starting Redis..."
+  redis6-server \
+    --daemonize yes \
+    --bind 127.0.0.1 \
+    --port 6379 \
+    --protected-mode yes \
+    --databases 16 \
+    --save "" \
+    --appendonly no \
+    --dir "$runtime_dir" \
+    --pidfile "$runtime_dir/oxana-redis.pid" \
+    --logfile "$runtime_dir/oxana-redis.log"
+
+  for _ in {1..50}; do
+    if redis6-cli -h 127.0.0.1 -p 6379 ping >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.1
+  done
+
+  echo "Redis failed to start. Log output:" >&2
+  sed -n '1,160p' "$runtime_dir/oxana-redis.log" >&2
+  return 1
+}
+
+echo "Setting up workspace: $WORKSPACE_NAME"
+
+if [[ "${CONDUCTOR_IS_LOCAL:-1}" == "0" ]]; then
+  install_cloud_dependencies
+  start_cloud_redis
 fi
 
-echo ""
+if [[ -f "$ENV_FILE" ]]; then
+  if configured_redis_db="$(local_redis_db_from_env)"; then
+    if [[ "${CONDUCTOR_IS_LOCAL:-1}" == "0" ]] && ((10#$configured_redis_db >= 16)); then
+      echo "Updating .env.test to use a database supported by cloud Redis..."
+      printf 'REDIS_URL=redis://127.0.0.1:6379/%s\n' "$GENERATED_REDIS_DB" > "$ENV_FILE"
+    else
+      REDIS_DB="$configured_redis_db"
+      echo ".env.test already exists, skipping"
+    fi
+  else
+    echo ".env.test already exists with a custom Redis URL, skipping"
+  fi
+else
+  echo "Creating .env.test..."
+  printf 'REDIS_URL=redis://127.0.0.1:6379/%s\n' "$REDIS_DB" > "$ENV_FILE"
+fi
+
+echo "Fetching Rust dependencies..."
+(cd "$WORKSPACE_DIR" && cargo fetch --locked)
+
+echo
 echo "Workspace setup complete!"
 echo "  Redis DB: $REDIS_DB"


### PR DESCRIPTION
## Summary

- migrate repository Conductor configuration to shared TOML settings
- bootstrap Rust tooling and Redis automatically in cloud workspaces
- make Redis setup and archive cleanup portable across cloud, local, and Docker environments
- correct the documented workspace formatting command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dev-environment scripts and docs; cloud setup uses `sudo dnf` and rewrites test Redis URLs only when needed.
> 
> **Overview**
> Moves Conductor repo configuration from `conductor.json` to **`.conductor/settings.toml`**, keeping the same setup/archive scripts and setting **`run_mode = "concurrent"`**.
> 
> **`workspace-setup.sh`** now keys off Conductor env vars (`CONDUCTOR_WORKSPACE_*`, `CONDUCTOR_IS_LOCAL`), assigns Redis DBs **1–15** (was modulo 255), and on cloud (`CONDUCTOR_IS_LOCAL=0`) installs Rust/redis via `dnf`, starts local `redis6-server`, normalizes `.env.test` URLs to `127.0.0.1`, and runs **`cargo fetch --locked`**. **`workspace-archive.sh`** flushes the workspace DB via `redis6-cli` / `redis-cli` / Docker fallback, reading the DB index from `.env.test` when present.
> 
> **`AGENTS.md`** documents **`cargo fmt --all`** (with optional `--check`) instead of `--workspace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88ca4e0b364e5c8844ac22324fdef96ca2210ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->