### PR TITLE
Add unique job deletion by ID or job value

### DIFF
--- a/oxana/src/job_envelope.rs
+++ b/oxana/src/job_envelope.rs
@@ -7,6 +7,25 @@ use crate::worker::Job;
 
 pub type JobId = String;
 
+/// Resolves the deterministic ID used by a unique job.
+pub trait UniqueJobId {
+    /// Returns the job ID, or [`None`] when a [`Job`] does not define a unique ID.
+    fn unique_job_id(&self) -> Option<JobId>;
+}
+
+impl UniqueJobId for JobId {
+    fn unique_job_id(&self) -> Option<JobId> {
+        Some(self.clone())
+    }
+}
+
+impl<T: Job + 'static> UniqueJobId for T {
+    fn unique_job_id(&self) -> Option<JobId> {
+        self.unique_id()
+            .map(|unique_id| format!("{}/{}", T::name(), unique_id))
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct JobEnvelope {
     pub id: JobId,
@@ -58,13 +77,10 @@ pub enum JobConflictStrategy {
 impl JobEnvelope {
     pub(crate) fn new<T: Job + 'static>(queue: String, job: T) -> Result<Self, OxanaError> {
         let job_name = T::name().to_string();
-        let unique_id = job.unique_id();
-        let unique = unique_id.is_some();
+        let unique_job_id = job.unique_job_id();
+        let unique = unique_job_id.is_some();
         let resurrect = T::should_resurrect();
-        let id = match unique_id {
-            Some(id) => format!("{}/{}", job_name, id),
-            None => Uuid::new_v4().to_string(),
-        };
+        let id = unique_job_id.unwrap_or_else(|| Uuid::new_v4().to_string());
         Ok(Self {
             id: id.clone(),
             queue,
@@ -115,8 +131,8 @@ impl JobEnvelope {
                 "{name}: cron jobs do not support `on_conflict = Replace`; use `Skip`"
             )));
         }
-        let (id, on_conflict, declared_unique) = match job.unique_id() {
-            Some(unique_id) => (format!("{name}/{unique_id}"), on_conflict, true),
+        let (id, on_conflict, declared_unique) = match job.unique_job_id() {
+            Some(unique_job_id) => (unique_job_id, on_conflict, true),
             None => (occurrence_id, JobConflictStrategy::Skip, false),
         };
         Ok((

--- a/oxana/src/lib.rs
+++ b/oxana/src/lib.rs
@@ -113,7 +113,9 @@ mod test_helper;
 pub use crate::context::JobContext;
 pub use crate::drainer::DrainStats;
 pub use crate::error::OxanaError;
-pub use crate::job_envelope::{JobConflictStrategy, JobData, JobEnvelope, JobId, JobMeta};
+pub use crate::job_envelope::{
+    JobConflictStrategy, JobData, JobEnvelope, JobId, JobMeta, UniqueJobId,
+};
 pub use crate::job_state::{JobProgress, JobProgressIterator, JobState};
 pub use crate::metrics::*;
 pub use crate::queue::{

--- a/oxana/src/storage.rs
+++ b/oxana/src/storage.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     config::DEFAULT_DEAD_PROCESS_THRESHOLD,
     error::OxanaError,
-    job_envelope::{JobEnvelope, JobId},
+    job_envelope::{JobEnvelope, JobId, UniqueJobId},
     metrics::{
         JobMetricsDetail, JobMetricsQuery, JobMetricsSnapshot, MetricIdentity,
         QueueLengthMetricsSnapshot,
@@ -348,6 +348,19 @@ impl Storage {
     /// An [`OxanaError`] if the operation fails.
     pub async fn delete_job(&self, id: &JobId) -> Result<(), OxanaError> {
         self.internal.delete_job(id).await
+    }
+
+    /// Deletes a unique job identified by either its [`JobId`] or its [`Job`] value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OxanaError::ConfigError`] when the provided job does not define
+    /// a unique ID.
+    pub async fn delete_unique_job<T: UniqueJobId>(&self, job: &T) -> Result<(), OxanaError> {
+        let id = job.unique_job_id().ok_or_else(|| {
+            OxanaError::ConfigError("delete_unique_job requires a job with a unique ID".to_string())
+        })?;
+        self.delete_job(&id).await
     }
 
     /// Returns a job by its ID.

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -674,7 +674,24 @@ impl StorageInternal {
 
     pub async fn delete_job(&self, id: &JobId) -> Result<(), OxanaError> {
         let mut redis = self.connection().await?;
-        let envelope = self.get_job_w_conn(&mut redis, id).await?;
+        let raw_envelope: Option<String> = redis.hget(&self.keys.jobs, id).await?;
+        let queue = raw_envelope
+            .as_deref()
+            .and_then(|envelope| serde_json::from_str::<serde_json::Value>(envelope).ok())
+            .and_then(|envelope| {
+                envelope
+                    .get("queue")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
+            });
+        let queue_keys = if let Some(queue) = queue {
+            HashSet::from([self.namespace_queue(&queue)])
+        } else if raw_envelope.is_some() {
+            self.scan_keys_w_conn(&mut redis, &self.namespace_queue("*"))
+                .await?
+        } else {
+            HashSet::new()
+        };
         let mut pipe = redis::pipe();
         pipe.atomic()
             .hdel(&self.keys.jobs, id)
@@ -682,8 +699,8 @@ impl StorageInternal {
             .zrem(&self.keys.retry, id)
             .lrem(self.current_processing_queue(), 0, id);
 
-        if let Some(envelope) = envelope {
-            pipe.lrem(self.namespace_queue(&envelope.queue), 0, id);
+        for queue_key in queue_keys {
+            pipe.lrem(queue_key, 0, id);
         }
 
         let _: () = pipe.query_async(&mut redis).await?;
@@ -3225,6 +3242,36 @@ mod tests {
         assert!(returned_ids.contains(&envelope1.id));
         assert!(!returned_ids.contains(&envelope2.id));
         assert!(returned_ids.contains(&envelope3.id));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_delete_job_cleans_up_corrupt_job_memberships() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+        let envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
+        let job_id = envelope.id.clone();
+
+        storage.enqueue(envelope).await?;
+
+        let mut redis = storage.connection().await?;
+        let _: () = redis::pipe()
+            .hset(&storage.keys.jobs, &job_id, "{invalid json")
+            .zadd(&storage.keys.schedule, &job_id, 1)
+            .zadd(&storage.keys.retry, &job_id, 1)
+            .lpush(storage.current_processing_queue(), &job_id)
+            .query_async(&mut redis)
+            .await?;
+
+        storage.delete_job(&job_id).await?;
+
+        let payload_exists: bool = redis.hexists(&storage.keys.jobs, &job_id).await?;
+        assert!(!payload_exists);
+        assert_eq!(storage.enqueued_count(&queue).await?, 0);
+        assert_eq!(storage.scheduled_count().await?, 0);
+        assert_eq!(storage.retries_count().await?, 0);
+        assert!(storage.currently_processing_job_ids().await?.is_empty());
 
         Ok(())
     }

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -674,11 +674,19 @@ impl StorageInternal {
 
     pub async fn delete_job(&self, id: &JobId) -> Result<(), OxanaError> {
         let mut redis = self.connection().await?;
-        let _: () = redis::pipe()
+        let envelope = self.get_job_w_conn(&mut redis, id).await?;
+        let mut pipe = redis::pipe();
+        pipe.atomic()
             .hdel(&self.keys.jobs, id)
-            .lrem(self.current_processing_queue(), 1, id)
-            .query_async(&mut redis)
-            .await?;
+            .zrem(&self.keys.schedule, id)
+            .zrem(&self.keys.retry, id)
+            .lrem(self.current_processing_queue(), 0, id);
+
+        if let Some(envelope) = envelope {
+            pipe.lrem(self.namespace_queue(&envelope.queue), 0, id);
+        }
+
+        let _: () = pipe.query_async(&mut redis).await?;
         Ok(())
     }
 

--- a/oxana/tests/integration/unique.rs
+++ b/oxana/tests/integration/unique.rs
@@ -576,8 +576,10 @@ pub async fn test_delete_unique_job_accepts_job_id_or_job() -> TestResult {
             },
         )
         .await?;
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
     storage.delete_unique_job(&first_job_id).await?;
     assert!(storage.get_job(&first_job_id).await?.is_none());
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
 
     let second_job_id = storage
         .enqueue(
@@ -596,6 +598,97 @@ pub async fn test_delete_unique_job_accepts_job_id_or_job() -> TestResult {
     };
     storage.delete_unique_job(&second_job).await?;
     assert!(storage.get_job(&second_job_id).await?.is_none());
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+
+    let re_enqueued_job_id = storage
+        .enqueue(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 2,
+                key: random_string(),
+                value: 4,
+            },
+        )
+        .await?;
+    assert_eq!(re_enqueued_job_id, second_job_id);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_delete_unique_job_removes_scheduled_membership() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+
+    let job_id = storage
+        .enqueue_in(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 1,
+                key: random_string(),
+                value: 1,
+            },
+            60,
+        )
+        .await?;
+    assert_eq!(storage.scheduled_count().await?, 1);
+
+    storage.delete_unique_job(&job_id).await?;
+
+    assert!(storage.get_job(&job_id).await?.is_none());
+    assert_eq!(storage.scheduled_count().await?, 0);
+
+    let re_enqueued_job_id = storage
+        .enqueue_in(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 1,
+                key: random_string(),
+                value: 2,
+            },
+            60,
+        )
+        .await?;
+    assert_eq!(re_enqueued_job_id, job_id);
+    assert_eq!(storage.scheduled_count().await?, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_delete_unique_job_removes_retry_membership() -> TestResult {
+    let redis_pool = setup();
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerUniqueReplaceRetry, WorkerUniqueReplaceRetryJob>()
+        .exit_when_processed(1);
+
+    let job_id = storage
+        .enqueue(QueueOne, WorkerUniqueReplaceRetryJob { id: 1, marker: 1 })
+        .await?;
+    runtime.run().await?;
+    assert_eq!(storage.retries_count().await?, 1);
+
+    storage.delete_unique_job(&job_id).await?;
+
+    assert!(storage.get_job(&job_id).await?.is_none());
+    assert_eq!(storage.retries_count().await?, 0);
+
+    let re_enqueued_job_id = storage
+        .enqueue(QueueOne, WorkerUniqueReplaceRetryJob { id: 1, marker: 2 })
+        .await?;
+    assert_eq!(re_enqueued_job_id, job_id);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 1);
 
     Ok(())
 }

--- a/oxana/tests/integration/unique.rs
+++ b/oxana/tests/integration/unique.rs
@@ -558,3 +558,61 @@ pub async fn test_unique_replace() -> TestResult {
 
     Ok(())
 }
+
+#[tokio::test]
+pub async fn test_delete_unique_job_accepts_job_id_or_job() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+
+    let first_job_id = storage
+        .enqueue(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 1,
+                key: random_string(),
+                value: 1,
+            },
+        )
+        .await?;
+    storage.delete_unique_job(&first_job_id).await?;
+    assert!(storage.get_job(&first_job_id).await?.is_none());
+
+    let second_job_id = storage
+        .enqueue(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 2,
+                key: random_string(),
+                value: 2,
+            },
+        )
+        .await?;
+    let second_job = WorkerUniqueSkipJob {
+        id: 2,
+        key: random_string(),
+        value: 3,
+    };
+    storage.delete_unique_job(&second_job).await?;
+    assert!(storage.get_job(&second_job_id).await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_delete_unique_job_rejects_non_unique_job() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+
+    let error = storage
+        .delete_unique_job(&WorkerNoopJob {})
+        .await
+        .expect_err("non-unique jobs cannot be resolved to a deterministic ID");
+
+    assert!(matches!(error, oxana::OxanaError::ConfigError(_)));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add Storage::delete_unique_job for JobId and typed Job inputs
- centralize deterministic unique job ID construction behind UniqueJobId
- atomically remove deleted jobs from waiting queues, scheduled jobs, retries, and current-process tracking
- cover ID deletion, typed job deletion, non-unique rejection, and safe re-enqueueing from every pending state

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-features --workspace --all-targets -- -D warnings
- cargo test --all-features --workspace (208 passed, 3 ignored)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Redis job-deletion paths used for queue/schedule/retry membership, so incomplete cleanup could leave stale unique-job state. Changes are narrowly scoped and covered by new integration tests.
> 
> **Overview**
> Adds **`Storage::delete_unique_job`**, so callers can cancel a unique job by either its `JobId` or a typed `Job` value without manually reconstructing the deterministic ID.
> 
> Introduces a shared **`UniqueJobId`** trait that centralizes `{job_name}/{unique_id}` resolution, and wires envelope creation through it.
> 
> Also hardens **`delete_job`** to atomically clear membership from waiting queues, the schedule set, retries, and the current processing list—including corrupt payloads—so deleted unique jobs can be safely re-enqueued from any pending state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a734f18a0d63c399b6e9fe3ebfa7064e9350f232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->