### PR TITLE
Add worker group filters

### DIFF
--- a/oxana-macros/src/lib.rs
+++ b/oxana-macros/src/lib.rs
@@ -2,11 +2,13 @@ mod job;
 mod queue;
 mod registry;
 mod worker;
+mod worker_group;
 
 use job::*;
 use queue::*;
 use registry::*;
 use worker::*;
+use worker_group::*;
 
 use proc_macro::TokenStream;
 use proc_macro_error2::proc_macro_error;
@@ -76,6 +78,17 @@ pub fn derive_worker(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     expand_derive_worker(input).into()
+}
+
+/// Generates an implementation of the `oxana::WorkerGroup` marker trait.
+///
+/// Worker groups must be unit structs.
+#[proc_macro_error]
+#[proc_macro_derive(WorkerGroup)]
+pub fn derive_worker_group(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    expand_derive_worker_group(input).into()
 }
 
 /// Helper to define a component registry.

--- a/oxana-macros/src/worker.rs
+++ b/oxana-macros/src/worker.rs
@@ -16,6 +16,8 @@ struct OxanaArgs {
     batch_size: Option<usize>,
     batch_timeout_ms: Option<u64>,
     cron: Option<Cron>,
+    #[darling(default, multiple)]
+    group: Vec<Path>,
 }
 
 #[derive(Debug)]
@@ -144,6 +146,7 @@ fn expand_worker_impl(
     };
 
     let batch_config = expand_batch_config(struct_ident, args);
