### PR TITLE
chore: release oxana 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2] - 2026-08-11
+
+### Added
+
+- Add `Storage::delete_unique_job` for deleting unique jobs by job ID or job value.
+
+### Fixed
+
+- Remove deleted jobs from pending, scheduled, retry, and processing queues so they can be re-enqueued cleanly.
+- Allow deleting jobs with corrupt payloads while cleaning up their queue memberships.
+
 ## [2.1.1] - 2026-08-06
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "darling",
  "heck",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.1.1", path = "oxana" }
-oxana-macros = { version = "=2.1.1", path = "oxana-macros" }
+oxana = { version = "2.1.2", path = "oxana" }
+oxana-macros = { version = "=2.1.2", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -35,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.1.1 --features registry
+cargo add oxana@2.1.2 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary
- bump all Oxana workspace crates to 2.1.2
- update the README installation example
- document unique-job deletion and queue cleanup fixes in the changelog

## Verification
- cargo fmt --all
- cargo clippy --all-features --workspace
- cargo check --all
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure version bump and documentation update with no runtime or API code changes in this PR.
> 
> **Overview**
> Releases **Oxana 2.1.2** by bumping `oxana`, `oxana-macros`, and `oxana-web` (plus workspace/`Cargo.lock` versions) and updating the README install example.
> 
> Changelog notes the already-landed `Storage::delete_unique_job` API and fixes that remove deleted jobs from pending/scheduled/retry/processing queues, including jobs with corrupt payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 180469cb82d0227814269428d7a2d792149749ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->