### PR TITLE
Enrich worker failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Store worker errors using `Debug` formatting by default so captured backtraces appear on retry, dead, and drained jobs, and add `RuntimeBuilder::error_formatter` for applications that need a custom representation.
+- Add `RuntimeBuilder::failure_reporter` with typed worker errors and execution metadata including serialized job arguments, enrich isolated default Sentry events, and suppress pre-catch panic-integration events so caught worker panics are reported once after reporter selection.
 
 ## [2.1.2] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Store worker errors using `Debug` formatting by default so captured backtraces appear on retry, dead, and drained jobs, and add `RuntimeBuilder::error_formatter` for applications that need a custom representation.
-- Add `RuntimeBuilder::failure_reporter` with typed worker errors and execution metadata including serialized job arguments, enrich isolated default Sentry events, and suppress pre-catch panic-integration events so caught worker panics are reported once after reporter selection.
+- Add `RuntimeBuilder::failure_reporter` with typed worker errors and execution metadata including serialized job arguments, enrich isolated default Sentry events, and defer panic-integration events until reporter selection while preserving their stacktraces.
 
 ## [2.1.2] - 2026-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +208,21 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -654,6 +684,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1089,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1121,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.10.2",
  "sentry-core",
+ "sentry-panic",
  "serde",
  "serde_json",
  "testresult",
