### PR TITLE
chore: release oxana 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [2.1.3] - 2026-08-13
 
 ### Added
 
-- Store worker errors using `Debug` formatting by default so captured backtraces appear on retry and dead jobs, and add `RuntimeBuilder::error_formatter` for applications that need a custom representation.
+- Store worker errors using `Debug` formatting by default so captured backtraces appear on retry, dead, and drained jobs, and add `RuntimeBuilder::error_formatter` for applications that need a custom representation.
 
 ## [2.1.2] - 2026-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,7 +1051,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "darling",
  "heck",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.1.2", path = "oxana" }
-oxana-macros = { version = "=2.1.2", path = "oxana-macros" }
+oxana = { version = "2.1.3", path = "oxana" }
+oxana-macros = { version = "=2.1.3", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -35,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.1.2 --features registry
+cargo add oxana@2.1.3 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary

- bump all Oxana workspace crates to 2.1.3
- update workspace dependency constraints, lockfile, and README install command
- promote the worker error formatting changelog entry to the 2.1.3 release

## Verification

- cargo check --all
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation updates with no runtime or API code changes in this diff.
> 
> **Overview**
> **Release 2.1.3** — version-only change across the workspace (`oxana`, `oxana-macros`, `oxana-web`), root `Cargo.toml` dependency pins, `Cargo.lock`, and the README `cargo add` example.
> 
> The **2.1.3** changelog section documents worker error storage via default **`Debug`** formatting (backtraces on retry, dead, and **drained** jobs) and **`RuntimeBuilder::error_formatter`**; the wording now explicitly includes drained jobs versus the prior unreleased note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c026e3b544656c54c21673c464a010794d0862a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->