### PR TITLE
Allow excluding specific runtime queues

### DIFF
--- a/oxana/README.md
+++ b/oxana/README.md
@@ -238,6 +238,22 @@ Selecting a dynamic queue processes all of its discovered subqueues. Cron jobs
 for unselected queues are not scheduled. Without any `only_queue` calls, all
 registered queues run as usual.
 
+To run every registered queue except specific ones, call `except_queue` once
+for each queue to exclude:
+
+```rust
+let runtime = storage
+    .runtime(ctx)
+    .register::<Components>()
+    .except_queue::<LowPriorityQueue>()
+    .except_queue::<MaintenanceQueue>();
+
+runtime.run().await?;
+```
+
+Excluding a dynamic queue excludes all of its discovered subqueues. Cron jobs
+for excluded queues are not scheduled.
+
 `Storage` remains the enqueueing and monitoring handle; `RuntimeBuilder<C>` is the worker setup and execution handle for app context type `C`.
 
 Worker errors use their `Debug` representation by default so error types that capture backtraces

--- a/oxana/src/config.rs
+++ b/oxana/src/config.rs
@@ -40,6 +40,7 @@ pub(crate) struct RuntimeSettings {
     pub(crate) dispatcher_idle_sleep: Duration,
     pub(crate) throttled_queue_fallback_wait: Duration,
     pub(crate) queue_allowlist: HashSet<QueueConfig>,
+    pub(crate) queue_denylist: HashSet<QueueConfig>,
 }
 
 impl RuntimeSettings {
@@ -63,17 +64,23 @@ impl RuntimeSettings {
             dispatcher_idle_sleep: Duration::from_secs(1),
             throttled_queue_fallback_wait: Duration::from_millis(100),
             queue_allowlist: HashSet::new(),
+            queue_denylist: HashSet::new(),
         }
     }
 
     pub(crate) fn runs_queue(&self, queue: &QueueConfig) -> bool {
-        self.queue_allowlist.is_empty() || self.queue_allowlist.contains(queue)
+        (self.queue_allowlist.is_empty() || self.queue_allowlist.contains(queue))
+            && !self.queue_denylist.contains(queue)
     }
 
     pub(crate) fn runs_static_queue(&self, queue_key: &str) -> bool {
-        self.queue_allowlist.is_empty()
+        (self.queue_allowlist.is_empty()
             || self
                 .queue_allowlist
+                .iter()
+                .any(|queue| queue.static_key().as_deref() == Some(queue_key)))
+            && !self
+                .queue_denylist
                 .iter()
                 .any(|queue| queue.static_key().as_deref() == Some(queue_key))
     }

--- a/oxana/src/runtime.rs
+++ b/oxana/src/runtime.rs
@@ -101,6 +101,23 @@ where
         self
     }
 
+    /// Excludes the specified queue from this runtime.
+    ///
+    /// This method can be called multiple times to exclude multiple queues.
+    /// Excluding a dynamic queue includes all of its discovered subqueues. Cron
+    /// jobs targeting excluded queues are not scheduled.
+    ///
+    /// The excluded queue must also be registered before [`Self::run`] is
+    /// called, either explicitly or through a component registry or cron
+    /// worker.
+    pub fn except_queue<Q>(mut self) -> Self
+    where
+        Q: Queue,
+    {
+        self.settings.queue_denylist.insert(Q::to_config());
+        self
+    }
+
     /// Registers a worker for a job type.
     pub fn worker<W, A>(mut self) -> Self
     where
@@ -332,6 +349,20 @@ where
             )));
         }
 
