### PR TITLE
Preserve worker error backtraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Store worker errors using `Debug` formatting by default so captured backtraces appear on retry and dead jobs, and add `RuntimeBuilder::error_formatter` for applications that need a custom representation.
+
 ## [2.1.2] - 2026-08-11
 
 ### Added

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -219,8 +219,22 @@ Runtime configuration is done on the typed runtime builder, which allows you to:
 - Automatically register queues and workers via the component registry
 - Set up graceful shutdown
 - Configure exit conditions and runtime timing/backoff knobs
+- Customize how worker errors are stored on retry and dead jobs
 
 `Storage` remains the enqueueing and monitoring handle; `RuntimeBuilder<C>` is the worker setup and execution handle for app context type `C`.
+
+Worker errors use their `Debug` representation by default so error types that capture backtraces
+can include them in the dashboard. Applications can override the stored representation when needed:
+
+```rust
+let runtime = storage
+    .runtime(ctx)
+    .error_formatter(|error| error.to_string());
+```
+
+Backtraces must be enabled before the process starts (for example with `RUST_BACKTRACE=1`) and
+captured by the application's error type. Diagnostic output may contain sensitive details, so only
+enable backtraces where access to stored job errors is appropriately restricted.
 
 ### Error Handling
 

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -81,6 +81,15 @@ impl RuntimeSettings {
             .take()
             .unwrap_or_else(no_signal)
     }