@@ -1386,6 +1441,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1474,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
@@ -1446,15 +1519,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sentry-backtrace"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "448b0981fbde6cdc9eb087ba3dc01035a253fef9a0d9e79aaf198fc26acb2e64"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
 name = "sentry-core"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecf0b1a4a4e9ec88395b52e6fa4868b95564c1fa96b26a0606f5f6288a0f7149"
 dependencies = [
+ "rand 0.9.5",
  "sentry-types",
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7d93d6ecb55d2251c5fc084c55c03a2bc68904918d76117e602c999e92f00f"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -15,7 +15,7 @@ test = true
 
 [features]
 default = ["sentry", "tracing-instrument", "macros"]
-sentry = ["sentry-core"]
+sentry = ["sentry-core/client"]
 tracing-instrument = []
 macros = ["oxana-macros"]
 registry = ["inventory", "oxana-macros?/registry"]
@@ -45,6 +45,8 @@ oxana-macros = { workspace = true, optional = true }
 divan = "^0.1"
 dotenvy = "^0.15"
 rand = "^0.10"
+sentry-core = { version = "=0.48.5", features = ["test"] }
+sentry-panic = "=0.48.5"
 testresult = "^0.4"
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
 trybuild = "1.0"

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -271,9 +271,10 @@ let runtime = storage.runtime(ctx).failure_reporter(|report| {
 ```
 
 The callback is also available without the `sentry` feature. Sentry's panic integration runs before
-Oxana catches a worker panic, so Oxana suppresses that pre-catch event on the isolated worker hub and
-reports the caught panic once after selecting the default or custom reporter. This prevents both a
-duplicate event and argument capture before custom redaction can run.
+Oxana catches a worker panic, so Oxana intercepts its event on the isolated worker hub. The built-in
+reporter enriches and submits that event after the catch, preserving its stacktrace. A custom
+reporter replaces and discards the intercepted event. This prevents both a duplicate event and
+argument capture before custom redaction can run.
 
 Serialized job arguments are included in failure metadata and default Sentry events. Arguments can
 contain sensitive application data; custom reporters receive the metadata without Oxana attaching

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -249,6 +249,36 @@ let runtime = storage
     .error_formatter(|error| error.to_string());
 ```
 
+With the `sentry` feature enabled, failed executions are reported once by default with isolated
+`oxana.*` tags and an `oxana` context containing job IDs, queue/job/worker names, batch size, and
+per-job arguments and retry state. Applications that need an error-specific integration can replace
+the capture while retaining the original concrete worker error:
+
+```rust
+let runtime = storage.runtime(ctx).failure_reporter(|report| {
+    match report.failure {
+        oxana::WorkerFailure::Error(error) => {
+            // Downcast to your application's worker error and call a richer
+            // integration, such as sentry_anyhow::capture_anyhow(...).
+            report_application_error(error, report.metadata);
+        }
+        oxana::WorkerFailure::Panic { message } => {
+            report_application_panic(message, report.metadata);
+        }
+        _ => {}
+    }
+});
+```
+
+The callback is also available without the `sentry` feature. Sentry's panic integration runs before
+Oxana catches a worker panic, so Oxana suppresses that pre-catch event on the isolated worker hub and
+reports the caught panic once after selecting the default or custom reporter. This prevents both a
+duplicate event and argument capture before custom redaction can run.
+
+Serialized job arguments are included in failure metadata and default Sentry events. Arguments can
+contain sensitive application data; custom reporters receive the metadata without Oxana attaching
+it automatically, allowing them to redact or omit arguments before capture.
+
 Backtraces must be enabled before the process starts (for example with `RUST_BACKTRACE=1`) and
 captured by the application's error type. Diagnostic output may contain sensitive details, so only
 enable backtraces where access to stored job errors is appropriately restricted.

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -3,6 +3,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use crate::failure::{ExecutionSentryHub, FailureReporterFn, WorkerFailureReport, report_failure};
 use crate::queue::QueueConfig;
 use crate::storage_types::{
     Catalog, CronWorkerInfo, OnDemandJobInfo, QueueInfo, QueueThrottleInfo, WorkerInfo,
@@ -27,6 +28,7 @@ pub(crate) struct RuntimeSettings {
     pub(crate) shutdown_timeout: Duration,
     pub(crate) retry_delay_override: Option<Arc<RetryDelayOverrideFn>>,
     pub(crate) error_formatter: Option<Arc<ErrorFormatterFn>>,
+    pub(crate) failure_reporter: Option<Arc<FailureReporterFn>>,
     pub(crate) heartbeat_interval: Duration,
     pub(crate) dead_process_threshold: Duration,
     pub(crate) resurrect_scan_interval: Duration,
@@ -50,6 +52,7 @@ impl RuntimeSettings {
             shutdown_timeout: Duration::from_secs(180),
             retry_delay_override: None,
             error_formatter: None,
+            failure_reporter: None,
             heartbeat_interval: Duration::from_millis(500),
             dead_process_threshold: DEFAULT_DEAD_PROCESS_THRESHOLD,
             resurrect_scan_interval: Duration::from_secs(2),
@@ -103,6 +106,14 @@ impl RuntimeSettings {
         self.error_formatter
             .as_ref()
             .map_or_else(|| format!("{error:?}"), |formatter| formatter(error))
+    }
+
+    pub(crate) fn report_failure(
+        &self,
+        report: WorkerFailureReport<'_>,
+        execution_hub: &ExecutionSentryHub,
+    ) {
+        report_failure(self.failure_reporter.as_ref(), report, execution_hub);
     }
 }
 

--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -6,12 +6,20 @@ use crate::job_envelope::JobEnvelope;
 use crate::job_state::JobState;
 use crate::runtime::Runtime;
 use crate::worker::{BoxedProcessable, WorkerError};
-use crate::{JobContext, OxanaError};
+use crate::{
+    FailedJobMetadata, JobContext, OxanaError, WorkerFailure, WorkerFailureMetadata,
+    WorkerFailureReport,
+};
 
 #[derive(Debug)]
 enum ExecutionResult {
     NotPanic(Result<(), WorkerError>),
     Panic(String),
+}
+
+struct ProcessResult {
+    result: ExecutionResult,
+    sentry_hub: crate::failure::ExecutionSentryHub,
 }
 
 pub(crate) enum ExecutionError {
@@ -90,7 +98,6 @@ where
         job: worker.job_name(),
         worker: worker.worker_name(),
     };
-
     if envelopes.len() == 1 {
         tracing::info!(
             job_id = first_envelope.id,
@@ -112,11 +119,11 @@ where
     let start = std::time::Instant::now();
     let job_contexts = job_contexts(&config.storage, envelopes);
 
-    let result = run_process(worker, job_contexts, first_envelope).await;
+    let process_result = run_process(worker, job_contexts, first_envelope).await;
 
     let duration = start.elapsed();
     let duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
-    let is_err = !matches!(result, ExecutionResult::NotPanic(Ok(_)));
+    let is_err = !matches!(process_result.result, ExecutionResult::NotPanic(Ok(_)));
     if envelopes.len() == 1 {
         tracing::info!(
             job_id = first_envelope.id,
@@ -140,7 +147,8 @@ where
         );
     }
 
-    let result = finish_batch_result(config.as_ref(), result, envelopes, &policies, names).await;
+    let result =
+        finish_batch_result(config.as_ref(), process_result, envelopes, &policies, names).await;
     Ok(ExecutionOutcome {
         result,
         duration_ms,
@@ -167,14 +175,14 @@ async fn run_process(
     worker: BoxedProcessable,
     job_contexts: Vec<JobContext>,
     envelope: &JobEnvelope,
-) -> ExecutionResult {
-    match AssertUnwindSafe(process(worker, job_contexts, envelope))
-        .catch_unwind()
-        .await
-    {
+) -> ProcessResult {
+    let future = AssertUnwindSafe(process(worker, job_contexts, envelope)).catch_unwind();
+    let (result, sentry_hub) = crate::failure::with_execution_sentry_hub(future).await;
+    let result = match result {
         Ok(result) => ExecutionResult::NotPanic(result),
         Err(panic) => ExecutionResult::Panic(panic_message(panic)),
-    }
+    };
+    ProcessResult { result, sentry_hub }
 }
 
 fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
@@ -189,7 +197,7 @@ fn panic_message(panic: Box<dyn std::any::Any + Send>) -> String {
 
 async fn finish_batch_result<DT>(
     config: &Runtime<DT>,
-    result: ExecutionResult,
+    process_result: ProcessResult,
     envelopes: &[JobEnvelope],
     policies: &[JobExecutionPolicy],
     names: ExecutionNames,
@@ -197,6 +205,7 @@ async fn finish_batch_result<DT>(
 where
     DT: Send + Sync + Clone + 'static,
 {
+    let ProcessResult { result, sentry_hub } = process_result;
     match result {
         ExecutionResult::NotPanic(Ok(())) => {
             if let Err(e) = config
@@ -210,8 +219,14 @@ where
             Ok(())
         }
         ExecutionResult::NotPanic(Err(e)) => {
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_error(e.as_ref());
+            let failure_metadata = failure_metadata(envelopes, policies, names);
+            config.settings.report_failure(
+                WorkerFailureReport {
+                    failure: WorkerFailure::Error(e.as_ref()),
+                    metadata: &failure_metadata,
+                },
+                &sentry_hub,
+            );
 
             if let Some(envelope) = envelopes.first() {
                 if envelopes.len() == 1 {
@@ -248,8 +263,16 @@ where
             Err(ExecutionError::NotPanic)
         }
         ExecutionResult::Panic(panic_msg) => {
-            #[cfg(feature = "sentry")]
-            sentry_core::capture_message(&panic_msg, sentry_core::Level::Error);
+            let failure_metadata = failure_metadata(envelopes, policies, names);
+            config.settings.report_failure(
+                WorkerFailureReport {
+                    failure: WorkerFailure::Panic {
+                        message: &panic_msg,
+                    },
+                    metadata: &failure_metadata,
+                },
+                &sentry_hub,
+            );
 
             for (envelope, policy) in envelopes.iter().zip(policies.iter()) {
                 handle_err(
@@ -264,6 +287,38 @@ where
 
             Err(ExecutionError::Panic())
         }
+    }
+}
+
+fn failure_metadata(
+    envelopes: &[JobEnvelope],
+    policies: &[JobExecutionPolicy],
+    names: ExecutionNames,
+) -> WorkerFailureMetadata {
+    let jobs = envelopes
+        .iter()
+        .zip(policies)
+        .map(|(envelope, policy)| {
+            let will_retry = envelope.meta.retries < policy.max_retries;
+            FailedJobMetadata {
+                job_id: envelope.id.clone(),
+                args: envelope.job.args.clone(),
+                retry_count: envelope.meta.retries,
+                max_retries: policy.max_retries,
+                will_retry,
+            }
+        })
+        .collect::<Vec<_>>();
+    let will_retry = jobs.iter().any(|job| job.will_retry);
+
+    WorkerFailureMetadata {
+        jobs,
+        queue: envelopes
+            .first()
+            .map_or_else(String::new, |envelope| envelope.queue.clone()),
+        job_name: names.job.to_string(),
+        worker_name: names.worker.to_string(),
+        will_retry,
     }
 }
 

--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -306,12 +306,14 @@ fn failure_metadata(
                 retry_count: envelope.meta.retries,
                 max_retries: policy.max_retries,
                 will_retry,
+                terminal: !will_retry,
             }
         })
         .collect::<Vec<_>>();
     let will_retry = jobs.iter().any(|job| job.will_retry);
 
     WorkerFailureMetadata {
+        batch_size: jobs.len(),
         jobs,
         queue: envelopes
             .first()
@@ -319,6 +321,7 @@ fn failure_metadata(
         job_name: names.job.to_string(),
         worker_name: names.worker.to_string(),
         will_retry,
+        terminal: !will_retry,
     }
 }
 

--- a/oxana/src/failure.rs
+++ b/oxana/src/failure.rs
@@ -1,0 +1,669 @@
+use std::error::Error;
+use std::future::Future;
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::JobId;
+
+/// The cause of a failed worker execution.
+///
+/// Returned errors retain their original concrete type. A reporter can use
+/// [`Error::downcast_ref`] before passing the error to a type-specific
+/// integration such as `sentry-anyhow`.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum WorkerFailure<'a> {
+    /// The error returned by the worker.
+    Error(&'a (dyn Error + Send + Sync + 'static)),
+    /// A panic caught while polling the worker future.
+    Panic {
+        /// The string panic payload, or a fallback for non-string payloads.
+        message: &'a str,
+    },
+}
+
+impl WorkerFailure<'_> {
+    #[cfg(feature = "sentry")]
+    fn kind(self) -> &'static str {
+        match self {
+            Self::Error(_) => "error",
+            Self::Panic { .. } => "panic",
+        }
+    }
+}
+
+/// Retry metadata for one job in a failed worker execution.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct FailedJobMetadata {
+    /// The job ID.
+    pub job_id: JobId,
+    /// The job's serialized arguments.
+    pub args: serde_json::Value,
+    /// The number of retries already performed before this execution.
+    pub retry_count: u32,
+    /// The maximum number of retries allowed for this job.
+    pub max_retries: u32,
+    /// Whether this job will be retried after the failure.
+    pub will_retry: bool,
+}
+
+/// Execution metadata attached to a worker failure report.
+///
+/// Batch jobs retain their individual IDs, serialized arguments, and retry
+/// states in [`Self::jobs`]. Job arguments can contain sensitive application
+/// data; configure a custom reporter when they need to be filtered or omitted.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub struct WorkerFailureMetadata {
+    /// Metadata for every job affected by this execution failure.
+    pub jobs: Vec<FailedJobMetadata>,
+    /// The queue key from which the jobs were dequeued.
+    pub queue: String,
+    /// The registered job type name.
+    pub job_name: String,
+    /// The concrete worker type name.
+    pub worker_name: String,
+    /// Whether at least one affected job will be retried.
+    pub will_retry: bool,
+}
+
+/// A worker failure and its execution metadata.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub struct WorkerFailureReport<'a> {
+    /// The returned error or caught panic.
+    pub failure: WorkerFailure<'a>,
+    /// Job, worker, queue, batch, and retry metadata for the execution.
+    pub metadata: &'a WorkerFailureMetadata,
+}
+
+pub(crate) type FailureReporterFn = dyn for<'a> Fn(WorkerFailureReport<'a>) + Send + Sync + 'static;
+
+pub(crate) struct ExecutionSentryHub {
+    #[cfg(feature = "sentry")]
+    hub: Arc<sentry_core::Hub>,
+}
+
+pub(crate) fn execution_sentry_hub() -> ExecutionSentryHub {
+    #[cfg(feature = "sentry")]
+    {
+        let hub = Arc::new(sentry_core::Hub::new_from_top(sentry_core::Hub::current()));
+        hub.configure_scope(|scope| {
+            // Sentry's panic hook runs before Oxana's catch_unwind completes.
+            // Suppress events emitted during that unwind so the caught panic
+            // can be reported once, after custom reporter selection and with
+            // failure-only metadata applied.
+            scope.add_event_processor(|event| {
+                if std::thread::panicking() {
+                    None
+                } else {
+                    Some(event)
+                }
+            });
+        });
+        ExecutionSentryHub { hub }
+    }
+
+    #[cfg(not(feature = "sentry"))]
+    {
+        ExecutionSentryHub {}
+    }
+}
+
+pub(crate) fn report_failure(
+    reporter: Option<&Arc<FailureReporterFn>>,
+    report: WorkerFailureReport<'_>,
+    execution_hub: &ExecutionSentryHub,
+) {
+    if let Some(reporter) = reporter {
+        on_execution_sentry_hub(execution_hub, || reporter(report));
+        return;
+    }
+
+    #[cfg(feature = "sentry")]
+    default_sentry_report(report, execution_hub);
+}
+
+#[cfg(feature = "sentry")]
+fn on_execution_sentry_hub<R>(
+    execution_hub: &ExecutionSentryHub,
+    callback: impl FnOnce() -> R,
+) -> R {
+    sentry_core::Hub::run(Arc::clone(&execution_hub.hub), callback)
+}
+
+#[cfg(not(feature = "sentry"))]
+fn on_execution_sentry_hub<R>(
+    _execution_hub: &ExecutionSentryHub,
+    callback: impl FnOnce() -> R,
+) -> R {
+    callback()
+}
+
+pub(crate) async fn with_execution_sentry_hub<F>(future: F) -> (F::Output, ExecutionSentryHub)
+where
+    F: Future,
+{
+    let execution_hub = execution_sentry_hub();
+
+    #[cfg(feature = "sentry")]
+    {
+        use sentry_core::SentryFutureExt;
+
+        let output = future.bind_hub(Arc::clone(&execution_hub.hub)).await;
+        (output, execution_hub)
+    }
+
+    #[cfg(not(feature = "sentry"))]
+    {
+        (future.await, execution_hub)
+    }
+}
+
+#[cfg(feature = "sentry")]
+fn default_sentry_report(report: WorkerFailureReport<'_>, execution_hub: &ExecutionSentryHub) {
+    with_failure_sentry_scope(report, execution_hub, || match report.failure {
+        WorkerFailure::Error(error) => {
+            sentry_core::capture_error(error);
+        }
+        WorkerFailure::Panic { message } => {
+            use sentry_core::protocol::{Event, Exception, Mechanism};
+
+            sentry_core::capture_event(Event {
+                exception: vec![Exception {
+                    ty: "panic".to_string(),
+                    value: Some(message.to_string()),
+                    mechanism: Some(Mechanism {
+                        ty: "oxana.worker_panic".to_string(),
+                        handled: Some(true),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }]
+                .into(),
+                level: sentry_core::Level::Error,
+                ..Default::default()
+            });
+        }
+    });
+}
+
+#[cfg(feature = "sentry")]
+fn with_failure_sentry_scope<R>(
+    report: WorkerFailureReport<'_>,
+    execution_hub: &ExecutionSentryHub,
+    callback: impl FnOnce() -> R,
+) -> R {
+    sentry_core::Hub::run(Arc::clone(&execution_hub.hub), || {
+        sentry_core::with_scope(
+            |scope| {
+                configure_sentry_scope(scope, report.metadata);
+                scope.set_tag("oxana.failure_kind", report.failure.kind());
+            },
+            callback,
+        )
+    })
+}
+
+#[cfg(feature = "sentry")]
+fn configure_sentry_scope(scope: &mut sentry_core::Scope, metadata: &WorkerFailureMetadata) {
+    scope.set_tag("oxana.queue", &metadata.queue);
+    scope.set_tag("oxana.job", &metadata.job_name);
+    scope.set_tag("oxana.worker", &metadata.worker_name);
+    scope.set_tag("oxana.batch_size", metadata.jobs.len());
+    scope.set_tag("oxana.will_retry", metadata.will_retry);
+
+    if let [job] = metadata.jobs.as_slice() {
+        scope.set_tag("oxana.job_id", &job.job_id);
+        scope.set_tag("oxana.retry_count", job.retry_count);
+        scope.set_tag("oxana.max_retries", job.max_retries);
+    }
+
+    let context = serde_json::to_value(metadata)
+        .expect("worker failure metadata contains only serializable values");
+    let context = context
+        .as_object()
+        .expect("worker failure metadata serializes as an object")
+        .clone()
+        .into_iter()
+        .collect();
+    scope.set_context("oxana", sentry_core::protocol::Context::Other(context));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct ConcreteWorkerError;
+
+    impl std::fmt::Display for ConcreteWorkerError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("concrete worker error")
+        }
+    }
+
+    impl Error for ConcreteWorkerError {}
+
+    fn job(job_id: &str, retry_count: u32, max_retries: u32) -> FailedJobMetadata {
+        let will_retry = retry_count < max_retries;
+        FailedJobMetadata {
+            job_id: job_id.to_string(),
+            args: serde_json::json!({ "source": job_id }),
+            retry_count,
+            max_retries,
+            will_retry,
+        }
+    }
+
+    fn metadata(queue: &str, jobs: Vec<FailedJobMetadata>) -> WorkerFailureMetadata {
+        let will_retry = jobs.iter().any(|job| job.will_retry);
+        WorkerFailureMetadata {
+            jobs,
+            queue: queue.to_string(),
+            job_name: "test::EmailJob".to_string(),
+            worker_name: "test::EmailWorker".to_string(),
+            will_retry,
+        }
+    }
+
+    fn report_failure(reporter: Option<&Arc<FailureReporterFn>>, report: WorkerFailureReport<'_>) {
+        let execution_hub = execution_sentry_hub();
+        super::report_failure(reporter, report, &execution_hub);
+    }
+
+    #[test]
+    fn custom_reporter_replaces_default_and_receives_concrete_error() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let saw_concrete_error = Arc::new(AtomicBool::new(false));
+        let saw_arguments = Arc::new(AtomicBool::new(false));
+        let calls_for_reporter = Arc::clone(&calls);
+        let saw_for_reporter = Arc::clone(&saw_concrete_error);
+        let saw_arguments_for_reporter = Arc::clone(&saw_arguments);
+        let reporter: Arc<FailureReporterFn> = Arc::new(move |report| {
+            calls_for_reporter.fetch_add(1, Ordering::SeqCst);
+            saw_arguments_for_reporter.store(
+                report.metadata.jobs[0].args == serde_json::json!({ "source": "custom-id" }),
+                Ordering::SeqCst,
+            );
+            if let WorkerFailure::Error(error) = report.failure {
+                let saw_concrete = error.downcast_ref::<ConcreteWorkerError>().is_some();
+                saw_for_reporter.store(saw_concrete, Ordering::SeqCst);
+                #[cfg(feature = "sentry")]
+                if saw_concrete {
+                    sentry_core::capture_message("custom capture", sentry_core::Level::Warning);
+                }
+            }
+        });
+        let error = ConcreteWorkerError;
+        let metadata = metadata("custom", vec![job("custom-id", 0, 1)]);
+
+        #[cfg(feature = "sentry")]
+        let events = sentry_core::test::with_captured_events(|| {
+            report_failure(
+                Some(&reporter),
+                WorkerFailureReport {
+                    failure: WorkerFailure::Error(&error),
+                    metadata: &metadata,
+                },
+            );
+        });
+
+        #[cfg(not(feature = "sentry"))]
+        report_failure(
+            Some(&reporter),
+            WorkerFailureReport {
+                failure: WorkerFailure::Error(&error),
+                metadata: &metadata,
+            },
+        );
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(saw_concrete_error.load(Ordering::SeqCst));
+        assert!(saw_arguments.load(Ordering::SeqCst));
+        #[cfg(feature = "sentry")]
+        {
+            assert_eq!(events.len(), 1, "the default capture must be replaced");
+            assert_eq!(events[0].message.as_deref(), Some("custom capture"));
+            assert!(!events[0].tags.contains_key("oxana.job_id"));
+            assert!(!events[0].contexts.contains_key("oxana"));
+        }
+    }
+
+    #[cfg(feature = "sentry")]
+    fn oxana_context<'a>(
+        event: &'a sentry_core::protocol::Event<'_>,
+    ) -> &'a std::collections::BTreeMap<String, serde_json::Value> {
+        match event.contexts.get("oxana") {
+            Some(sentry_core::protocol::Context::Other(context)) => context,
+            context => panic!("expected Oxana context, got {context:?}"),
+        }
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn returned_error_creates_one_enriched_report() {
+        let error = ConcreteWorkerError;
+        let metadata = metadata("mailers", vec![job("job-123", 1, 3)]);
+        let events = sentry_core::test::with_captured_events(|| {
+            report_failure(
+                None,
+                WorkerFailureReport {
+                    failure: WorkerFailure::Error(&error),
+                    metadata: &metadata,
+                },
+            );
+        });
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(
+            event.tags.get("oxana.queue").map(String::as_str),
+            Some("mailers")
+        );
+        assert_eq!(
+            event.tags.get("oxana.job").map(String::as_str),
+            Some("test::EmailJob")
+        );
+        assert_eq!(
+            event.tags.get("oxana.worker").map(String::as_str),
+            Some("test::EmailWorker")
+        );
+        assert_eq!(
+            event.tags.get("oxana.job_id").map(String::as_str),
+            Some("job-123")
+        );
+        assert_eq!(
+            event.tags.get("oxana.retry_count").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            event.tags.get("oxana.max_retries").map(String::as_str),
+            Some("3")
+        );
+        assert_eq!(
+            event.tags.get("oxana.batch_size").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            event.tags.get("oxana.will_retry").map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            event.tags.get("oxana.failure_kind").map(String::as_str),
+            Some("error")
+        );
+
+        let context = oxana_context(event);
+        assert_eq!(context.get("queue"), Some(&serde_json::json!("mailers")));
+        assert_eq!(
+            context.get("jobs").and_then(serde_json::Value::as_array),
+            Some(&vec![serde_json::json!({
+                "job_id": "job-123",
+                "args": { "source": "job-123" },
+                "retry_count": 1,
+                "max_retries": 3,
+                "will_retry": true,
+            })])
+        );
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn final_report_reuses_worker_scope_without_exposing_args_to_worker_events() {
+        let error = ConcreteWorkerError;
+        let metadata = metadata("mailers", vec![job("job-123", 1, 3)]);
+        let events = sentry_core::test::with_captured_events(|| {
+            let ((), execution_hub) =
+                futures::executor::block_on(with_execution_sentry_hub(async {
+                    sentry_core::configure_scope(|scope| {
+                        scope.set_tag("worker.context", "preserved");
+                        scope.set_user(Some(sentry_core::User {
+                            id: Some("worker-user".to_string()),
+                            ..Default::default()
+                        }));
+                    });
+                    sentry_core::add_breadcrumb(sentry_core::Breadcrumb {
+                        message: Some("worker breadcrumb".to_string()),
+                        ..Default::default()
+                    });
+                    sentry_core::capture_message("worker diagnostic", sentry_core::Level::Info);
+                }));
+
+            super::report_failure(
+                None,
+                WorkerFailureReport {
+                    failure: WorkerFailure::Error(&error),
+                    metadata: &metadata,
+                },
+                &execution_hub,
+            );
+        });
+
+        assert_eq!(events.len(), 2);
+        let diagnostic = events
+            .iter()
+            .find(|event| event.message.as_deref() == Some("worker diagnostic"))
+            .expect("worker diagnostic event");
+        assert!(!diagnostic.contexts.contains_key("oxana"));
+        assert!(!diagnostic.tags.keys().any(|key| key.starts_with("oxana.")));
+
+        let failure = events
+            .iter()
+            .find(|event| !event.exception.is_empty())
+            .expect("worker failure event");
+        assert_eq!(failure.tags["worker.context"], "preserved");
+        assert_eq!(failure.tags["oxana.job_id"], "job-123");
+        assert_eq!(
+            failure.user.as_ref().and_then(|user| user.id.as_deref()),
+            Some("worker-user")
+        );
+        assert!(
+            failure
+                .breadcrumbs
+                .iter()
+                .any(|breadcrumb| { breadcrumb.message.as_deref() == Some("worker breadcrumb") })
+        );
+        assert_eq!(
+            oxana_context(failure)["jobs"][0]["args"]["source"],
+            "job-123"
+        );
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn batch_report_contains_per_job_retry_metadata() {
+        let error = ConcreteWorkerError;
+        let metadata = metadata("batch", vec![job("retrying", 0, 2), job("terminal", 2, 2)]);
+        let events = sentry_core::test::with_captured_events(|| {
+            report_failure(
+                None,
+                WorkerFailureReport {
+                    failure: WorkerFailure::Error(&error),
+                    metadata: &metadata,
+                },
+            );
+        });
+
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(
+            event.tags.get("oxana.batch_size").map(String::as_str),
+            Some("2")
+        );
+        assert!(!event.tags.contains_key("oxana.retry_count"));
+        assert!(!event.tags.contains_key("oxana.max_retries"));
+        assert_eq!(
+            event.tags.get("oxana.will_retry").map(String::as_str),
+            Some("true")
+        );
+        assert!(!event.tags.contains_key("oxana.job_id"));
+
+        let jobs = oxana_context(event)
+            .get("jobs")
+            .and_then(serde_json::Value::as_array)
+            .expect("batch jobs metadata");
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0]["job_id"], "retrying");
+        assert_eq!(jobs[0]["args"], serde_json::json!({ "source": "retrying" }));
+        assert_eq!(jobs[0]["will_retry"], true);
+        assert_eq!(jobs[1]["job_id"], "terminal");
+        assert_eq!(jobs[1]["args"], serde_json::json!({ "source": "terminal" }));
+        assert_eq!(jobs[1]["will_retry"], false);
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn retrying_and_non_retrying_executions_are_filterable() {
+        let error = ConcreteWorkerError;
+        let retrying = metadata("retrying", vec![job("retrying", 0, 1)]);
+        let terminal = metadata("terminal", vec![job("terminal", 1, 1)]);
+        let mut events = sentry_core::test::with_captured_events(|| {
+            for metadata in [&retrying, &terminal] {
+                report_failure(
+                    None,
+                    WorkerFailureReport {
+                        failure: WorkerFailure::Error(&error),
+                        metadata,
+                    },
+                );
+            }
+        });
+        events.sort_by(|left, right| left.tags["oxana.queue"].cmp(&right.tags["oxana.queue"]));
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].tags["oxana.queue"], "retrying");
+        assert_eq!(events[0].tags["oxana.will_retry"], "true");
+        assert_eq!(events[1].tags["oxana.queue"], "terminal");
+        assert_eq!(events[1].tags["oxana.will_retry"], "false");
+    }
+
+    #[cfg(feature = "sentry")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_reports_do_not_leak_scope_metadata() {
+        use sentry_core::SentryFutureExt;
+
+        let transport = sentry_core::test::TestTransport::new();
+        let options = sentry_core::ClientOptions::new()
+            .dsn("https://public@sentry.invalid/1")
+            .transport(Arc::clone(&transport));
+        let hub = Arc::new(sentry_core::Hub::new(
+            Some(Arc::new(options.into())),
+            Arc::new(Default::default()),
+        ));
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let spawn_report = |queue: &'static str, job_id: &'static str| {
+            let barrier = Arc::clone(&barrier);
+            let hub = Arc::clone(&hub);
+            tokio::spawn(
+                async move {
+                    let error = ConcreteWorkerError;
+                    let metadata = metadata(queue, vec![job(job_id, 0, 1)]);
+                    barrier.wait().await;
+                    report_failure(
+                        None,
+                        WorkerFailureReport {
+                            failure: WorkerFailure::Error(&error),
+                            metadata: &metadata,
+                        },
+                    );
+                }
+                .bind_hub(hub),
+            )
+        };
+
+        let first = spawn_report("queue-a", "job-a");
+        let second = spawn_report("queue-b", "job-b");
+        first.await.expect("first report task");
+        second.await.expect("second report task");
+
+        let mut events = transport.fetch_and_clear_events();
+        events.sort_by(|left, right| left.tags["oxana.queue"].cmp(&right.tags["oxana.queue"]));
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].tags["oxana.queue"], "queue-a");
+        assert_eq!(events[0].tags["oxana.job_id"], "job-a");
+        assert_eq!(oxana_context(&events[0])["queue"], "queue-a");
+        assert_eq!(events[1].tags["oxana.queue"], "queue-b");
+        assert_eq!(events[1].tags["oxana.job_id"], "job-b");
+        assert_eq!(oxana_context(&events[1])["queue"], "queue-b");
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn panic_integration_waits_for_custom_reporter_before_capture() {
+        use futures::FutureExt;
+        use std::panic::AssertUnwindSafe;
+
+        let metadata = metadata("panics", vec![job("panic-id", 0, 0)]);
+        let reporter: Arc<FailureReporterFn> = Arc::new(|report| {
+            assert!(matches!(report.failure, WorkerFailure::Panic { .. }));
+            assert_eq!(report.metadata.jobs[0].args["source"], "panic-id");
+            sentry_core::capture_message("redacted panic", sentry_core::Level::Error);
+        });
+        let options = sentry_core::ClientOptions::new()
+            .add_integration(sentry_panic::PanicIntegration::default());
+        let events = sentry_core::test::with_captured_events_options(
+            || {
+                let (result, execution_hub) =
+                    futures::executor::block_on(with_execution_sentry_hub(
+                        AssertUnwindSafe(async { panic!("worker panicked") }).catch_unwind(),
+                    ));
+                assert!(result.is_err());
+                super::report_failure(
+                    Some(&reporter),
+                    WorkerFailureReport {
+                        failure: WorkerFailure::Panic {
+                            message: "worker panicked",
+                        },
+                        metadata: &metadata,
+                    },
+                    &execution_hub,
+                );
+            },
+            options,
+        );
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].message.as_deref(), Some("redacted panic"));
+        assert!(events[0].exception.is_empty());
+        assert!(!events[0].contexts.contains_key("oxana"));
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn panic_without_panic_integration_is_reported_once_by_oxana() {
+        let metadata = metadata("panics", vec![job("panic-id", 0, 0)]);
+        let events = sentry_core::test::with_captured_events(|| {
+            report_failure(
+                None,
+                WorkerFailureReport {
+                    failure: WorkerFailure::Panic {
+                        message: "worker panicked",
+                    },
+                    metadata: &metadata,
+                },
+            );
+        });
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].message.is_none());
+        assert_eq!(events[0].exception[0].ty, "panic");
+        assert_eq!(
+            events[0].exception[0].value.as_deref(),
+            Some("worker panicked")
+        );
+        assert_eq!(
+            events[0].exception[0]
+                .mechanism
+                .as_ref()
+                .and_then(|mechanism| mechanism.handled),
+            Some(true)
+        );
+        assert_eq!(events[0].tags["oxana.failure_kind"], "panic");
+    }
+}