+        let mut missing_queues: Vec<String> = self
+            .settings
+            .queue_denylist
+            .difference(&self.config.queues)
+            .map(QueueConfig::key_or_prefix)
+            .collect();
+        if !missing_queues.is_empty() {
+            missing_queues.sort();
+            return Err(OxanaError::ConfigError(format!(
+                "Excluded queues are not registered: {}",
+                missing_queues.join(", ")
+            )));
+        }
+
         if self.settings.dead_process_threshold <= self.settings.heartbeat_interval {
             tracing::warn!(
                 dead_process_threshold_ms = self.settings.dead_process_threshold.as_millis(),
@@ -452,6 +483,34 @@ mod tests {
     }
 
     #[test]
+    fn except_queue_builds_a_denylist_without_changing_the_catalog() {
+        let runtime = test_storage()
+            .runtime(())
+            .queue::<QueueOne>()
+            .queue::<QueueTwo>()
+            .queue::<DynamicQueue>()
+            .except_queue::<QueueTwo>()
+            .except_queue::<DynamicQueue>();
+
+        assert!(runtime.settings.runs_queue(&QueueOne::to_config()));
+        assert!(!runtime.settings.runs_queue(&QueueTwo::to_config()));
+        assert!(!runtime.settings.runs_queue(&DynamicQueue::to_config()));
+        assert!(runtime.settings.runs_static_queue("one"));
+        assert!(!runtime.settings.runs_static_queue("two"));
+
+        let catalog = runtime.catalog();
+        assert_eq!(catalog.queues.len(), 3);
+        assert!(catalog.queues.iter().any(|queue| queue.key == "one"));
+        assert!(catalog.queues.iter().any(|queue| queue.key == "two"));
+        assert!(
+            catalog
+                .queues
+                .iter()
+                .any(|queue| queue.key == "dynamic" && queue.dynamic)
+        );
+    }
+
+    #[test]
     fn runtime_runs_all_queues_without_an_allowlist() {
         let runtime = test_storage()
             .runtime(())
@@ -479,6 +538,22 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn run_rejects_an_unregistered_excluded_queue() {
+        let result = test_storage()
+            .runtime(())
+            .except_queue::<QueueTwo>()
+            .run()
+            .await;
+
+        match result {
+            Err(OxanaError::ConfigError(message)) => {
+                assert_eq!(message, "Excluded queues are not registered: two");
+            }
+            _ => panic!("expected an unregistered queue configuration error"),
+        }
+    }
+
     #[test]
     fn dynamic_queue_selection_matches_the_parent_configuration() {
         let runtime = test_storage()
@@ -494,5 +569,22 @@ mod tests {
 
         assert!(matches!(selected.kind, QueueKind::Dynamic { .. }));
         assert!(runtime.settings.runs_queue(&DynamicQueue::to_config()));
+    }
+
+    #[test]
+    fn dynamic_queue_exclusion_matches_the_parent_configuration() {
+        let runtime = test_storage()
+            .runtime(())
+            .queue::<DynamicQueue>()
+            .except_queue::<DynamicQueue>();
+        let excluded = runtime
+            .settings
+            .queue_denylist
+            .iter()
+            .next()
+            .expect("dynamic queue should be excluded");
+
+        assert!(matches!(excluded.kind, QueueKind::Dynamic { .. }));
+        assert!(!runtime.settings.runs_queue(&DynamicQueue::to_config()));
     }
 }

--- a/oxana/tests/integration/standard.rs
+++ b/oxana/tests/integration/standard.rs
@@ -200,6 +200,57 @@ pub async fn test_runtime_only_processes_selected_queues() -> TestResult {
 }
 
 #[tokio::test]
+pub async fn test_runtime_does_not_process_excluded_queues() -> TestResult {
+    let redis_pool = setup();
+    let mut redis_conn = redis_pool.get().await?;
+    let ctx = WorkerState {
+        redis: redis_pool.clone(),
+    };
+    let storage = oxana::Storage::builder()
+        .namespace(random_string())
+        .build_from_pool(redis_pool.clone())?;
+    let runtime = storage
+        .runtime(ctx)
+        .queue::<QueueOne>()
+        .queue::<QueueTwo>()
+        .worker::<WorkerRedisSet, WorkerRedisSetJob>()
+        .except_queue::<QueueTwo>()
+        .exit_when_processed(1);
+    let included_key = random_string();
+    let excluded_key = random_string();
+
+    storage
+        .enqueue(
+            QueueOne,
+            WorkerRedisSetJob {
+                key: included_key.clone(),
+                value: "included".to_string(),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            QueueTwo,
+            WorkerRedisSetJob {
+                key: excluded_key.clone(),
+                value: "excluded".to_string(),
+            },
+        )
+        .await?;
+
+    runtime.run().await?;
+
+    let included: Option<String> = redis_conn.get(included_key).await?;
+    let excluded: Option<String> = redis_conn.get(excluded_key).await?;
+    assert_eq!(included.as_deref(), Some("included"));
+    assert_eq!(excluded, None);
+    assert_eq!(storage.enqueued_count(QueueOne).await?, 0);
+    assert_eq!(storage.enqueued_count(QueueTwo).await?, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
 pub async fn test_enqueue_list() -> TestResult {
     let redis_pool = setup();
     let mut redis_conn = redis_pool.get().await?;


### PR DESCRIPTION
## Summary

- add a repeatable `RuntimeBuilder::except_queue::<Q>()` denylist
- skip excluded queue coordinators and cron scheduling
- reject excluded queues that were not registered
- support dynamic parent queue exclusions and document the API

When combined with `only_queue`, the allowlist selects queues first and the denylist removes excluded matches.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace`
- `cargo test -p oxana runtime::tests`
- `cargo test -p oxana --test integration --no-run`

The Redis-backed integration test was compiled but not executed locally because `REDIS_URL` is not configured in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive runtime configuration with validation and tests; behavior for callers not using except_queue is unchanged aside from the static-queue allowlist check fix in runs_static_queue.
> 
> **Overview**
> Adds **`RuntimeBuilder::except_queue::<Q>()`** so workers can run all registered queues except named ones, mirroring the existing **`only_queue`** allowlist.
> 
> Runtime settings gain a **`queue_denylist`**; **`runs_queue`** and **`runs_static_queue`** now require a queue to pass the allowlist (if any) and not appear on the denylist. Excluding a dynamic parent queue skips its subqueues; existing launcher checks skip coordinators and cron scheduling for excluded queues. **`run`** fails fast with a config error if an excluded queue was never registered.
> 
> README documents the API and behavior alongside **`only_queue`**. Unit and Redis integration tests cover denylist building, dynamic exclusions, validation, and end-to-end job processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f2230db4f6b2e55959739a47f9544eb391eb01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->