+
+    pub(crate) fn format_error(
+        &self,
+        error: &(dyn std::error::Error + Send + Sync + 'static),
+    ) -> String {
+        self.error_formatter
+            .as_ref()
+            .map_or_else(|| format!("{error:?}"), |formatter| formatter(error))
+    }
 }
 
 impl Default for RuntimeSettings {

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -14,6 +14,8 @@ pub(crate) const DEFAULT_DEAD_PROCESS_THRESHOLD: Duration = Duration::from_secs(
 
 pub(crate) type RetryDelayOverrideFn =
     dyn Fn(&(dyn std::error::Error + Send + Sync + 'static), u32, u64) -> Option<u64> + Send + Sync;
+pub(crate) type ErrorFormatterFn =
+    dyn Fn(&(dyn std::error::Error + Send + Sync + 'static)) -> String + Send + Sync;
 
 type ShutdownSignal =
     Pin<Box<dyn Future<Output = Result<(), std::io::Error>> + Send + Sync + 'static>>;
@@ -24,6 +26,7 @@ pub(crate) struct RuntimeSettings {
     shutdown_signal: Arc<Mutex<Option<ShutdownSignal>>>,
     pub(crate) shutdown_timeout: Duration,
     pub(crate) retry_delay_override: Option<Arc<RetryDelayOverrideFn>>,
+    pub(crate) error_formatter: Option<Arc<ErrorFormatterFn>>,
     pub(crate) heartbeat_interval: Duration,
     pub(crate) dead_process_threshold: Duration,
     pub(crate) resurrect_scan_interval: Duration,
@@ -45,6 +48,7 @@ impl RuntimeSettings {
             shutdown_signal: Arc::new(Mutex::new(Some(Box::pin(default_shutdown_signal())))),
             shutdown_timeout: Duration::from_secs(180),
             retry_delay_override: None,
+            error_formatter: None,
             heartbeat_interval: Duration::from_millis(500),
             dead_process_threshold: DEFAULT_DEAD_PROCESS_THRESHOLD,
             resurrect_scan_interval: Duration::from_secs(2),

--- a/oxana/src/drainer.rs
+++ b/oxana/src/drainer.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, RuntimeSettings};
 use crate::context::ContextValue;
 use crate::error::OxanaError;
 use crate::job_state::JobState;
@@ -28,6 +28,7 @@ pub struct DrainStats {
 ///
 /// * `storage` - The job storage to drain from
 /// * `config` - The worker configuration, including queue and worker registrations
+/// * `settings` - Runtime settings, including worker error formatting
 /// * `ctx` - The context value that will be shared across all worker instances
 /// * `queue` - The queue to drain
 ///
@@ -37,6 +38,7 @@ pub struct DrainStats {
 pub async fn drain<DT>(
     storage: &Storage,
     config: &Config<DT>,
+    settings: &RuntimeSettings,
     ctx: ContextValue<DT>,
     queue: impl Queue,
 ) -> Result<DrainStats, OxanaError>
@@ -47,7 +49,7 @@ where
     let mut stats = DrainStats::default();
 
     while let Some(job_id) = storage.internal.dequeue(&queue_key).await? {
-        let result = process_job(storage, config, ctx.clone(), job_id).await?;
+        let result = process_job(storage, config, settings, ctx.clone(), job_id).await?;
         match result {
             ProcessJobResult::Success => stats.succeeded += 1,
             ProcessJobResult::Failed => stats.failed += 1,
@@ -62,6 +64,7 @@ where
 async fn process_job<DT>(
     storage: &Storage,
     config: &Config<DT>,
+    settings: &RuntimeSettings,
     ctx: ContextValue<DT>,
     job_id: JobId,
 ) -> Result<ProcessJobResult, OxanaError>
@@ -98,7 +101,10 @@ where
         Err(e) => {
             tracing::error!("Job failed: {}", e);
             storage.internal.finish_with_failure(&envelope).await?;
-            storage.internal.kill(&envelope, e.to_string()).await?;
+            storage
+                .internal
+                .kill(&envelope, settings.format_error(e.as_ref()))
+                .await?;
             Ok(ProcessJobResult::Failed)
         }
     }

--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -233,11 +233,7 @@ where
                 }
             }
 
-            let err_msg = config
-                .settings
-                .error_formatter
-                .as_ref()
-                .map_or_else(|| format!("{e:?}"), |formatter| formatter(e.as_ref()));
+            let err_msg = config.settings.format_error(e.as_ref());
             for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
                 handle_err(
                     config,

--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -233,7 +233,11 @@ where
                 }
             }
 
-            let err_msg = e.to_string();
+            let err_msg = config
+                .settings
+                .error_formatter
+                .as_ref()
+                .map_or_else(|| format!("{e:?}"), |formatter| formatter(e.as_ref()));
             for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
                 handle_err(
                     config,

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -315,7 +315,14 @@ where
 
     /// Drains a queue of jobs using this runtime's registrations.
     pub async fn drain(&self, queue: impl Queue) -> Result<DrainStats, OxanaError> {
-        drainer::drain(&self.storage, &self.config, self.ctx.clone(), queue).await
+        drainer::drain(
+            &self.storage,
+            &self.config,
+            &self.settings,
+            self.ctx.clone(),
+            queue,
+        )
+        .await
     }
 
     #[cfg(test)]

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 
-use crate::config::{Config, RetryDelayOverrideFn, RuntimeSettings};
+use crate::config::{Config, ErrorFormatterFn, RetryDelayOverrideFn, RuntimeSettings};
 use crate::context::ContextValue;
 use crate::drainer::{self, DrainStats};
 use crate::error::OxanaError;
@@ -144,6 +144,19 @@ where
         + 'static,
     ) -> Self {
         self.settings.retry_delay_override = Some(Arc::new(f) as Arc<RetryDelayOverrideFn>);
+        self
+    }
+
+    /// Sets a global formatter for worker errors before they are stored on retry or dead jobs.
+    ///
+    /// By default, errors use their [`std::fmt::Debug`] representation so error types that capture
+    /// backtraces can include them. The `'static` bound on
+    /// the error trait object allows `error.downcast_ref::<ConcreteError>()` inside the formatter.
+    pub fn error_formatter(
+        mut self,
+        f: impl Fn(&(dyn std::error::Error + Send + Sync + 'static)) -> String + Send + Sync + 'static,
+    ) -> Self {
+        self.settings.error_formatter = Some(Arc::new(f) as Arc<ErrorFormatterFn>);
         self
     }
 

--- a/oxana/tests/integration/dead.rs
+++ b/oxana/tests/integration/dead.rs
@@ -60,5 +60,46 @@ pub async fn test_dead() -> TestResult {
     assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
     assert_eq!(storage.jobs_count().await?, 0);
 
+    let dead = storage
+        .list_dead(&oxana::QueueListOpts {
+            count: 1,
+            offset: 0,
+        })
+        .await?;
+    assert_eq!(
+        dead[0].meta.error.as_deref(),
+        Some("Generic(\"I have nothing to live for...\")")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_dead_uses_custom_error_formatter() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let runtime = storage
+        .runtime(())
+        .queue::<QueueOne>()
+        .worker::<WorkerFail, WorkerFailJob>()
+        .error_formatter(|error| format!("diagnostic:\n{error:?}"))
+        .exit_when_processed(1);
+
+    storage.enqueue(QueueOne, WorkerFailJob {}).await?;
+    runtime.run().await?;
+
+    let dead = storage
+        .list_dead(&oxana::QueueListOpts {
+            count: 1,
+            offset: 0,
+        })
+        .await?;
+    assert_eq!(
+        dead[0].meta.error.as_deref(),
+        Some("diagnostic:\nGeneric(\"I have nothing to live for...\")")
+    );
+
     Ok(())
 }

--- a/oxana/tests/integration/drain.rs
+++ b/oxana/tests/integration/drain.rs
@@ -1,5 +1,5 @@
 use crate::shared::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use testresult::TestResult;
 
 #[derive(Serialize)]
@@ -24,6 +24,31 @@ impl oxana::Queue for QueueDynamic {
 impl oxana::Queue for QueueStatic {
     fn to_config() -> oxana::QueueConfig {
         oxana::QueueConfig::as_static("static")
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DrainFailJob;
+
+impl oxana::Job for DrainFailJob {}
+
+struct DrainFailWorker;
+
+impl oxana::FromContext<()> for DrainFailWorker {
+    fn from_context(_ctx: &()) -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl oxana::Worker<DrainFailJob> for DrainFailWorker {
+    type Error = WorkerError;
+
+    async fn run_batch(
+        &self,
+        _jobs: Vec<oxana::BatchItem<DrainFailJob>>,
+    ) -> Result<(), WorkerError> {
+        Err(WorkerError::Generic("drain failed".to_string()))
     }
 }
 
@@ -84,6 +109,37 @@ pub async fn test_drain() -> TestResult {
     assert_eq!(storage.enqueued_count(QueueDynamic(2)).await?, 0);
     assert_eq!(storage.enqueued_count(QueueDynamic(3)).await?, 0);
     assert_eq!(storage.enqueued_count(QueueStatic).await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_drain_uses_custom_error_formatter() -> TestResult {
+    let redis_pool = setup();
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let runtime = storage
+        .runtime(())
+        .queue::<QueueStatic>()
+        .worker::<DrainFailWorker, DrainFailJob>()
+        .error_formatter(|error| format!("diagnostic:\n{error:?}"));
+
+    storage.enqueue(QueueStatic, DrainFailJob).await?;
+
+    let stats = runtime.drain(QueueStatic).await?;
+    let dead = storage
+        .list_dead(&oxana::QueueListOpts {
+            count: 1,
+            offset: 0,
+        })
+        .await?;
+
+    assert_eq!(stats.failed, 1);
+    assert_eq!(
+        dead[0].meta.error.as_deref(),
+        Some("diagnostic:\nGeneric(\"drain failed\")")
+    );
 
     Ok(())
 }

--- a/oxana/tests/integration/retry.rs
+++ b/oxana/tests/integration/retry.rs
@@ -425,3 +425,39 @@ pub async fn test_retry_delay_override_receives_downcastable_error() -> TestResu
 
     Ok(())
 }
+
+#[tokio::test]
+pub async fn test_retry_uses_custom_error_formatter() -> TestResult {
+    let redis_pool = setup();
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool)?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .worker::<WorkerAlwaysFail, WorkerAlwaysFailJob>()
+        .retry_delay_override(|_error, _retries, _default_delay| Some(60))
+        .error_formatter(|error| format!("diagnostic:\n{error:?}"))
+        .dequeue_timeout(Duration::from_millis(50))
+        .exit_when_processed(1);
+
+    storage.enqueue(QueueOne, WorkerAlwaysFailJob {}).await?;
+    runtime.run().await?;
+
+    let retries = storage
+        .list_retries(&oxana::QueueListOpts {
+            count: 1,
+            offset: 0,
+        })
+        .await?;
+    assert_eq!(
+        retries[0].meta.error.as_deref(),
+        Some("diagnostic:\nGeneric(\"always fails\")")
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- store worker failures with Debug formatting by default so captured backtraces reach retry and dead-job metadata
- add a runtime error formatter override for applications that need a custom representation
- cover default and custom formatting in integration tests and document backtrace requirements

## Verification

- cargo fmt --all -- --check
- cargo clippy --all-features --workspace --all-targets -- -D warnings
- cargo test --workspace --all-features
- cargo check --all-features --workspace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stored error text changes from Display to Debug by default, which may alter dashboard copy but does not touch auth or persistence semantics; optional backtraces can expose sensitive stack data if enabled.
> 
> **Overview**
> Worker failures persisted on **retry** and **dead** jobs now use each error’s **`Debug`** string instead of **`Display`**, so types that embed backtraces (when enabled) surface that detail in stored metadata and the dashboard.
> 
> Adds **`RuntimeBuilder::error_formatter`** and **`RuntimeSettings::format_error`** so apps can override the stored text (e.g. back to `error.to_string()`). The **executor** and **queue drain** path both route failures through this helper; drain now takes runtime settings for formatting.
> 
> Changelog, README (backtrace env notes and sensitivity), and integration tests cover default `Debug` output and custom formatters on dead, retry, and drain flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa35fd45228e32fa3b8d8e88ddb332f540286f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->