### PR TITLE
chore: release oxana 2.1.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     services:
       redis:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1] - 2026-08-06
+
+### Changed
+
+- Prepare a fresh workload for each benchmark sample and stabilize the benchmark environment in CI.
+- Support local and cloud Conductor workspaces in the setup and archive scripts.
+
+### Fixed
+
+- Stop dispatchers from acquiring new jobs after graceful shutdown begins.
+
 ## [2.1.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Prepare a fresh workload for each benchmark sample and stabilize the benchmark environment in CI.
+- Prepare a fresh workload for each benchmark sample, stabilize the benchmark environment, and allow CI enough time to finish benchmarks.
 - Support local and cloud Conductor workspaces in the setup and archive scripts.
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "darling",
  "heck",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.1.0", path = "oxana" }
-oxana-macros = { version = "=2.1.0", path = "oxana-macros" }
+oxana = { version = "2.1.1", path = "oxana" }
+oxana-macros = { version = "=2.1.1", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -35,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.1.0 --features registry
+cargo add oxana@2.1.1 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary
- bump all Oxana workspace crates from 2.1.0 to 2.1.1
- update the install example and lockfile versions
- document all changes since 2.1.0 in the changelog

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-features --workspace
- cargo check --all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation updates plus a CI timeout tweak; no application logic changes in this diff.
> 
> **Overview**
> **Release 2.1.1** — bumps `oxana`, `oxana-macros`, and `oxana-web` from **2.1.0** to **2.1.1** across workspace `Cargo.toml`, `Cargo.lock`, and the `cargo add` example in `oxana/README.md`.
> 
> Adds a **CHANGELOG** entry for 2.1.1 summarizing work already landed since 2.1.0: benchmark/CI stability (fresh workload per sample, longer CI allowance), Conductor local/cloud workspace support in setup/archive scripts, and a fix so dispatchers stop taking new jobs once graceful shutdown starts.
> 
> Raises the **Test** workflow job `timeout-minutes` from **10** to **15** so `cargo bench` in CI can finish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b168811759059f6ca104b3d5accb555eb45d8314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->