--- a/oxana/src/failure.rs
+++ b/oxana/src/failure.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
 use std::future::Future;
 use std::sync::Arc;
+#[cfg(feature = "sentry")]
+use std::sync::Mutex;
 
 use serde::Serialize;
 
@@ -47,6 +49,8 @@ pub struct FailedJobMetadata {
     pub max_retries: u32,
     /// Whether this job will be retried after the failure.
     pub will_retry: bool,
+    /// Whether this failure is terminal for this job.
+    pub terminal: bool,
 }
 
 /// Execution metadata attached to a worker failure report.
@@ -65,8 +69,12 @@ pub struct WorkerFailureMetadata {
     pub job_name: String,
     /// The concrete worker type name.
     pub worker_name: String,
+    /// The number of jobs processed by the failed execution.
+    pub batch_size: usize,
     /// Whether at least one affected job will be retried.
     pub will_retry: bool,
+    /// Whether the failure is terminal for every affected job.
+    pub terminal: bool,
 }
 
 /// A worker failure and its execution metadata.
@@ -84,31 +92,64 @@ pub(crate) type FailureReporterFn = dyn for<'a> Fn(WorkerFailureReport<'a>) + Se
 pub(crate) struct ExecutionSentryHub {
     #[cfg(feature = "sentry")]
     hub: Arc<sentry_core::Hub>,
+    #[cfg(feature = "sentry")]
+    panic_event: Arc<Mutex<Option<sentry_core::protocol::Event<'static>>>>,
 }
 
 pub(crate) fn execution_sentry_hub() -> ExecutionSentryHub {
     #[cfg(feature = "sentry")]
     {
         let hub = Arc::new(sentry_core::Hub::new_from_top(sentry_core::Hub::current()));
+        let panic_event = Arc::new(Mutex::new(None));
+        let panic_event_for_processor = Arc::clone(&panic_event);
         hub.configure_scope(|scope| {
             // Sentry's panic hook runs before Oxana's catch_unwind completes.
-            // Suppress events emitted during that unwind so the caught panic
-            // can be reported once, after custom reporter selection and with
-            // failure-only metadata applied.
-            scope.add_event_processor(|event| {
+            // Retain the first event emitted during that unwind. The panic
+            // integration runs before destructors, so this preserves its
+            // stacktrace while still delaying capture until after custom
+            // reporter selection.
+            scope.add_event_processor(move |event| {
                 if std::thread::panicking() {
+                    if is_panic_integration_event(&event) {
+                        let mut panic_event = panic_event_for_processor
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                        if panic_event.is_none() {
+                            *panic_event = Some(event);
+                        }
+                    }
                     None
                 } else {
                     Some(event)
                 }
             });
         });
-        ExecutionSentryHub { hub }
+        ExecutionSentryHub { hub, panic_event }
     }
 
     #[cfg(not(feature = "sentry"))]
     {
         ExecutionSentryHub {}
+    }
+}
+
+#[cfg(feature = "sentry")]
+fn is_panic_integration_event(event: &sentry_core::protocol::Event<'_>) -> bool {
+    event.exception.iter().any(|exception| {
+        exception
+            .mechanism
+            .as_ref()
+            .is_some_and(|mechanism| mechanism.ty == "panic")
+    })
+}
+
+#[cfg(feature = "sentry")]
+impl ExecutionSentryHub {
+    fn take_panic_event(&self) -> Option<sentry_core::protocol::Event<'static>> {
+        self.panic_event
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
     }
 }
 
@@ -164,29 +205,71 @@ where
 
 #[cfg(feature = "sentry")]
 fn default_sentry_report(report: WorkerFailureReport<'_>, execution_hub: &ExecutionSentryHub) {
-    with_failure_sentry_scope(report, execution_hub, || match report.failure {
-        WorkerFailure::Error(error) => {
+    match report.failure {
+        WorkerFailure::Error(error) => with_failure_sentry_scope(report, execution_hub, || {
             sentry_core::capture_error(error);
-        }
+        }),
         WorkerFailure::Panic { message } => {
-            use sentry_core::protocol::{Event, Exception, Mechanism};
-
-            sentry_core::capture_event(Event {
-                exception: vec![Exception {
-                    ty: "panic".to_string(),
-                    value: Some(message.to_string()),
-                    mechanism: Some(Mechanism {
-                        ty: "oxana.worker_panic".to_string(),
-                        handled: Some(true),
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                }]
-                .into(),
-                level: sentry_core::Level::Error,
-                ..Default::default()
-            });
+            let event = execution_hub
+                .take_panic_event()
+                .map_or_else(|| fallback_panic_event(message), mark_panic_event_handled);
+            capture_panic_event(report, execution_hub, event);
         }
+    }
+}
+
+#[cfg(feature = "sentry")]
+fn mark_panic_event_handled(
+    mut event: sentry_core::protocol::Event<'static>,
+) -> sentry_core::protocol::Event<'static> {
+    if let Some(exception) = event.exception.first_mut() {
+        let mechanism = exception
+            .mechanism
+            .get_or_insert_with(sentry_core::protocol::Mechanism::default);
+        mechanism.ty = "oxana.worker_panic".to_string();
+        mechanism.handled = Some(true);
+    }
+    event.level = sentry_core::Level::Error;
+    event
+}
+
+#[cfg(feature = "sentry")]
+fn fallback_panic_event(message: &str) -> sentry_core::protocol::Event<'static> {
+    use sentry_core::protocol::{Event, Exception, Mechanism};
+
+    Event {
+        exception: vec![Exception {
+            ty: "panic".to_string(),
+            value: Some(message.to_string()),
+            mechanism: Some(Mechanism {
+                ty: "oxana.worker_panic".to_string(),
+                handled: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]
+        .into(),
+        level: sentry_core::Level::Error,
+        ..Default::default()
+    }
+}
+
+#[cfg(feature = "sentry")]
+fn capture_panic_event(
+    report: WorkerFailureReport<'_>,
+    execution_hub: &ExecutionSentryHub,
+    event: sentry_core::protocol::Event<'static>,
+) {
+    // The retained event already contains the execution scope that Sentry
+    // applied before our processor intercepted it. Capture it through a fresh
+    // scope on the same client to avoid duplicating worker breadcrumbs while
+    // adding failure-only metadata.
+    let reporting_hub = Arc::new(sentry_core::Hub::new(
+        execution_hub.hub.client(),
+        Arc::new(sentry_core::Scope::default()),
+    ));
+    with_failure_sentry_scope_on_hub(report, reporting_hub, || {
+        sentry_core::capture_event(event);
     });
 }
 
@@ -196,7 +279,16 @@ fn with_failure_sentry_scope<R>(
     execution_hub: &ExecutionSentryHub,
     callback: impl FnOnce() -> R,
 ) -> R {
-    sentry_core::Hub::run(Arc::clone(&execution_hub.hub), || {
+    with_failure_sentry_scope_on_hub(report, Arc::clone(&execution_hub.hub), callback)
+}
+
+#[cfg(feature = "sentry")]
+fn with_failure_sentry_scope_on_hub<R>(
+    report: WorkerFailureReport<'_>,
+    hub: Arc<sentry_core::Hub>,
+    callback: impl FnOnce() -> R,
+) -> R {
+    sentry_core::Hub::run(hub, || {
         sentry_core::with_scope(
             |scope| {
                 configure_sentry_scope(scope, report.metadata);
@@ -212,8 +304,9 @@ fn configure_sentry_scope(scope: &mut sentry_core::Scope, metadata: &WorkerFailu
     scope.set_tag("oxana.queue", &metadata.queue);
     scope.set_tag("oxana.job", &metadata.job_name);
     scope.set_tag("oxana.worker", &metadata.worker_name);
-    scope.set_tag("oxana.batch_size", metadata.jobs.len());
+    scope.set_tag("oxana.batch_size", metadata.batch_size);
     scope.set_tag("oxana.will_retry", metadata.will_retry);
+    scope.set_tag("oxana.terminal", metadata.terminal);
 
     if let [job] = metadata.jobs.as_slice() {
         scope.set_tag("oxana.job_id", &job.job_id);
@@ -257,18 +350,29 @@ mod tests {
             retry_count,
             max_retries,
             will_retry,
+            terminal: !will_retry,
         }
     }
 
     fn metadata(queue: &str, jobs: Vec<FailedJobMetadata>) -> WorkerFailureMetadata {
         let will_retry = jobs.iter().any(|job| job.will_retry);
         WorkerFailureMetadata {
+            batch_size: jobs.len(),
             jobs,
             queue: queue.to_string(),
             job_name: "test::EmailJob".to_string(),
             worker_name: "test::EmailWorker".to_string(),
             will_retry,
+            terminal: !will_retry,
         }
+    }
+
+    fn item<T>(items: &[T], index: usize) -> &T {
+        items.get(index).expect("test item")
+    }
+
+    fn json_field<'a>(value: &'a serde_json::Value, key: &str) -> &'a serde_json::Value {
+        value.get(key).expect("JSON field")
     }
 
     fn report_failure(reporter: Option<&Arc<FailureReporterFn>>, report: WorkerFailureReport<'_>) {
@@ -286,8 +390,9 @@ mod tests {
         let saw_arguments_for_reporter = Arc::clone(&saw_arguments);
         let reporter: Arc<FailureReporterFn> = Arc::new(move |report| {
             calls_for_reporter.fetch_add(1, Ordering::SeqCst);
+            let reported_job = item(&report.metadata.jobs, 0);
             saw_arguments_for_reporter.store(
-                report.metadata.jobs[0].args == serde_json::json!({ "source": "custom-id" }),
+                reported_job.args == serde_json::json!({ "source": "custom-id" }),
                 Ordering::SeqCst,
             );
             if let WorkerFailure::Error(error) = report.failure {
@@ -328,9 +433,10 @@ mod tests {
         #[cfg(feature = "sentry")]
         {
             assert_eq!(events.len(), 1, "the default capture must be replaced");
-            assert_eq!(events[0].message.as_deref(), Some("custom capture"));
-            assert!(!events[0].tags.contains_key("oxana.job_id"));
-            assert!(!events[0].contexts.contains_key("oxana"));
+            let event = item(&events, 0);
+            assert_eq!(event.message.as_deref(), Some("custom capture"));
+            assert!(!event.tags.contains_key("oxana.job_id"));
+            assert!(!event.contexts.contains_key("oxana"));
         }
     }
 
@@ -342,6 +448,11 @@ mod tests {
             Some(sentry_core::protocol::Context::Other(context)) => context,
             context => panic!("expected Oxana context, got {context:?}"),
         }
+    }
+
+    #[cfg(feature = "sentry")]
+    fn tag<'a>(event: &'a sentry_core::protocol::Event<'_>, key: &str) -> &'a str {
+        event.tags.get(key).map(String::as_str).expect("event tag")
     }
 
     #[cfg(feature = "sentry")]
@@ -360,7 +471,7 @@ mod tests {
         });
 
         assert_eq!(events.len(), 1);
-        let event = &events[0];
+        let event = item(&events, 0);
         assert_eq!(
             event.tags.get("oxana.queue").map(String::as_str),
             Some("mailers")
@@ -408,6 +519,7 @@ mod tests {
                 "retry_count": 1,
                 "max_retries": 3,
                 "will_retry": true,
+                "terminal": false,
             })])
         );
     }
@@ -456,8 +568,8 @@ mod tests {
             .iter()
             .find(|event| !event.exception.is_empty())
             .expect("worker failure event");
-        assert_eq!(failure.tags["worker.context"], "preserved");
-        assert_eq!(failure.tags["oxana.job_id"], "job-123");
+        assert_eq!(tag(failure, "worker.context"), "preserved");
+        assert_eq!(tag(failure, "oxana.job_id"), "job-123");
         assert_eq!(
             failure.user.as_ref().and_then(|user| user.id.as_deref()),
             Some("worker-user")
@@ -468,10 +580,12 @@ mod tests {
                 .iter()
                 .any(|breadcrumb| { breadcrumb.message.as_deref() == Some("worker breadcrumb") })
         );
-        assert_eq!(
-            oxana_context(failure)["jobs"][0]["args"]["source"],
-            "job-123"
-        );
+        let jobs = oxana_context(failure)
+            .get("jobs")
+            .and_then(serde_json::Value::as_array)
+            .expect("failure jobs");
+        let args = json_field(item(jobs, 0), "args");
+        assert_eq!(json_field(args, "source"), "job-123");
     }
 
     #[cfg(feature = "sentry")]
@@ -490,7 +604,7 @@ mod tests {
         });
 
         assert_eq!(events.len(), 1);
-        let event = &events[0];
+        let event = item(&events, 0);
         assert_eq!(
             event.tags.get("oxana.batch_size").map(String::as_str),
             Some("2")
@@ -508,12 +622,22 @@ mod tests {
             .and_then(serde_json::Value::as_array)
             .expect("batch jobs metadata");
         assert_eq!(jobs.len(), 2);
-        assert_eq!(jobs[0]["job_id"], "retrying");
-        assert_eq!(jobs[0]["args"], serde_json::json!({ "source": "retrying" }));
-        assert_eq!(jobs[0]["will_retry"], true);
-        assert_eq!(jobs[1]["job_id"], "terminal");
-        assert_eq!(jobs[1]["args"], serde_json::json!({ "source": "terminal" }));
-        assert_eq!(jobs[1]["will_retry"], false);
+        let retrying_job = item(jobs, 0);
+        assert_eq!(json_field(retrying_job, "job_id"), "retrying");
+        assert_eq!(
+            json_field(retrying_job, "args"),
+            &serde_json::json!({ "source": "retrying" })
+        );
+        assert_eq!(json_field(retrying_job, "will_retry"), true);
+        assert_eq!(json_field(retrying_job, "terminal"), false);
+        let terminal_job = item(jobs, 1);
+        assert_eq!(json_field(terminal_job, "job_id"), "terminal");
+        assert_eq!(
+            json_field(terminal_job, "args"),
+            &serde_json::json!({ "source": "terminal" })
+        );
+        assert_eq!(json_field(terminal_job, "will_retry"), false);
+        assert_eq!(json_field(terminal_job, "terminal"), true);
     }
 
     #[cfg(feature = "sentry")]
@@ -533,13 +657,17 @@ mod tests {
                 );
             }
         });
-        events.sort_by(|left, right| left.tags["oxana.queue"].cmp(&right.tags["oxana.queue"]));
+        events.sort_by(|left, right| tag(left, "oxana.queue").cmp(tag(right, "oxana.queue")));
 
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].tags["oxana.queue"], "retrying");
-        assert_eq!(events[0].tags["oxana.will_retry"], "true");
-        assert_eq!(events[1].tags["oxana.queue"], "terminal");
-        assert_eq!(events[1].tags["oxana.will_retry"], "false");
+        let retrying_event = item(&events, 0);
+        assert_eq!(tag(retrying_event, "oxana.queue"), "retrying");
+        assert_eq!(tag(retrying_event, "oxana.will_retry"), "true");
+        assert_eq!(tag(retrying_event, "oxana.terminal"), "false");
+        let terminal_event = item(&events, 1);
+        assert_eq!(tag(terminal_event, "oxana.queue"), "terminal");
+        assert_eq!(tag(terminal_event, "oxana.will_retry"), "false");
+        assert_eq!(tag(terminal_event, "oxana.terminal"), "true");
     }
 
     #[cfg(feature = "sentry")]
@@ -583,14 +711,98 @@ mod tests {
         second.await.expect("second report task");
 
         let mut events = transport.fetch_and_clear_events();
-        events.sort_by(|left, right| left.tags["oxana.queue"].cmp(&right.tags["oxana.queue"]));
+        events.sort_by(|left, right| tag(left, "oxana.queue").cmp(tag(right, "oxana.queue")));
         assert_eq!(events.len(), 2);
-        assert_eq!(events[0].tags["oxana.queue"], "queue-a");
-        assert_eq!(events[0].tags["oxana.job_id"], "job-a");
-        assert_eq!(oxana_context(&events[0])["queue"], "queue-a");
-        assert_eq!(events[1].tags["oxana.queue"], "queue-b");
-        assert_eq!(events[1].tags["oxana.job_id"], "job-b");
-        assert_eq!(oxana_context(&events[1])["queue"], "queue-b");
+        let first_event = item(&events, 0);
+        assert_eq!(tag(first_event, "oxana.queue"), "queue-a");
+        assert_eq!(tag(first_event, "oxana.job_id"), "job-a");
+        assert_eq!(
+            oxana_context(first_event).get("queue"),
+            Some(&serde_json::json!("queue-a"))
+        );
+        let second_event = item(&events, 1);
+        assert_eq!(tag(second_event, "oxana.queue"), "queue-b");
+        assert_eq!(tag(second_event, "oxana.job_id"), "job-b");
+        assert_eq!(
+            oxana_context(second_event).get("queue"),
+            Some(&serde_json::json!("queue-b"))
+        );
+    }
+
+    #[cfg(feature = "sentry")]
+    #[test]
+    fn default_report_preserves_panic_integration_stacktrace() {
+        use futures::FutureExt;
+        use std::panic::AssertUnwindSafe;
+
+        let metadata = metadata("panics", vec![job("panic-id", 0, 0)]);
+        let options = sentry_core::ClientOptions::new()
+            .add_integration(sentry_panic::PanicIntegration::default());
+        let events = sentry_core::test::with_captured_events_options(
+            || {
+                let (result, execution_hub) =
+                    futures::executor::block_on(with_execution_sentry_hub(
+                        AssertUnwindSafe(async {
+                            sentry_core::configure_scope(|scope| {
+                                scope.set_tag("worker.context", "preserved");
+                            });
+                            sentry_core::add_breadcrumb(sentry_core::Breadcrumb {
+                                message: Some("before panic".to_string()),
+                                ..Default::default()
+                            });
+                            panic!("worker panicked");
+                        })
+                        .catch_unwind(),
+                    ));
+                assert!(result.is_err());
+                super::report_failure(
+                    None,
+                    WorkerFailureReport {
+                        failure: WorkerFailure::Panic {
+                            message: "worker panicked",
+                        },
+                        metadata: &metadata,
+                    },
+                    &execution_hub,
+                );
+            },
+            options,
+        );
+
+        assert_eq!(events.len(), 1);
+        let event = item(&events, 0);
+        let exception = item(event.exception.as_ref(), 0);
+        let stacktrace = exception
+            .stacktrace
+            .as_ref()
+            .expect("panic integration stacktrace");
+        assert!(!stacktrace.frames.is_empty());
+        assert_eq!(
+            exception
+                .mechanism
+                .as_ref()
+                .and_then(|mechanism| mechanism.handled),
+            Some(true)
+        );
+        assert_eq!(
+            exception
+                .mechanism
+                .as_ref()
+                .map(|mechanism| mechanism.ty.as_str()),
+            Some("oxana.worker_panic")
+        );
+        assert_eq!(tag(event, "worker.context"), "preserved");
+        assert_eq!(tag(event, "oxana.job_id"), "panic-id");
+        assert_eq!(tag(event, "oxana.terminal"), "true");
+        assert_eq!(
+            event
+                .breadcrumbs
+                .iter()
+                .filter(|breadcrumb| breadcrumb.message.as_deref() == Some("before panic"))
+                .count(),
+            1,
+            "worker breadcrumbs must not be duplicated when the event is recaptured"
+        );
     }
 
     #[cfg(feature = "sentry")]
@@ -602,7 +814,8 @@ mod tests {
         let metadata = metadata("panics", vec![job("panic-id", 0, 0)]);
         let reporter: Arc<FailureReporterFn> = Arc::new(|report| {
             assert!(matches!(report.failure, WorkerFailure::Panic { .. }));
-            assert_eq!(report.metadata.jobs[0].args["source"], "panic-id");
+            let reported_job = item(&report.metadata.jobs, 0);
+            assert_eq!(json_field(&reported_job.args, "source"), "panic-id");
             sentry_core::capture_message("redacted panic", sentry_core::Level::Error);
         });
         let options = sentry_core::ClientOptions::new()
@@ -629,9 +842,10 @@ mod tests {
         );
 
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].message.as_deref(), Some("redacted panic"));
-        assert!(events[0].exception.is_empty());
-        assert!(!events[0].contexts.contains_key("oxana"));
+        let event = item(&events, 0);
+        assert_eq!(event.message.as_deref(), Some("redacted panic"));
+        assert!(event.exception.is_empty());
+        assert!(!event.contexts.contains_key("oxana"));
     }
 
     #[cfg(feature = "sentry")]
@@ -651,19 +865,18 @@ mod tests {
         });
 
         assert_eq!(events.len(), 1);
-        assert!(events[0].message.is_none());
-        assert_eq!(events[0].exception[0].ty, "panic");
+        let event = item(&events, 0);
+        let exception = item(event.exception.as_ref(), 0);
+        assert!(event.message.is_none());
+        assert_eq!(exception.ty, "panic");
+        assert_eq!(exception.value.as_deref(), Some("worker panicked"));
         assert_eq!(
-            events[0].exception[0].value.as_deref(),
-            Some("worker panicked")
-        );
-        assert_eq!(
-            events[0].exception[0]
+            exception
                 .mechanism
                 .as_ref()
                 .and_then(|mechanism| mechanism.handled),
             Some(true)
         );
-        assert_eq!(events[0].tags["oxana.failure_kind"], "panic");
+        assert_eq!(tag(event, "oxana.failure_kind"), "panic");
     }
 }

--- a/oxana/src/lib.rs
+++ b/oxana/src/lib.rs
@@ -81,6 +81,7 @@ mod dispatcher;
 mod drainer;
 mod error;
 mod executor;
+mod failure;
 mod job_envelope;
 mod job_state;
 mod launcher;
@@ -112,6 +113,9 @@ mod test_helper;
 pub use crate::context::JobContext;
 pub use crate::drainer::DrainStats;
 pub use crate::error::OxanaError;
+pub use crate::failure::{
+    FailedJobMetadata, WorkerFailure, WorkerFailureMetadata, WorkerFailureReport,
+};
 pub use crate::job_envelope::{
     JobConflictStrategy, JobData, JobEnvelope, JobId, JobMeta, UniqueJobId,
 };

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -199,10 +199,11 @@ where
     /// available and runs without any Sentry dependency.
     ///
     /// Sentry's panic integration observes a panic before Oxana catches it.
-    /// Oxana suppresses that pre-catch event on the isolated worker hub, then
-    /// reports the caught panic once after selecting the default or custom
-    /// reporter. This prevents both duplicate events and argument capture
-    /// before a custom reporter can redact the metadata.
+    /// Oxana intercepts that event on the isolated worker hub. The built-in
+    /// reporter enriches and submits it after the panic is caught, preserving
+    /// its stacktrace. A custom reporter replaces and discards the intercepted
+    /// event. This prevents both duplicate events and argument capture before
+    /// a custom reporter can redact the metadata.
     pub fn failure_reporter(
         mut self,
         reporter: impl for<'a> Fn(WorkerFailureReport<'a>) + Send + Sync + 'static,

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -8,6 +8,7 @@ use crate::config::{Config, ErrorFormatterFn, RetryDelayOverrideFn, RuntimeSetti
 use crate::context::ContextValue;
 use crate::drainer::{self, DrainStats};
 use crate::error::OxanaError;
+use crate::failure::{FailureReporterFn, WorkerFailureReport};
 use crate::queue::{Queue, QueueConcurrency, QueueConfig, require_non_zero_duration};
 use crate::result_collector::Stats as RunStats;
 use crate::storage::Storage;
@@ -174,6 +175,39 @@ where
         f: impl Fn(&(dyn std::error::Error + Send + Sync + 'static)) -> String + Send + Sync + 'static,
     ) -> Self {
         self.settings.error_formatter = Some(Arc::new(f) as Arc<ErrorFormatterFn>);
+        self
+    }
+
+    /// Replaces Oxana's built-in worker failure reporting.
+    ///
+    /// The callback runs once per failed execution, including once for an
+    /// entire failed batch. Returned errors preserve their concrete type, so
+    /// callers can downcast them and use integrations such as `sentry-anyhow`
+    /// without Oxana depending on that error library. Panic failures are
+    /// represented by [`crate::WorkerFailure::Panic`].
+    ///
+    /// The supplied metadata includes each job's serialized arguments and
+    /// per-job retry state because jobs in one batch can have different retry
+    /// limits or attempt counts. Arguments can contain sensitive application
+    /// data; use the custom reporter to filter or omit them when necessary.
+    ///
+    /// When the `sentry` feature is enabled, the callback runs on the worker's
+    /// isolated execution hub, retaining breadcrumbs and scope changes made by
+    /// the worker. The metadata is passed explicitly instead of being attached
+    /// automatically, so the callback controls whether arguments are captured,
+    /// redacted, or omitted. Without the feature, the callback remains
+    /// available and runs without any Sentry dependency.
+    ///
+    /// Sentry's panic integration observes a panic before Oxana catches it.
+    /// Oxana suppresses that pre-catch event on the isolated worker hub, then
+    /// reports the caught panic once after selecting the default or custom
+    /// reporter. This prevents both duplicate events and argument capture
+    /// before a custom reporter can redact the metadata.
+    pub fn failure_reporter(
+        mut self,
+        reporter: impl for<'a> Fn(WorkerFailureReport<'a>) + Send + Sync + 'static,
+    ) -> Self {
+        self.settings.failure_reporter = Some(Arc::new(reporter) as Arc<FailureReporterFn>);
         self
     }
 


### PR DESCRIPTION
## Summary

- add a RuntimeBuilder failure-reporting hook that preserves concrete worker errors and exposes structured job, batch, retry, terminal, and argument metadata
- enrich default Sentry events on an isolated per-execution hub while preserving worker breadcrumbs and scope context
- defer panic-integration events until reporter selection, preserving the original panic stacktrace while still reporting exactly once
- build failure metadata only on failed executions and keep custom reporters in full control of argument redaction
- add focused coverage for returned errors, batches, retries, custom reporters, scope isolation, panic stacktraces, panic replacement, and builds without Sentry

## Testing

- cargo fmt --all -- --check
- cargo clippy --all-features --workspace --all-targets -- -D warnings
- cargo test
- cargo check --all
- cargo check -p oxana --no-default-features