### PR TITLE
chore: release oxana 2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.4] - 2026-08-31
+
+### Added
+
+- Add `RuntimeBuilder::only_queue` and `RuntimeBuilder::except_queue` for selecting which registered queues a runtime processes, including dynamic subqueues and cron jobs.
+- Add `RuntimeBuilder::failure_reporter` with typed worker errors and execution metadata including serialized job arguments, and enrich isolated default Sentry events.
+
+### Fixed
+
+- Preserve worker panic stacktraces when using Sentry's panic integration while deferring events until reporter selection.
+
 ## [2.1.3] - 2026-08-13
 
 ### Added
 
 - Store worker errors using `Debug` formatting by default so captured backtraces appear on retry, dead, and drained jobs, and add `RuntimeBuilder::error_formatter` for applications that need a custom representation.
-- Add `RuntimeBuilder::failure_reporter` with typed worker errors and execution metadata including serialized job arguments, enrich isolated default Sentry events, and defer panic-integration events until reporter selection while preserving their stacktraces.
 
 ## [2.1.2] - 2026-08-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "darling",
  "heck",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.1.3", path = "oxana" }
-oxana-macros = { version = "=2.1.3", path = "oxana-macros" }
+oxana = { version = "2.1.4", path = "oxana" }
+oxana-macros = { version = "=2.1.4", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -35,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.1.3 --features registry
+cargo add oxana@2.1.4 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
## Summary

- document runtime queue selection and worker failure reporting changes
- bump the Oxana workspace crates to 2.1.4
- update the lockfile and README installation example

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-features --workspace
- cargo check --all --locked

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application or library code changes in the diff—only version bumps, lockfile, changelog, and README install example.
> 
> **Overview**
> **Release 2.1.4** for the workspace (`oxana`, `oxana-macros`, `oxana-web`): versions, `Cargo.lock`, and the README `cargo add` pin move from **2.1.3** to **2.1.4**.
> 
> The new **CHANGELOG** entry documents what ships in this release: **`RuntimeBuilder::only_queue`** / **`except_queue`** for allow/deny queue processing (including dynamic subqueues and cron scheduling behavior), **`RuntimeBuilder::failure_reporter`** with typed failures and execution metadata (including serialized job args) plus richer default Sentry reporting, and a fix to **keep panic stacktraces** when Sentry’s panic integration is used while events are deferred for reporter selection. The 2.1.3 note is trimmed so failure-reporting details live under 2.1.4 instead of being duplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 925d058e4442a245380a80bd29069ac8158eb9ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->