### PR TITLE
Allow selectively running specific queues

### DIFF
--- a/oxana/README.md
+++ b/oxana/README.md
@@ -221,6 +221,23 @@ Runtime configuration is done on the typed runtime builder, which allows you to:
 - Configure exit conditions and runtime timing/backoff knobs
 - Customize how worker errors are stored on retry and dead jobs
 
+To run only selected queues while keeping every queue and worker registered,
+call `only_queue` once for each queue to process:
+
+```rust
+let runtime = storage
+    .runtime(ctx)
+    .register::<Components>()
+    .only_queue::<PriorityQueue>()
+    .only_queue::<EmailQueue>();
+
+runtime.run().await?;
+```
+
+Selecting a dynamic queue processes all of its discovered subqueues. Cron jobs
+for unselected queues are not scheduled. Without any `only_queue` calls, all
+registered queues run as usual.
+
 `Storage` remains the enqueueing and monitoring handle; `RuntimeBuilder<C>` is the worker setup and execution handle for app context type `C`.
 
 Worker errors use their `Debug` representation by default so error types that capture backtraces

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -39,6 +39,7 @@ pub(crate) struct RuntimeSettings {
     pub(crate) dequeue_timeout: Duration,
     pub(crate) dispatcher_idle_sleep: Duration,
     pub(crate) throttled_queue_fallback_wait: Duration,
+    pub(crate) queue_allowlist: HashSet<QueueConfig>,
 }
 
 impl RuntimeSettings {
@@ -61,7 +62,20 @@ impl RuntimeSettings {
             dequeue_timeout: Duration::from_secs(10),
             dispatcher_idle_sleep: Duration::from_secs(1),
             throttled_queue_fallback_wait: Duration::from_millis(100),
+            queue_allowlist: HashSet::new(),
         }
+    }
+
+    pub(crate) fn runs_queue(&self, queue: &QueueConfig) -> bool {
+        self.queue_allowlist.is_empty() || self.queue_allowlist.contains(queue)
+    }
+
+    pub(crate) fn runs_static_queue(&self, queue_key: &str) -> bool {
+        self.queue_allowlist.is_empty()
+            || self
+                .queue_allowlist
+                .iter()
+                .any(|queue| queue.static_key().as_deref() == Some(queue_key))
     }
 
     pub(crate) fn replace_shutdown_signal(

--- a/oxana/src/launcher.rs
+++ b/oxana/src/launcher.rs
@@ -39,6 +39,9 @@ where
     joinset.spawn(cleanup_loop(Arc::clone(&runtime)));
 
     for queue_config in &runtime.queues {
+        if !runtime.settings.runs_queue(queue_config) {
+            continue;
+        }
         coordinator_joinset.spawn(coordinator::run(
             Arc::clone(&runtime),
             Arc::clone(&stats),
@@ -218,6 +221,9 @@ where
     let mut set = JoinSet::new();
 
     for (name, cron_job) in &runtime.registry.schedules {
+        if !runtime.settings.runs_static_queue(&cron_job.queue_key) {
+            continue;
+        }
         set.spawn(cron_job_loop(
             Arc::clone(&runtime),
             name.clone(),

--- a/oxana/src/lib.rs
+++ b/oxana/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::flat_map_option,
     clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
-    clippy::from_iter_instead_of_collect,
     clippy::if_let_mutex,
     clippy::implicit_clone,
     clippy::imprecise_flops,

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -8,7 +8,7 @@ use crate::config::{Config, ErrorFormatterFn, RetryDelayOverrideFn, RuntimeSetti
 use crate::context::ContextValue;
 use crate::drainer::{self, DrainStats};
 use crate::error::OxanaError;
-use crate::queue::{Queue, QueueConcurrency, require_non_zero_duration};
+use crate::queue::{Queue, QueueConcurrency, QueueConfig, require_non_zero_duration};
 use crate::result_collector::Stats as RunStats;
 use crate::storage::Storage;
 use crate::storage_types::Catalog;
@@ -82,6 +82,23 @@ where
         let mut config = Q::to_config();
         config.concurrency = QueueConcurrency::Fixed(concurrency);
         self.queue_with(config)
+    }
+
+    /// Restricts this runtime to processing the specified queue.
+    ///
+    /// This method can be called multiple times to allow multiple queues. If it
+    /// is never called, the runtime processes every registered queue. Selecting
+    /// a dynamic queue includes all of its discovered subqueues.
+    ///
+    /// The selected queue must also be registered before [`Self::run`] is
+    /// called, either explicitly or through a component registry or cron
+    /// worker.
+    pub fn only_queue<Q>(mut self) -> Self
+    where
+        Q: Queue,
+    {
+        self.settings.queue_allowlist.insert(Q::to_config());
+        self
     }
 
     /// Registers a worker for a job type.
@@ -301,6 +318,20 @@ where
 
     /// Runs the Oxana worker system.
     pub async fn run(self) -> Result<RunStats, OxanaError> {
+        let mut missing_queues: Vec<String> = self
+            .settings
+            .queue_allowlist
+            .difference(&self.config.queues)
+            .map(QueueConfig::key_or_prefix)
+            .collect();
+        if !missing_queues.is_empty() {
+            missing_queues.sort();
+            return Err(OxanaError::ConfigError(format!(
+                "Selected queues are not registered: {}",
+                missing_queues.join(", ")
+            )));
+        }
+
         if self.settings.dead_process_threshold <= self.settings.heartbeat_interval {
             tracing::warn!(
                 dead_process_threshold_ms = self.settings.dead_process_threshold.as_millis(),
@@ -354,5 +385,114 @@ impl<DT> Deref for Runtime<DT> {
 
     fn deref(&self) -> &Self::Target {
         &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::QueueKind;
+
+    struct QueueOne;
+
+    impl Queue for QueueOne {
+        fn to_config() -> QueueConfig {
+            QueueConfig::as_static("one")
+        }
+    }
+
+    struct QueueTwo;
+
+    impl Queue for QueueTwo {
+        fn to_config() -> QueueConfig {
+            QueueConfig::as_static("two")
+        }
+    }
+
+    struct DynamicQueue;
+
+    impl Queue for DynamicQueue {
+        fn to_config() -> QueueConfig {
+            QueueConfig::as_dynamic("dynamic")
+        }
+    }
+
+    fn test_storage() -> Storage {
+        Storage::builder()
+            .build_from_redis_url("redis://127.0.0.1/0")
+            .expect("test storage should build")
+    }
+
+    #[test]
+    fn only_queue_builds_an_allowlist_without_changing_the_catalog() {
+        let runtime = test_storage()
+            .runtime(())
+            .queue::<QueueOne>()
+            .queue::<QueueTwo>()
+            .queue::<DynamicQueue>()
+            .only_queue::<QueueOne>()
+            .only_queue::<DynamicQueue>();
+
+        assert!(runtime.settings.runs_queue(&QueueOne::to_config()));
+        assert!(!runtime.settings.runs_queue(&QueueTwo::to_config()));
+        assert!(runtime.settings.runs_queue(&DynamicQueue::to_config()));
+        assert!(runtime.settings.runs_static_queue("one"));
+        assert!(!runtime.settings.runs_static_queue("two"));
+
+        let catalog = runtime.catalog();
+        assert_eq!(catalog.queues.len(), 3);
+        assert!(catalog.queues.iter().any(|queue| queue.key == "one"));
+        assert!(catalog.queues.iter().any(|queue| queue.key == "two"));
+        assert!(
+            catalog
+                .queues
+                .iter()
+                .any(|queue| queue.key == "dynamic" && queue.dynamic)
+        );
+    }
+
+    #[test]
+    fn runtime_runs_all_queues_without_an_allowlist() {
+        let runtime = test_storage()
+            .runtime(())
+            .queue::<QueueOne>()
+            .queue::<DynamicQueue>();
+
+        assert!(runtime.settings.runs_queue(&QueueOne::to_config()));
+        assert!(runtime.settings.runs_queue(&DynamicQueue::to_config()));
+        assert!(runtime.settings.runs_static_queue("any-static-queue"));
+    }
+
+    #[tokio::test]
+    async fn run_rejects_an_unregistered_selected_queue() {
+        let result = test_storage()
+            .runtime(())
+            .only_queue::<QueueTwo>()
+            .run()
+            .await;
+
+        match result {
+            Err(OxanaError::ConfigError(message)) => {
+                assert_eq!(message, "Selected queues are not registered: two");
+            }
+            _ => panic!("expected an unregistered queue configuration error"),
+        }
+    }
+
+    #[test]
+    fn dynamic_queue_selection_matches_the_parent_configuration() {
+        let runtime = test_storage()
+            .runtime(())
+            .queue::<DynamicQueue>()
+            .only_queue::<DynamicQueue>();
+        let selected = runtime
+            .settings
+            .queue_allowlist
+            .iter()
+            .next()
+            .expect("dynamic queue should be selected");
+
+        assert!(matches!(selected.kind, QueueKind::Dynamic { .. }));
+        assert!(runtime.settings.runs_queue(&DynamicQueue::to_config()));
     }
 }

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -7,6 +7,15 @@ use testresult::TestResult;
 use tokio::sync::{Notify, oneshot};
 
 #[derive(serde::Serialize)]
+struct QueueTwo;
+
+impl oxana::Queue for QueueTwo {
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_static("two")
+    }
+}
+
+#[derive(serde::Serialize)]
 struct DynamicConcurrencyQueue;
 
 impl oxana::Queue for DynamicConcurrencyQueue {
@@ -135,6 +144,57 @@ pub async fn test_standard() -> TestResult {
     assert_eq!(value, Some(random_value));
     assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
     assert_eq!(storage.jobs_count().await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+pub async fn test_runtime_only_processes_selected_queues() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .queue::<QueueTwo>()
+        .worker::<WorkerRedisSet, WorkerRedisSetJob>()
+        .only_queue::<QueueOne>()
+        .exit_when_processed(1);
+    let selected_key = random_string();
+    let excluded_key = random_string();
+
+    storage
+        .enqueue(
+            QueueOne,
+            WorkerRedisSetJob {
+                key: selected_key.clone(),
+                value: "selected".to_string(),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            QueueTwo,
+            WorkerRedisSetJob {
+                key: excluded_key.clone(),
+                value: "excluded".to_string(),
+            },
+        )
+        .await?;
+
+    runtime.run().await?;
+
+    let selected: Option<String> = redis_conn.get(selected_key).await?;
+    let excluded: Option<String> = redis_conn.get(excluded_key).await?;
+    assert_eq!(selected.as_deref(), Some("selected"));
+    assert_eq!(excluded, None);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.enqueued_count(QueueTwo).await?, 1);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add a repeatable `RuntimeBuilder::only_queue::<Q>()` allowlist
- run coordinators and cron scheduling only for selected queues
- reject selected queues that were not registered
- document the API and cover default, static, and dynamic queue behavior

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace` (passes with one pre-existing removed-lint warning)
- `cargo test -p oxana runtime::tests`
- `cargo test -p oxana --test integration --no-run`
- `cargo check --all-features --workspace`

The Redis-backed integration test was compiled but not executed locally because `REDIS_URL` is not configured in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in runtime filtering with unchanged default behavior; misconfiguration is caught at startup when a selected queue is not registered.
> 
> **Overview**
> Adds **`RuntimeBuilder::only_queue::<Q>()`**, repeatable, so one worker process can register every queue and worker but only **run coordinators** (and related cron scheduling) for an allowlisted subset. With no `only_queue` calls, behavior is unchanged: all registered queues run.
> 
> **`RuntimeSettings`** stores a `queue_allowlist`; empty means “all queues.” **`runs_queue`** gates queue coordinators in the launcher; **`runs_static_queue`** skips cron loops whose target queue key is not selected. Selecting a dynamic queue is documented to include all discovered subqueues.
> 
> **`run()`** fails fast with **`ConfigError`** if any selected queue was never registered. Registration and **`catalog()`** still list every queue; only execution is filtered.
> 
> README documents the API; unit tests cover allowlist defaults, catalog unchanged, dynamic selection, and unregistered selection; an integration test asserts jobs on a non-selected queue stay enqueued.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb39b01c2456cf05a9754f014d3053ff62acfe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->