+    let groups = &args.group;
     let process = if batch_config.is_some() {
         quote! {
             async fn process(&self, job: #type_args, ctx: &oxana::JobContext) -> Result<(), Self::Error> {
@@ -173,6 +176,10 @@ fn expand_worker_impl(
         #[async_trait::async_trait]
         impl oxana::Worker<#type_args> for #struct_ident {
             type Error = #type_error;
+
+            fn groups() -> Vec<std::any::TypeId> {
+                vec![#(oxana::worker_group_id::<#groups>()),*]
+            }
 
             #process
 

--- a/oxana-macros/src/worker_group.rs
+++ b/oxana-macros/src/worker_group.rs
@@ -1,0 +1,21 @@
+use proc_macro_error2::abort;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields};
+
+pub fn expand_derive_worker_group(input: DeriveInput) -> TokenStream {
+    let Data::Struct(data) = &input.data else {
+        abort!(input.ident, "WorkerGroup must be a unit struct.");
+    };
+
+    if !matches!(data.fields, Fields::Unit) {
+        abort!(input.ident, "WorkerGroup must be a unit struct.");
+    }
+
+    let ident = &input.ident;
+
+    quote! {
+        #[automatically_derived]
+        impl oxana::WorkerGroup for #ident {}
+    }
+}

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -140,6 +140,7 @@ Jobs carry the data that gets enqueued and define enqueue-time metadata. Workers
 | `#[oxana(resume = false)]` - reset prior-attempt job state on retry | `#[oxana(registry = MyRegistry)]` - choose component registry |
 | `#[oxana(throttle_cost = 2)]` - set per-job throttle cost | `#[oxana(max_retries = 3)]` - set maximum retry attempts |
 | `#[oxana(on_demand)]` - expose the job in the web dashboard for manual enqueueing | `#[oxana(retry_delay = 5)]` - set retry delay in seconds |
+|  | `#[oxana(group = MyGroup)]` - assign the worker to a typed worker group (repeatable) |
 |  | `#[oxana(cron(schedule = "*/5 * * * * *", queue = MyQueue))]` - schedule periodic jobs |
 |  | `#[oxana(batch_size = 100, batch_timeout_ms = 500)]` - process jobs in batches |
 
@@ -152,6 +153,42 @@ For job hooks, `Self::...` resolves to the job type. For worker hooks, `Self::..
 On-demand argument templates infer editable placeholders from field types. Numeric primitives and common numeric ID newtypes named `*Id` or `*ID` are prefilled with `0`.
 
 Batch workers use all-or-nothing result semantics: if `process_batch` returns `Ok(())`, every job in the batch is marked successful; if it returns an error or panics, every job in that batch follows the normal retry or failure path. Batch handlers should therefore be idempotent, or should only commit external side effects after the whole batch is ready to succeed.
+
+### Worker Groups
+
+Worker groups let different Oxana processes run selected subsets of the registered workers. Groups
+are typed unit structs, and a worker may belong to more than one group:
+
+```rust
+#[derive(oxana::WorkerGroup)]
+pub struct ProductionCron;
+
+#[derive(oxana::WorkerGroup)]
+pub struct ProductionOnly;
+
+#[derive(oxana::Worker)]
+#[oxana(group = ProductionCron)]
+#[oxana(group = ProductionOnly)]
+pub struct ReportWorker;
+```
+
+Apply group filters when building the runtime:
+
+```rust
+storage
+    .runtime(ctx)
+    .register::<ComponentRegistry>()
+    .only_groups((ProductionCron, ProductionOnly))
+    .exclude_groups(Maintenance)
+    .run()
+    .await?;
+```
+
+Repeated filter calls accumulate. An `only_groups` filter enables workers that belong to at least
+one included group and disables ungrouped workers. An `exclude_groups` filter disables workers that
+belong to any excluded group while leaving ungrouped workers enabled. If both filters are used, both
+conditions apply. Startup returns a configuration error if no workers remain enabled. Jobs for
+disabled workers must be routed to queues that this runtime does not poll.
 
 ### Queues
 

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -174,13 +174,23 @@ impl<DT> Config<DT> {
                 kind,
             },
             Some(worker_registry::cron_envelope_factory::<A>),
+            W::groups(),
         );
         self
     }
 
     /// Registers a worker from a [`WorkerConfig`].
     pub fn register_worker_with(&mut self, config: WorkerConfig<DT>) {
-        self.registry.register_worker_with(config, None);
+        self.registry.register_worker_with(config, None, Vec::new());
+    }
+
+    pub(crate) fn apply_group_filters(
+        &mut self,
+        only_groups: &HashSet<std::any::TypeId>,
+        excluded_groups: &HashSet<std::any::TypeId>,
+    ) {
+        self.registry
+            .apply_group_filters(only_groups, excluded_groups);
     }
 
     /// Returns a catalog of all registered workers.
@@ -295,6 +305,12 @@ mod tests {
 
     macro_rules! impl_test_worker {
         ($worker:ty, $job:ty) => {
+            impl_test_worker!(@impl $worker, $job, []);
+        };
+        ($worker:ty, $job:ty, $($group:ty),+ $(,)?) => {
+            impl_test_worker!(@impl $worker, $job, [$($group),+]);
+        };
+        (@impl $worker:ty, $job:ty, [$($group:ty),*]) => {
             impl oxana::FromContext<()> for $worker {
                 fn from_context(_ctx: &()) -> Self {
                     Self
@@ -305,6 +321,10 @@ mod tests {
             impl oxana::Worker<$job> for $worker {
                 type Error = WorkerError;
 
+                fn groups() -> Vec<std::any::TypeId> {
+                    vec![$(oxana::worker_group_id::<$group>()),*]
+                }
+
                 async fn run_batch(
                     &self,
                     _jobs: Vec<oxana::BatchItem<$job>>,
@@ -314,6 +334,12 @@ mod tests {
             }
         };
     }
+
+    struct GroupA;
+    impl oxana::WorkerGroup for GroupA {}
+
+    struct GroupB;
+    impl oxana::WorkerGroup for GroupB {}
 
     #[derive(Debug, Serialize, Deserialize)]
     struct PlainJob {
@@ -341,7 +367,7 @@ mod tests {
         }
     }
 
-    impl_test_worker!(ZetaWorker, ZetaJob);
+    impl_test_worker!(ZetaWorker, ZetaJob, GroupA);
 
     #[derive(Debug, Serialize, Deserialize)]
     struct AlphaJob {
@@ -378,7 +404,55 @@ mod tests {
         }
     }
 
-    impl_test_worker!(AlphaWorker, AlphaJob);
+    impl_test_worker!(AlphaWorker, AlphaJob, GroupA, GroupB);
+
+    fn grouped_config() -> Config<()> {
+        Config::<()>::new()
+            .register_worker::<PlainWorker, PlainJob>()
+            .register_worker::<ZetaWorker, ZetaJob>()
+            .register_worker::<AlphaWorker, AlphaJob>()
+    }
+
+    fn worker_names(config: &Config<()>) -> Vec<String> {
+        let mut names = config
+            .registry
+            .worker_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn group_filters_include_exclude_and_preserve_ungrouped_semantics() {
+        let group_a = HashSet::from([oxana::worker_group_id::<GroupA>()]);
+        let group_b = HashSet::from([oxana::worker_group_id::<GroupB>()]);
+        let no_groups = HashSet::new();
+
+        let mut only_a = grouped_config();
+        only_a.apply_group_filters(&group_a, &no_groups);
+        assert_eq!(
+            worker_names(&only_a),
+            vec![AlphaJob::name().to_string(), ZetaJob::name().to_string()]
+        );
+        let mut exclude_a = grouped_config();
+        exclude_a.apply_group_filters(&no_groups, &group_a);
+        assert_eq!(worker_names(&exclude_a), vec![PlainJob::name().to_string()]);
+
+        let mut only_a_or_b_excluding_b = grouped_config();
+        only_a_or_b_excluding_b.apply_group_filters(
+            &HashSet::from([
+                oxana::worker_group_id::<GroupA>(),
+                oxana::worker_group_id::<GroupB>(),
+            ]),
+            &group_b,
+        );
+        assert_eq!(
+            worker_names(&only_a_or_b_excluding_b),
+            vec![ZetaJob::name().to_string()]
+        );
+    }
 
     #[test]
     #[should_panic(expected = "manual cron worker registration is not supported")]

--- a/oxana/src/lib.rs
+++ b/oxana/src/lib.rs
@@ -99,6 +99,7 @@ mod storage_types;
 mod throttler;
 mod worker;
 mod worker_event;
+mod worker_group;
 mod worker_registry;
 
 #[cfg(feature = "registry")]
@@ -131,6 +132,7 @@ pub use crate::storage_types::*;
 pub use crate::worker::{
     BatchItem, BoxError, FromContext, IntoWorkerError, Job, Worker, WorkerBatchConfig,
 };
+pub use crate::worker_group::{WorkerGroup, WorkerGroups, worker_group_id};
 pub use crate::worker_registry::{
     OnDemandJobRegistration, WorkerConfig, WorkerConfigKind, job_batch_factory,
     job_envelope_factory, job_factory,
@@ -140,4 +142,4 @@ pub use crate::worker_registry::{
 pub use registry::*;
 
 #[cfg(feature = "macros")]
-pub use oxana_macros::{Job, Queue, Registry, Worker};
+pub use oxana_macros::{Job, Queue, Registry, Worker, WorkerGroup};

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,6 +15,7 @@ use crate::result_collector::Stats as RunStats;
 use crate::storage::Storage;
 use crate::storage_types::Catalog;
 use crate::worker::{FromContext, Job, Worker};
+use crate::worker_group::WorkerGroups;
 
 #[cfg(feature = "registry")]
 use crate::registry::RegisterComponents;
@@ -25,6 +28,8 @@ where
     config: Config<DT>,
     settings: RuntimeSettings,
     ctx: ContextValue<DT>,
+    only_groups: HashSet<TypeId>,
+    excluded_groups: HashSet<TypeId>,
 }
 
 impl<DT> RuntimeBuilder<DT>
@@ -37,6 +42,8 @@ where
             config: Config::new(),
             settings: RuntimeSettings::new(),
             ctx: ContextValue::new(ctx),
+            only_groups: HashSet::new(),
+            excluded_groups: HashSet::new(),
         }
     }
 
@@ -97,6 +104,28 @@ where
     /// Registers a worker from a [`crate::WorkerConfig`].
     pub fn worker_with(mut self, worker: crate::WorkerConfig<DT>) -> Self {
         self.config.register_worker_with(worker);
+        self
+    }
+
+    /// Runs only workers belonging to at least one of the supplied groups.
+    ///
+    /// Calls accumulate, and ungrouped workers are excluded when this filter is present.
+    pub fn only_groups<G>(mut self, groups: G) -> Self
+    where
+        G: WorkerGroups,
+    {
+        self.only_groups.extend(groups.group_ids());
+        self
+    }
+
+    /// Excludes workers belonging to any of the supplied groups.
+    ///
+    /// Calls accumulate, and ungrouped workers remain enabled.
+    pub fn exclude_groups<G>(mut self, groups: G) -> Self
+    where
+        G: WorkerGroups,
+    {
+        self.excluded_groups.extend(groups.group_ids());
         self
     }
 
@@ -300,7 +329,7 @@ where
     }
 
     /// Runs the Oxana worker system.
-    pub async fn run(self) -> Result<RunStats, OxanaError> {
+    pub async fn run(mut self) -> Result<RunStats, OxanaError> {
         if self.settings.dead_process_threshold <= self.settings.heartbeat_interval {
             tracing::warn!(
                 dead_process_threshold_ms = self.settings.dead_process_threshold.as_millis(),
@@ -309,6 +338,13 @@ where
                  live processes may be treated as dead and their in-flight jobs \
                  re-enqueued while still running"
             );
+        }
+        self.config
+            .apply_group_filters(&self.only_groups, &self.excluded_groups);
+        if self.config.registry.worker_names().is_empty() {
+            return Err(OxanaError::ConfigError(
+                "no workers are enabled for this runtime".to_string(),
+            ));
         }
         crate::launcher::run(self.storage, self.config, self.settings, self.ctx).await
     }

--- a/oxana/src/worker.rs
+++ b/oxana/src/worker.rs
@@ -1,3 +1,5 @@
+use std::any::TypeId;
+
 use crate::{
     QueueConfig, WorkerConfigKind, context::JobContext, job_envelope::JobConflictStrategy,
 };
@@ -77,6 +79,14 @@ pub struct BatchItem<Args> {
 #[async_trait::async_trait]
 pub trait Worker<Args: Send + 'static>: Send + Sync {
     type Error: IntoWorkerError + Send + Sync + 'static;
+
+    #[doc(hidden)]
+    fn groups() -> Vec<TypeId>
+    where
+        Self: Sized,
+    {
+        Vec::new()
+    }
 
     async fn process(&self, job: Args, ctx: &JobContext) -> Result<(), Self::Error> {
         self.run_batch(vec![BatchItem {
@@ -682,6 +692,41 @@ mod tests {
             batch_config.timeout(),
             std::time::Duration::from_millis(150)
         );
+    }
+
+    #[test]
+    fn worker_macro_supports_multiple_groups() {
+        #[derive(oxana::WorkerGroup)]
+        struct ProductionCron;
+
+        #[derive(oxana::WorkerGroup)]
+        struct ProductionOnly;
+
+        #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+        struct GroupedJob;
+
+        #[derive(oxana::Worker)]
+        #[oxana(group = ProductionCron)]
+        #[oxana(group = ProductionOnly)]
+        struct GroupedWorker;
+
+        impl GroupedWorker {
+            async fn process(
+                &self,
+                _job: GroupedJob,
+                _ctx: &oxana::JobContext,
+            ) -> Result<(), WorkerError> {
+                Ok(())
+            }
+        }
+
+        let groups = <GroupedWorker as oxana::Worker<GroupedJob>>::groups();
+        assert_eq!(groups.len(), 2);
+        assert!(groups.contains(&oxana::worker_group_id::<ProductionCron>()));
+        assert!(groups.contains(&oxana::worker_group_id::<ProductionOnly>()));
+
+        let filter_groups = oxana::WorkerGroups::group_ids((ProductionCron, ProductionOnly));
+        assert_eq!(filter_groups.len(), 2);
     }
 
     #[tokio::test]

--- a/oxana/src/worker_group.rs
+++ b/oxana/src/worker_group.rs
@@ -1,0 +1,52 @@
+use std::any::TypeId;
+
+/// Marker trait for a worker group.
+///
+/// Prefer deriving this trait with `#[derive(oxana::WorkerGroup)]`.
+pub trait WorkerGroup: 'static {}
+
+/// A worker group or tuple of worker groups accepted by runtime filters.
+pub trait WorkerGroups {
+    #[doc(hidden)]
+    fn group_ids(self) -> Vec<TypeId>;
+}
+
+impl<G> WorkerGroups for G
+where
+    G: WorkerGroup,
+{
+    fn group_ids(self) -> Vec<TypeId> {
+        vec![TypeId::of::<G>()]
+    }
+}
+
+macro_rules! impl_worker_groups_tuple {
+    ($($group:ident),+) => {
+        impl<$($group),+> WorkerGroups for ($($group,)+)
+        where
+            $($group: WorkerGroup),+
+        {
+            fn group_ids(self) -> Vec<TypeId> {
+                vec![$(TypeId::of::<$group>()),+]
+            }
+        }
+    };
+}
+
+impl_worker_groups_tuple!(A);
+impl_worker_groups_tuple!(A, B);
+impl_worker_groups_tuple!(A, B, C);
+impl_worker_groups_tuple!(A, B, C, D);
+impl_worker_groups_tuple!(A, B, C, D, E);
+impl_worker_groups_tuple!(A, B, C, D, E, F);
+impl_worker_groups_tuple!(A, B, C, D, E, F, G);
+impl_worker_groups_tuple!(A, B, C, D, E, F, G, H);
+impl_worker_groups_tuple!(A, B, C, D, E, F, G, H, I);
+impl_worker_groups_tuple!(A, B, C, D, E, F, G, H, I, J);
+impl_worker_groups_tuple!(A, B, C, D, E, F, G, H, I, J, K);
+impl_worker_groups_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
+
+#[doc(hidden)]
+pub fn worker_group_id<G: WorkerGroup>() -> TypeId {
+    TypeId::of::<G>()
+}

--- a/oxana/src/worker_registry.rs
+++ b/oxana/src/worker_registry.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::any::TypeId;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 
 use crate::WorkerBatchConfig;
@@ -34,6 +35,7 @@ pub struct WorkerRegistry<DT> {
     aliases: HashMap<String, String>,
     pub schedules: HashMap<String, CronJob>,
     pub on_demand_jobs: HashMap<String, OnDemandJobRegistration>,
+    disabled_workers: HashSet<String>,
 }
 
 pub struct WorkerConfig<DT> {
@@ -141,6 +143,7 @@ struct WorkerFactories<DT> {
     batch_factory: JobBatchFactory<DT>,
     batch_config: Option<WorkerBatchConfig>,
     cron_envelope_factory: Option<CronEnvelopeFactory>,
+    groups: Vec<TypeId>,
 }
 
 impl<DT> WorkerRegistry<DT> {
@@ -150,6 +153,7 @@ impl<DT> WorkerRegistry<DT> {
             aliases: HashMap::new(),
             schedules: HashMap::new(),
             on_demand_jobs: HashMap::new(),
+            disabled_workers: HashSet::new(),
         }
     }
 
@@ -157,6 +161,7 @@ impl<DT> WorkerRegistry<DT> {
         &mut self,
         config: WorkerConfig<DT>,
         cron_envelope_factory: Option<CronEnvelopeFactory>,
+        groups: Vec<TypeId>,
     ) {
         assert!(
             cron_envelope_factory.is_some()
@@ -170,6 +175,7 @@ impl<DT> WorkerRegistry<DT> {
             batch_factory: config.batch_factory,
             batch_config: config.batch_config,
             cron_envelope_factory,
+            groups,
         };
 
         if let Some(alias_target) = self.aliases.remove(&name) {
@@ -228,7 +234,46 @@ impl<DT> WorkerRegistry<DT> {
     }
 
     pub fn worker_names(&self) -> Vec<&str> {
-        self.jobs.keys().map(|s| s.as_str()).collect()
+        self.jobs
+            .keys()
+            .filter(|name| !self.disabled_workers.contains(*name))
+            .map(String::as_str)
+            .collect()
+    }
+
+    pub(crate) fn apply_group_filters(
+        &mut self,
+        only_groups: &HashSet<TypeId>,
+        excluded_groups: &HashSet<TypeId>,
+    ) {
+        self.disabled_workers = self
+            .jobs
+            .iter()
+            .filter_map(|(name, factories)| {
+                let included = only_groups.is_empty()
+                    || factories
+                        .groups
+                        .iter()
+                        .any(|group| only_groups.contains(group));
+                let excluded = factories
+                    .groups
+                    .iter()
+                    .any(|group| excluded_groups.contains(group));
+
+                (!included || excluded).then(|| name.clone())
+            })
+            .collect();
+
+        for (alias, target) in &self.aliases {
+            if self.disabled_workers.contains(target) {
+                self.disabled_workers.insert(alias.clone());
+            }
+        }
+
+        self.schedules
+            .retain(|name, _| !self.disabled_workers.contains(name));
+        self.on_demand_jobs
+            .retain(|name, _| !self.disabled_workers.contains(name));
     }
 
     pub(crate) fn batch_config(&self, name: &str) -> Option<WorkerBatchConfig> {
@@ -322,7 +367,11 @@ impl<DT> WorkerRegistry<DT> {
 
     fn factories_for(&self, name: &str) -> Option<&WorkerFactories<DT>> {
         let canonical_name = self.resolve_name(name);
-        self.jobs.get(canonical_name)
+        if self.disabled_workers.contains(name) || self.disabled_workers.contains(canonical_name) {
+            None
+        } else {
+            self.jobs.get(canonical_name)
+        }
     }
 
     fn resolve_name<'a>(&'a self, name: &'a str) -> &'a str {

--- a/oxana/tests/compile_fail.rs
+++ b/oxana/tests/compile_fail.rs
@@ -6,6 +6,7 @@ fn worker_macro_validation_errors() {
     t.compile_fail("tests/ui/batch_timeout_requires_size.rs");
     t.compile_fail("tests/ui/cron_replace_conflict.rs");
     t.compile_fail("tests/ui/static_queue_discovery_interval.rs");
+    t.compile_fail("tests/ui/worker_group_requires_unit_struct.rs");
 }
 
 #[test]

--- a/oxana/tests/ui/worker_group_requires_unit_struct.rs
+++ b/oxana/tests/ui/worker_group_requires_unit_struct.rs
@@ -1,0 +1,6 @@
+#[derive(oxana::WorkerGroup)]
+struct InvalidGroup {
+    name: String,
+}
+
+fn main() {}

--- a/oxana/tests/ui/worker_group_requires_unit_struct.stderr
+++ b/oxana/tests/ui/worker_group_requires_unit_struct.stderr
@@ -1,0 +1,5 @@
+error: WorkerGroup must be a unit struct.
+ --> tests/ui/worker_group_requires_unit_struct.rs:2:8
+  |
+2 | struct InvalidGroup {
+  |        ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- add typed `WorkerGroup` unit-struct derives and repeatable worker group annotations
- add accumulating runtime include/exclude group filters
- reject startup when filtering leaves no enabled workers
- document filtering semantics and add macro/configuration coverage

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace` (passes with the existing removed-lint warning for `clippy::from_iter_instead_of_collect`)
- targeted worker-group and compile-fail tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which workers a process registers and runs at startup; misconfigured filters can leave jobs unprocessed or fail startup, though the empty-worker guard limits silent no-op runtimes.
> 
> **Overview**
> Adds **typed worker groups** so different Oxana processes can run subsets of the same component registry. Groups are unit structs via `#[derive(oxana::WorkerGroup)]`; workers declare membership with repeatable `#[oxana(group = MyGroup)]`, and the `Worker` derive emits `groups()` from those attributes.
> 
> **Runtime filtering** is configured on `RuntimeBuilder` with accumulating `only_groups` and `exclude_groups` (single groups or tuples). Filters are applied at `run()`: `only_groups` keeps workers in at least one listed group and drops ungrouped workers; `exclude_groups` drops workers in any listed group and leaves ungrouped workers on. Combined filters apply both rules. Disabled workers are hidden from the registry (including legacy aliases, cron schedules, and on-demand entries), and startup fails with a config error if nothing remains enabled.
> 
> Docs, macro compile-fail validation (non–unit struct groups), and unit/macro tests cover the semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27524d77d84a838c27ef310033472d7961374ea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->