### PR TITLE
test: cover unique enqueue_at conflict schedules

### DIFF
--- a/oxana/tests/integration/unique.rs
+++ b/oxana/tests/integration/unique.rs
@@ -128,6 +128,110 @@ impl oxana::FromContext<WorkerState> for WorkerUniqueReplaceRetry {
     }
 }
 
+#[tokio::test]
+pub async fn test_enqueue_at_unique_skip_preserves_original_schedule() -> TestResult {
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(setup())?;
+    let first_at = chrono::Utc::now() + chrono::Duration::seconds(60);
+    let between_at = first_at + chrono::Duration::seconds(30);
+    let second_at = first_at + chrono::Duration::seconds(60);
+    let key = random_string();
+
+    let first_id = storage
+        .enqueue_at(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 1,
+                key: key.clone(),
+                value: 1,
+            },
+            first_at,
+        )
+        .await?;
+    let skipped_id = storage
+        .enqueue_at(
+            QueueOne,
+            WorkerUniqueSkipJob {
+                id: 1,
+                key,
+                value: 2,
+            },
+            second_at,
+        )
+        .await?;
+    let between_id = storage
+        .enqueue_at(QueueOne, WorkerNoopJob {}, between_at)
+        .await?;
+
+    assert_eq!(skipped_id, first_id);
+    let scheduled = storage
+        .list_scheduled(&oxana::QueueListOpts {
+            count: 10,
+            offset: 0,
+        })
+        .await?;
+    assert_eq!(scheduled.len(), 2);
+    assert_eq!(scheduled[0].id, first_id);
+    assert_eq!(scheduled[0].meta.scheduled_at, first_at.timestamp_micros());
+    assert_eq!(scheduled[0].job.args["value"], 1);
+    assert_eq!(scheduled[1].id, between_id);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_enqueue_at_unique_replace_uses_new_schedule() -> TestResult {
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(setup())?;
+    let first_at = chrono::Utc::now() + chrono::Duration::seconds(60);
+    let between_at = first_at + chrono::Duration::seconds(30);
+    let second_at = first_at + chrono::Duration::seconds(60);
+    let key = random_string();
+
+    let first_id = storage
+        .enqueue_at(
+            QueueOne,
+            WorkerUniqueReplaceJob {
+                id: 1,
+                key: key.clone(),
+                value: 1,
+            },
+            first_at,
+        )
+        .await?;
+    let replaced_id = storage
+        .enqueue_at(
+            QueueOne,
+            WorkerUniqueReplaceJob {
+                id: 1,
+                key,
+                value: 2,
+            },
+            second_at,
+        )
+        .await?;
+    let between_id = storage
+        .enqueue_at(QueueOne, WorkerNoopJob {}, between_at)
+        .await?;
+
+    assert_eq!(replaced_id, first_id);
+    let scheduled = storage
+        .list_scheduled(&oxana::QueueListOpts {
+            count: 10,
+            offset: 0,
+        })
+        .await?;
+    assert_eq!(scheduled.len(), 2);
+    assert_eq!(scheduled[0].id, between_id);
+    assert_eq!(scheduled[1].id, first_id);
+    assert_eq!(scheduled[1].meta.scheduled_at, second_at.timestamp_micros());
+    assert_eq!(scheduled[1].job.args["value"], 2);
+
+    Ok(())
+}
+
 #[async_trait::async_trait]
 impl oxana::Worker<WorkerUniqueReplaceRetryJob> for WorkerUniqueReplaceRetry {
     type Error = WorkerError;


### PR DESCRIPTION
## Summary

- verify unique enqueue_at with Skip preserves the original schedule and payload
- verify unique enqueue_at with Replace uses the new schedule and payload
- assert sorted schedule ordering through the public Storage API

## Testing

- cargo fmt --all -- --check
- cargo clippy --all-features --workspace --all-targets -- -D warnings
- cargo test -p oxana

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no production code changes.
> 
> **Overview**
> Adds integration coverage for unique job conflicts on **scheduled** enqueue via `enqueue_at`.
> 
> **Skip** keeps the original `scheduled_at` and payload when a duplicate unique job is enqueued later. **Replace** updates both the schedule and payload, and schedule order is checked through `list_scheduled`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373df4da58ee8ac419854363ba1ae66708265b94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->