### PR TITLE
refactor(web): share charts, pagination, and progress views

### DIFF
--- a/oxana-web/src/filters.rs
+++ b/oxana-web/src/filters.rs
@@ -235,16 +235,49 @@ fn progress_parts(val: &serde_json::Value) -> Option<oxana::JobProgress> {
     serde_json::from_value(val.clone()).ok()
 }
 
-fn should_show_progress(val: &serde_json::Value) -> bool {
-    progress_parts(val).is_some_and(|progress| progress.total > 0)
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ProgressView {
+    pub summary: String,
+    pub percent: String,
+    pub note: String,
+    pub eta: String,
+}
+
+impl ProgressView {
+    fn from_state(
+        state: &serde_json::Value,
+        started_at_micros: Option<i64>,
+        now_micros: i64,
+    ) -> Option<Self> {
+        let progress = progress_parts(state)?;
+        if progress.total <= 0 {
+            return None;
+        }
+
+        let percent =
+            ((progress.cursor.max(0) as f64 / progress.total as f64) * 100.0).clamp(0.0, 100.0);
+        let eta = progress_eta_s(&progress, started_at_micros, now_micros)
+            .map(format_duration_from_secs)
+            .unwrap_or_else(|| "—".to_string());
+
+        Some(Self {
+            summary: format!(
+                "{} / {} ({percent:.0}%)",
+                format_with_commas(progress.cursor.max(0) as u64),
+                format_with_commas(progress.total as u64),
+            ),
+            percent: format!("{percent:.0}"),
+            note: progress.note.unwrap_or_default(),
+            eta,
+        })
+    }
 }
 
 fn progress_eta_s(
-    val: &serde_json::Value,
+    progress: &oxana::JobProgress,
     started_at_micros: Option<i64>,
     now_micros: i64,
 ) -> Option<f64> {
-    let progress = progress_parts(val)?;
     let started_at_micros = started_at_micros?;
     if progress.total <= 0 || progress.cursor <= 0 || started_at_micros <= 0 {
         return None;
@@ -265,89 +298,66 @@ fn progress_eta_s(
 }
 
 #[askama::filter_fn]
-pub fn show_job_progress(
-    val: &serde_json::Value,
-    _env: &dyn askama::Values,
-) -> askama::Result<bool> {
-    Ok(should_show_progress(val))
-}
-
-#[askama::filter_fn]
-pub fn job_progress_percent(
-    val: &serde_json::Value,
-    _env: &dyn askama::Values,
-) -> askama::Result<String> {
-    let Some(progress) = progress_parts(val) else {
-        return Ok("0".to_string());
-    };
-    let cursor = progress.cursor;
-    let total = progress.total;
-    if total <= 0 {
-        return Ok("0".to_string());
-    }
-
-    let percent = ((cursor.max(0) as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
-    Ok(format!("{percent:.0}"))
-}
-
-#[askama::filter_fn]
-pub fn job_progress_summary(
-    val: &serde_json::Value,
-    _env: &dyn askama::Values,
-) -> askama::Result<String> {
-    let Some(progress) = progress_parts(val) else {
-        return Ok("0 / 0".to_string());
-    };
-    let cursor = progress.cursor;
-    let total = progress.total;
-    if total <= 0 {
-        return Ok(format!(
-            "{} / {}",
-            format_with_commas(cursor.max(0) as u64),
-            total
-        ));
-    }
-
-    let percent = ((cursor.max(0) as f64 / total as f64) * 100.0).clamp(0.0, 100.0);
-    Ok(format!(
-        "{} / {} ({percent:.0}%)",
-        format_with_commas(cursor.max(0) as u64),
-        format_with_commas(total as u64)
-    ))
-}
-
-#[askama::filter_fn]
-pub fn job_progress_note(
-    val: &serde_json::Value,
-    _env: &dyn askama::Values,
-) -> askama::Result<String> {
-    Ok(progress_parts(val)
-        .and_then(|progress| progress.note)
-        .unwrap_or_default())
-}
-
-#[askama::filter_fn]
-pub fn job_progress_eta(
-    val: &serde_json::Value,
+pub fn job_progress(
+    state: &serde_json::Value,
     _env: &dyn askama::Values,
     started_at_micros: &Option<i64>,
-) -> askama::Result<String> {
-    Ok(progress_eta_s(
-        val,
+) -> askama::Result<Option<ProgressView>> {
+    Ok(ProgressView::from_state(
+        state,
         *started_at_micros,
         chrono::Utc::now().timestamp_micros(),
-    )
-    .map(format_duration_from_secs)
-    .unwrap_or_else(|| "—".to_string()))
+    ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        SimpleArgPill, progress_eta_s, progress_parts, should_show_args_json, should_show_progress,
-        simple_args_for,
+        ProgressView, SimpleArgPill, progress_parts, should_show_args_json, simple_args_for,
     };
     use serde_json::json;
+
+    fn progress_eta_s(state: &serde_json::Value, started_at: Option<i64>, now: i64) -> Option<f64> {
+        super::progress_eta_s(&progress_parts(state)?, started_at, now)
+    }
+
+    fn should_show_progress(state: &serde_json::Value) -> bool {
+        ProgressView::from_state(state, None, 0).is_some()
+    }
+
+    #[test]
+    fn progress_view_formats_object_and_tuple_states_identically() {
+        let expected = ProgressView {
+            summary: "1,250 / 5,000 (25%)".to_string(),
+            percent: "25".to_string(),
+            note: "Importing".to_string(),
+            eta: "30.0s".to_string(),
+        };
+        for state in [
+            json!({"cursor": 1250, "total": 5000, "note": "Importing"}),
+            json!([1250, 5000, "Importing"]),
+        ] {
+            assert_eq!(
+                ProgressView::from_state(&state, Some(1_000_000), 11_000_000).as_ref(),
+                Some(&expected)
+            );
+        }
+    }
+
+    #[test]
+    fn progress_view_clamps_percent_and_preserves_unknown_eta() {
+        let negative = ProgressView::from_state(&json!([-1, 10]), None, 0).unwrap();
+        assert_eq!(negative.summary, "0 / 10 (0%)");
+        assert_eq!(negative.percent, "0");
+        assert_eq!(negative.eta, "—");
+        assert!(negative.note.is_empty());
+
+        let complete =
+            ProgressView::from_state(&json!([15, 10]), Some(1_000_000), 11_000_000).unwrap();
+        assert_eq!(complete.summary, "15 / 10 (100%)");
+        assert_eq!(complete.percent, "100");
+        assert_eq!(complete.eta, "0.0s");
+    }
 
     #[test]
     fn simple_args_include_top_level_scalar_values() {

--- a/oxana-web/src/handlers.rs
+++ b/oxana-web/src/handlers.rs
@@ -6,9 +6,9 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 
-use crate::JOBS_PER_PAGE;
 use crate::OxanaWebState;
 use crate::error::OxanaWebError;
+use crate::pagination::JobPage;
 use crate::templates::{
     BusyTemplate, CronRow, CronTemplate, CronWorkerView, DashboardTemplate, GlobalJobsTemplate,
     JobDetailTemplate, JobListKind, MetricDetailTemplate, MetricsTemplate, OnDemandJobView,
@@ -188,52 +188,47 @@ pub(crate) async fn enqueue_on_demand_job(
     )))
 }
 
+async fn global_jobs(
+    state: OxanaWebState,
+    params: PaginationParams,
+    kind: JobListKind,
+) -> Result<GlobalJobsTemplate, OxanaWebError> {
+    let opts = JobPage::list_opts(params.page);
+    let (total, jobs) = match kind {
+        JobListKind::Scheduled => (
+            state.storage.scheduled_count().await?,
+            state.storage.list_scheduled(&opts).await?,
+        ),
+        JobListKind::Dead => (
+            state.storage.dead_count().await?,
+            state.storage.list_dead(&opts).await?,
+        ),
+        JobListKind::Retries => (
+            state.storage.retries_count().await?,
+            state.storage.list_retries(&opts).await?,
+        ),
+    };
+
+    Ok(GlobalJobsTemplate {
+        base_path: state.base_path,
+        active_tab: kind.path(),
+        kind,
+        page: JobPage::new(params.page, total, jobs),
+    })
+}
+
 pub(crate) async fn scheduled_jobs(
     Extension(state): Extension<OxanaWebState>,
     Query(params): Query<PaginationParams>,
 ) -> Result<GlobalJobsTemplate, OxanaWebError> {
-    let page = params.page.max(1);
-    let opts = list_opts(page);
-
-    let total = state.storage.scheduled_count().await?;
-    let mut jobs = state.storage.list_scheduled(&opts).await?;
-
-    let has_next = jobs.len() > JOBS_PER_PAGE;
-    jobs.truncate(JOBS_PER_PAGE);
-
-    Ok(GlobalJobsTemplate {
-        base_path: state.base_path,
-        active_tab: "/scheduled",
-        kind: JobListKind::Scheduled,
-        jobs,
-        page,
-        total,
-        has_next,
-    })
+    global_jobs(state, params, JobListKind::Scheduled).await
 }
 
 pub(crate) async fn dead_jobs(
     Extension(state): Extension<OxanaWebState>,
     Query(params): Query<PaginationParams>,
 ) -> Result<GlobalJobsTemplate, OxanaWebError> {
-    let page = params.page.max(1);
-    let opts = list_opts(page);
-
-    let total = state.storage.dead_count().await?;
-    let mut jobs = state.storage.list_dead(&opts).await?;
-
-    let has_next = jobs.len() > JOBS_PER_PAGE;
-    jobs.truncate(JOBS_PER_PAGE);
-
-    Ok(GlobalJobsTemplate {
-        base_path: state.base_path,
-        active_tab: "/dead",
-        kind: JobListKind::Dead,
-        jobs,
-        page,
-        total,
-        has_next,
-    })
+    global_jobs(state, params, JobListKind::Dead).await
 }
 
 pub(crate) async fn wipe_dead(
@@ -256,24 +251,7 @@ pub(crate) async fn retry_jobs(
     Extension(state): Extension<OxanaWebState>,
     Query(params): Query<PaginationParams>,
 ) -> Result<GlobalJobsTemplate, OxanaWebError> {
-    let page = params.page.max(1);
-    let opts = list_opts(page);
-
-    let total = state.storage.retries_count().await?;
-    let mut jobs = state.storage.list_retries(&opts).await?;
-
-    let has_next = jobs.len() > JOBS_PER_PAGE;
-    jobs.truncate(JOBS_PER_PAGE);
-
-    Ok(GlobalJobsTemplate {
-        base_path: state.base_path,
-        active_tab: "/retries",
-        kind: JobListKind::Retries,
-        jobs,
-        page,
-        total,
-        has_next,
-    })
+    global_jobs(state, params, JobListKind::Retries).await
 }
 
 pub(crate) async fn retry_all_now(
@@ -308,8 +286,7 @@ pub(crate) async fn queue_detail(
         return Ok(Redirect::to(&format!("{}/queues", state.base_path)).into_response());
     }
 
-    let page = params.page.max(1);
-    let opts = list_opts(page);
+    let opts = JobPage::list_opts(params.page);
 
     let stats = state.storage.stats().await?;
     let queue_config = queue_runtime_config_for(&state, &queue_key).await?;
@@ -318,7 +295,6 @@ pub(crate) async fn queue_detail(
         .enqueued_count(RawQueue::fixed(queue_key.clone()))
         .await?;
     let queue_stats = queue_detail_queue_stats(&stats, &queue_key, live_enqueued);
-    let total = live_enqueued;
     let active_jobs = stats
         .processing
         .iter()
@@ -327,13 +303,10 @@ pub(crate) async fn queue_detail(
         .collect::<Vec<_>>();
     let busy = active_jobs.len();
 
-    let mut jobs = state
+    let jobs = state
         .storage
         .list_queue_jobs(RawQueue::fixed(queue_key.clone()), &opts)
         .await?;
-
-    let has_next = jobs.len() > JOBS_PER_PAGE;
-    jobs.truncate(JOBS_PER_PAGE);
 
     Ok(QueueDetailTemplate {
         base_path: state.base_path,
@@ -343,10 +316,7 @@ pub(crate) async fn queue_detail(
         queue_config,
         active_jobs,
         busy,
-        jobs,
-        page,
-        total,
-        has_next,
+        page: JobPage::new(params.page, live_enqueued, jobs),
     }
     .into_response())
 }
@@ -664,13 +634,6 @@ pub(crate) struct OnDemandParams {
 pub(crate) struct CronParams {
     #[serde(default)]
     enqueued: Option<String>,
-}
-
-fn list_opts(page: usize) -> oxana::QueueListOpts {
-    oxana::QueueListOpts {
-        count: JOBS_PER_PAGE + 1,
-        offset: (page - 1) * JOBS_PER_PAGE,
-    }
 }
 
 async fn queue_config_map(

--- a/oxana-web/src/lib.rs
+++ b/oxana-web/src/lib.rs
@@ -1,6 +1,7 @@
 mod error;
 mod filters;
 mod handlers;
+mod pagination;
 mod templates;
 
 use axum::{

--- a/oxana-web/src/pagination.rs
+++ b/oxana-web/src/pagination.rs
@@ -1,0 +1,36 @@
+use crate::JOBS_PER_PAGE;
+
+pub(crate) struct JobPage {
+    pub jobs: Vec<oxana::JobEnvelope>,
+    pub number: usize,
+    pub total: usize,
+    pub has_next: bool,
+}
+
+impl JobPage {
+    pub fn list_opts(page: usize) -> oxana::QueueListOpts {
+        oxana::QueueListOpts {
+            count: JOBS_PER_PAGE + 1,
+            offset: (page.max(1) - 1) * JOBS_PER_PAGE,
+        }
+    }
+
+    pub fn new(page: usize, total: usize, mut jobs: Vec<oxana::JobEnvelope>) -> Self {
+        let has_next = jobs.len() > JOBS_PER_PAGE;
+        jobs.truncate(JOBS_PER_PAGE);
+        Self {
+            jobs,
+            number: page.max(1),
+            total,
+            has_next,
+        }
+    }
+
+    pub fn range_start(&self) -> usize {
+        (self.number - 1) * JOBS_PER_PAGE + 1
+    }
+
+    pub fn range_end(&self) -> usize {
+        ((self.number - 1) * JOBS_PER_PAGE + self.jobs.len()).min(self.total)
+    }
+}

--- a/oxana-web/src/templates.rs
+++ b/oxana-web/src/templates.rs
@@ -2,8 +2,8 @@ use askama::Template;
 use askama_web::WebTemplate;
 use std::collections::HashMap;
 
-use crate::JOBS_PER_PAGE;
 use crate::filters;
+use crate::pagination::JobPage;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub(crate) enum QueueConcurrencyStatus {
@@ -912,10 +912,7 @@ pub(crate) struct QueueDetailTemplate {
     pub queue_config: QueueRuntimeConfigView,
     pub active_jobs: Vec<oxana::StatsProcessing>,
     pub busy: usize,
-    pub jobs: Vec<oxana::JobEnvelope>,
-    pub page: usize,
-    pub total: usize,
-    pub has_next: bool,
+    pub page: JobPage,
 }
 
 impl QueueDetailTemplate {
@@ -953,14 +950,6 @@ impl QueueDetailTemplate {
     pub fn queue_action_path(&self, action: &str) -> String {
         queue_action_path(&self.base_path, &self.queue_key, action)
     }
-
-    pub fn range_start(&self) -> usize {
-        (self.page - 1) * JOBS_PER_PAGE + 1
-    }
-
-    pub fn range_end(&self) -> usize {
-        ((self.page - 1) * JOBS_PER_PAGE + self.jobs.len()).min(self.total)
-    }
 }
 
 pub(crate) enum JobListKind {
@@ -970,6 +959,14 @@ pub(crate) enum JobListKind {
 }
 
 impl JobListKind {
+    pub fn path(&self) -> &'static str {
+        match self {
+            Self::Dead => "/dead",
+            Self::Retries => "/retries",
+            Self::Scheduled => "/scheduled",
+        }
+    }
+
     pub fn title(&self) -> &'static str {
         match self {
             Self::Dead => "Dead Jobs",
@@ -1025,20 +1022,7 @@ pub(crate) struct GlobalJobsTemplate {
     pub base_path: String,
     pub active_tab: &'static str,
     pub kind: JobListKind,
-    pub jobs: Vec<oxana::JobEnvelope>,
-    pub page: usize,
-    pub total: usize,
-    pub has_next: bool,
-}
-
-impl GlobalJobsTemplate {
-    pub fn range_start(&self) -> usize {
-        (self.page - 1) * JOBS_PER_PAGE + 1
-    }
-
-    pub fn range_end(&self) -> usize {
-        ((self.page - 1) * JOBS_PER_PAGE + self.jobs.len()).min(self.total)
-    }
+    pub page: JobPage,
 }
 
 #[derive(Template, WebTemplate)]
@@ -1054,6 +1038,7 @@ pub(crate) struct JobDetailTemplate {
 #[cfg(test)]
 mod job_card_tests {
     use super::{GlobalJobsTemplate, JobListKind};
+    use crate::pagination::JobPage;
     use askama::Template;
     use serde_json::json;
 
@@ -1086,18 +1071,86 @@ mod job_card_tests {
     }
 
     #[test]
+    fn global_job_pagination_uses_lookahead_and_preserves_links() {
+        for kind in [
+            JobListKind::Scheduled,
+            JobListKind::Dead,
+            JobListKind::Retries,
+        ] {
+            let jobs = (1..=51)
+                .map(|id| job_envelope_with_id(&format!("job-{id}"), json!({})))
+                .collect();
+            let path = kind.path();
+            let template = GlobalJobsTemplate {
+                base_path: "/admin".to_string(),
+                active_tab: path,
+                kind,
+                page: JobPage::new(2, 101, jobs),
+            };
+            let rendered = template.render().unwrap();
+
+            assert!(rendered.contains("href=\"/admin/jobs/job-50\""));
+            assert!(!rendered.contains("href=\"/admin/jobs/job-51\""));
+            assert!(rendered.contains("href=\"?page=1\""));
+            assert!(rendered.contains("href=\"?page=3\""));
+            assert!(rendered.contains("51&ndash;100 of 101"));
+        }
+    }
+
+    #[test]
+    fn pagination_normalizes_zero_and_does_not_infer_next_page_from_total() {
+        let opts = JobPage::list_opts(0);
+        assert_eq!((opts.offset, opts.count), (0, 51));
+        assert_eq!(JobPage::list_opts(2).offset, 50);
+
+        let page = JobPage::new(0, 100, vec![job_envelope(json!({}))]);
+        assert_eq!(page.number, 1);
+        assert_eq!((page.range_start(), page.range_end()), (1, 1));
+        assert!(!page.has_next);
+
+        let page = JobPage::new(2, 50, vec![job_envelope(json!({}))]);
+        assert_eq!(page.range_end(), 50);
+    }
+
+    #[test]
+    fn global_job_cards_escape_progress_notes_and_keep_other_state_visible() {
+        for (state, expected) in [
+            (json!([1, 4, "<b>Importing</b>"]), "1 / 4 (25%)"),
+            (json!({"checkpoint": "resume-here"}), "resume-here"),
+        ] {
+            let mut job = job_envelope(json!({}));
+            job.meta.state = Some(state);
+            let template = GlobalJobsTemplate {
+                base_path: "/admin".to_string(),
+                active_tab: "/scheduled",
+                kind: JobListKind::Scheduled,
+                page: JobPage::new(1, 1, vec![job]),
+            };
+            let rendered = template.render().unwrap();
+            assert!(rendered.contains(expected));
+            assert!(!rendered.contains("<b>Importing</b>"));
+            if expected == "1 / 4 (25%)" {
+                assert!(rendered.contains("&#60;b&#62;Importing&#60;/b&#62;"));
+                assert!(rendered.contains("style=\"width: 25%\""));
+                assert!(rendered.contains("ETA —"));
+            }
+        }
+    }
+
+    #[test]
     fn global_job_cards_render_simple_arg_pills() {
         let template = GlobalJobsTemplate {
             base_path: "/admin".to_string(),
             active_tab: "/scheduled",
             kind: JobListKind::Scheduled,
-            jobs: vec![job_envelope(json!({
-                "game_id": 12345,
-                "dry_run": false,
-            }))],
-            page: 1,
-            total: 1,
-            has_next: false,
+            page: JobPage::new(
+                1,
+                1,
+                vec![job_envelope(json!({
+                    "game_id": 12345,
+                    "dry_run": false,
+                }))],
+            ),
         };
 
         let rendered = template.render().unwrap();
@@ -1117,13 +1170,14 @@ mod job_card_tests {
             base_path: "/admin".to_string(),
             active_tab: "/scheduled",
             kind: JobListKind::Scheduled,
-            jobs: vec![job_envelope(json!({
-                "game_id": 12345,
-                "metadata": { "season": 2026 },
-            }))],
-            page: 1,
-            total: 1,
-            has_next: false,
+            page: JobPage::new(
+                1,
+                1,
+                vec![job_envelope(json!({
+                    "game_id": 12345,
+                    "metadata": { "season": 2026 },
+                }))],
+            ),
         };
 
         let rendered = template.render().unwrap();
@@ -1143,10 +1197,11 @@ mod job_card_tests {
             base_path: "/admin".to_string(),
             active_tab: "/scheduled",
             kind: JobListKind::Scheduled,
-            jobs: vec![job_envelope_with_id("crate::Worker/type-123", json!({}))],
-            page: 1,
-            total: 1,
-            has_next: false,
+            page: JobPage::new(
+                1,
+                1,
+                vec![job_envelope_with_id("crate::Worker/type-123", json!({}))],
+            ),
         };
 
         let rendered = template.render().unwrap();
@@ -1160,10 +1215,7 @@ mod job_card_tests {
             base_path: "/admin".to_string(),
             active_tab: "/dead",
             kind: JobListKind::Dead,
-            jobs: vec![job_envelope(json!({}))],
-            page: 1,
-            total: 1,
-            has_next: false,
+            page: JobPage::new(1, 1, vec![job_envelope(json!({}))]),
         };
 
         let rendered = template.render().unwrap();
@@ -1179,10 +1231,7 @@ mod job_card_tests {
             base_path: "/admin".to_string(),
             active_tab: "/retries",
             kind: JobListKind::Retries,
-            jobs: vec![job_envelope(json!({}))],
-            page: 1,
-            total: 1,
-            has_next: false,
+            page: JobPage::new(1, 1, vec![job_envelope(json!({}))]),
         };
 
         let rendered = template.render().unwrap();

--- a/oxana-web/templates/_chart_head.html
+++ b/oxana-web/templates/_chart_head.html
@@ -1,0 +1,30 @@
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.iife.min.js"></script>
+    <style>
+        .uplot {
+            color: #d1d5db;
+            background: transparent;
+        }
+        .chart-tooltip {
+            position: absolute;
+            z-index: 10;
+            min-width: {{ tooltip_min_width }}rem;
+            pointer-events: none;
+            border: 1px solid #374151;
+            border-radius: 0.375rem;
+            background: rgba(17, 24, 39, 0.96);
+            color: #f9fafb;
+            padding: 0.5rem 0.625rem;
+            font-size: 0.75rem;
+            line-height: 1.25rem;
+            white-space: nowrap;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.35);
+            transform: translate(-50%, -100%);
+        }
+        .chart-tooltip.hidden {
+            display: none;
+        }
+        .chart-tooltip-label {
+            color: #9ca3af;
+        }
+    </style>

--- a/oxana-web/templates/_charts.html
+++ b/oxana-web/templates/_charts.html
@@ -1,0 +1,279 @@
+<script>
+const oxanaCharts = (function () {
+    function formatTime(ts) {
+        return new Date(ts * 1000).toLocaleString(undefined, {
+            month: 'numeric',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit'
+        });
+    }
+
+    function formatCount(value) {
+        return Math.round(value).toLocaleString();
+    }
+
+    function formatShortTime(ts) {
+        return new Date(ts * 1000).toLocaleString(undefined, {
+            hour: 'numeric',
+            minute: '2-digit'
+        });
+    }
+
+    var palette = [
+        '#60a5fa', '#4ade80', '#f472b6', '#facc15',
+        '#a78bfa', '#2dd4bf', '#fb923c', '#94a3b8'
+    ];
+
+    function seriesColor(series, index) {
+        return series.color || palette[index % palette.length];
+    }
+
+    function seriesTooltipRows(payload, idx, formatter) {
+        return payload.series.map(function (series, seriesIdx) {
+            return { series: series, seriesIdx: seriesIdx, value: series.data[idx] || 0 };
+        }).sort(function (a, b) {
+            return (b.value - a.value) || (a.seriesIdx - b.seriesIdx);
+        }).filter(function (entry) {
+            return entry.value !== 0;
+        }).map(function (entry) {
+            return {
+                label: entry.series.fullLabel || entry.series.label,
+                value: formatter(entry.value),
+                color: seriesColor(entry.series, entry.seriesIdx)
+            };
+        });
+    }
+
+    function createTooltip(chartEl) {
+        var tooltip = document.createElement('div');
+        tooltip.className = 'chart-tooltip hidden';
+        chartEl.appendChild(tooltip);
+        return tooltip;
+    }
+
+    function fillTooltip(tooltip, timestamp, rows) {
+        tooltip.replaceChildren();
+        [{ label: 'Time', value: formatTime(timestamp) }].concat(rows).forEach(function (entry) {
+            var row = document.createElement('div');
+            var label = document.createElement('span');
+            label.className = 'chart-tooltip-label';
+            label.textContent = entry.label + ':';
+            if (entry.color) {
+                label.style.color = entry.color;
+            }
+            row.appendChild(label);
+            row.append(' ' + entry.value);
+            tooltip.appendChild(row);
+        });
+        tooltip.classList.remove('hidden');
+    }
+
+    function positionTooltip(chartEl, tooltip, x, y) {
+        var halfWidth = tooltip.offsetWidth / 2;
+        var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
+        var top = Math.max(y - 12, tooltip.offsetHeight + 8);
+        tooltip.style.left = left + 'px';
+        tooltip.style.top = top + 'px';
+    }
+
+    function buildTooltip(chartEl, timestamps, rowsForIndex) {
+        var tooltip = createTooltip(chartEl);
+        chartEl.addEventListener('mouseleave', function () {
+            tooltip.classList.add('hidden');
+        });
+        return function (u) {
+            var idx = u.cursor.idx;
+            if (idx == null || idx < 0 || idx >= timestamps.length) {
+                tooltip.classList.add('hidden');
+                return;
+            }
+            fillTooltip(tooltip, timestamps[idx], rowsForIndex(idx));
+            positionTooltip(chartEl, tooltip, u.over.offsetLeft + u.cursor.left, u.over.offsetTop + u.cursor.top);
+        };
+    }
+
+    function renderChart(chartId, payload, valueFormatter, rowsForIndex) {
+        var chartEl = document.getElementById(chartId);
+        if (!chartEl) {
+            return;
+        }
+
+        var data = [payload.timestamps].concat(payload.series.map(function (series) {
+            return series.data;
+        }));
+
+        new uPlot({
+            width: Math.max(chartEl.clientWidth, 320),
+            height: 300,
+            legend: { show: false },
+            tzDate: function (ts) { return uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'); },
+            scales: {
+                x: { time: true },
+                y: { range: [0, null] }
+            },
+            axes: [
+                {
+                    stroke: '#9ca3af',
+                    grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
+                    ticks: { stroke: '#374151' }
+                },
+                {
+                    size: 72,
+                    stroke: '#9ca3af',
+                    grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
+                    ticks: { stroke: '#374151' },
+                    values: function (_u, vals) {
+                        return vals.map(valueFormatter);
+                    }
+                }
+            ],
+            series: [
+                {}
+            ].concat(payload.series.map(function (series, index) {
+                return {
+                    label: series.label,
+                    stroke: seriesColor(series, index),
+                    fill: series.fill,
+                    width: 2
+                };
+            })),
+            hooks: {
+                setCursor: [buildTooltip(chartEl, payload.timestamps, rowsForIndex)]
+            }
+        }, data, chartEl);
+    }
+
+    function svgEl(name) {
+        return document.createElementNS('http://www.w3.org/2000/svg', name);
+    }
+
+    function renderStackedChart(chartId, payload, ariaLabel, rowsForIndex) {
+        var chartEl = document.getElementById(chartId);
+        if (!chartEl) {
+            return;
+        }
+
+        var width = Math.max(chartEl.clientWidth, 320);
+        var height = 300;
+        var margin = { top: 12, right: 16, bottom: 44, left: 72 };
+        var plotWidth = width - margin.left - margin.right;
+        var plotHeight = height - margin.top - margin.bottom;
+        var timestamps = payload.timestamps;
+        var totals = timestamps.map(function (_ts, idx) {
+            return payload.series.reduce(function (sum, series) {
+                return sum + (series.data[idx] || 0);
+            }, 0);
+        });
+        var maxTotal = Math.max.apply(null, totals.concat([1]));
+        var barStep = plotWidth / Math.max(timestamps.length, 1);
+        var barWidth = Math.max(1, Math.min(18, barStep * 0.72));
+        var bottom = margin.top + plotHeight;
+
+        chartEl.replaceChildren();
+
+        var tooltip = createTooltip(chartEl);
+
+        var svg = svgEl('svg');
+        svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+        svg.setAttribute('width', '100%');
+        svg.setAttribute('height', height.toString());
+        svg.setAttribute('role', 'img');
+        svg.setAttribute('aria-label', ariaLabel);
+        chartEl.appendChild(svg);
+
+        for (var tick = 0; tick <= 4; tick += 1) {
+            var value = Math.round((maxTotal * tick) / 4);
+            var y = bottom - (plotHeight * value / maxTotal);
+
+            var grid = svgEl('line');
+            grid.setAttribute('x1', margin.left.toString());
+            grid.setAttribute('x2', (width - margin.right).toString());
+            grid.setAttribute('y1', y.toString());
+            grid.setAttribute('y2', y.toString());
+            grid.setAttribute('stroke', 'rgba(31, 41, 55, 0.7)');
+            svg.appendChild(grid);
+
+            var label = svgEl('text');
+            label.setAttribute('x', (margin.left - 14).toString());
+            label.setAttribute('y', (y + 4).toString());
+            label.setAttribute('text-anchor', 'end');
+            label.setAttribute('fill', '#9ca3af');
+            label.setAttribute('font-size', '12');
+            label.textContent = formatCount(value);
+            svg.appendChild(label);
+        }
+
+        var xTickIndexes = Array.from(new Set([
+            0,
+            Math.floor((timestamps.length - 1) / 3),
+            Math.floor(((timestamps.length - 1) * 2) / 3),
+            timestamps.length - 1
+        ])).filter(function (idx) {
+            return idx >= 0 && idx < timestamps.length;
+        });
+
+        xTickIndexes.forEach(function (idx) {
+            var x = margin.left + (idx + 0.5) * barStep;
+            var label = svgEl('text');
+            label.setAttribute('x', x.toString());
+            label.setAttribute('y', (height - 14).toString());
+            label.setAttribute('text-anchor', 'middle');
+            label.setAttribute('fill', '#9ca3af');
+            label.setAttribute('font-size', '12');
+            label.textContent = formatShortTime(timestamps[idx]);
+            svg.appendChild(label);
+        });
+
+        function appendSegment(idx, value, offset, series, seriesIdx) {
+            if (value <= 0) {
+                return;
+            }
+
+            var segmentHeight = Math.max(1, plotHeight * value / maxTotal);
+            var y = bottom - (plotHeight * (offset + value) / maxTotal);
+            var rect = svgEl('rect');
+            rect.setAttribute('x', (margin.left + idx * barStep + (barStep - barWidth) / 2).toString());
+            rect.setAttribute('y', y.toString());
+            rect.setAttribute('width', barWidth.toString());
+            rect.setAttribute('height', segmentHeight.toString());
+            rect.setAttribute('fill', seriesColor(series, seriesIdx));
+            if (series.border) {
+                rect.setAttribute('stroke', series.border);
+                rect.setAttribute('stroke-width', '0.75');
+            }
+            svg.appendChild(rect);
+        }
+
+        timestamps.forEach(function (_ts, idx) {
+            var offset = 0;
+            payload.series.forEach(function (series, seriesIdx) {
+                var value = series.data[idx] || 0;
+                appendSegment(idx, value, offset, series, seriesIdx);
+                offset += value;
+            });
+        });
+
+        svg.addEventListener('mousemove', function (event) {
+            var rect = svg.getBoundingClientRect();
+            var localX = ((event.clientX - rect.left) / rect.width) * width;
+            var idx = Math.round((localX - margin.left) / barStep - 0.5);
+            idx = Math.max(0, Math.min(timestamps.length - 1, idx));
+
+            fillTooltip(tooltip, timestamps[idx], rowsForIndex(idx, totals[idx] || 0));
+            positionTooltip(chartEl, tooltip, event.clientX - rect.left, event.clientY - rect.top);
+        });
+
+        svg.addEventListener('mouseleave', function () {
+            tooltip.classList.add('hidden');
+        });
+    }
+
+    return {
+        renderChart: renderChart,
+        renderStackedChart: renderStackedChart,
+        seriesTooltipRows: seriesTooltipRows,
+        formatCount: formatCount
+    };
+})();
+</script>

--- a/oxana-web/templates/_job_progress.html
+++ b/oxana-web/templates/_job_progress.html
@@ -3,18 +3,18 @@
         <div>
             <div class="text-xs font-medium text-cyan-200">Progress</div>
             <div class="mt-1 text-xs text-gray-400">
-                {{ state|job_progress_summary }}
+                {{ progress.summary }}
             </div>
         </div>
         <div class="shrink-0 text-right">
-            <div class="text-sm font-semibold text-cyan-200">{{ state|job_progress_percent }}%</div>
-            <div class="mt-1 text-[11px] text-cyan-200/70">ETA {{ state|job_progress_eta(progress_started_at) }}</div>
+            <div class="text-sm font-semibold text-cyan-200">{{ progress.percent }}%</div>
+            <div class="mt-1 text-[11px] text-cyan-200/70">ETA {{ progress.eta }}</div>
         </div>
     </div>
     <div class="mt-3 h-2 overflow-hidden rounded-full bg-gray-800">
-        <div class="h-full rounded-full bg-cyan-400 transition-all" style="width: {{ state|job_progress_percent }}%"></div>
+        <div class="h-full rounded-full bg-cyan-400 transition-all" style="width: {{ progress.percent }}%"></div>
     </div>
-    {% if state|job_progress_note != "" %}
-    <div class="mt-2 text-xs text-gray-300">{{ state|job_progress_note }}</div>
+    {% if progress.note != "" %}
+    <div class="mt-2 text-xs text-gray-300">{{ progress.note }}</div>
     {% endif %}
 </div>

--- a/oxana-web/templates/busy.html
+++ b/oxana-web/templates/busy.html
@@ -153,8 +153,8 @@
                     {% match item.job_envelope.meta.state %}
                     {% when Some with (state) %}
                     {% if state|has_args %}
-                    {% if state|show_job_progress %}
                     {% let progress_started_at = item.job_envelope.meta.started_at %}
+                    {% if let Some(progress) = state|job_progress(progress_started_at) %}
                     {% include "_job_progress.html" %}
                     {% else %}
                     <div class="mt-3">

--- a/oxana-web/templates/global_jobs.html
+++ b/oxana-web/templates/global_jobs.html
@@ -16,15 +16,15 @@
 
         <div class="flex items-center justify-between mb-4">
             <h2 class="text-lg font-semibold">
-                {% if total > 0 %}
-                {{ self.range_start() }}&ndash;{{ self.range_end() }} of {{ total }} {{ kind.label() }}
+                {% if page.total > 0 %}
+                {{ page.range_start() }}&ndash;{{ page.range_end() }} of {{ page.total }} {{ kind.label() }}
                 {% else %}
                 0 {{ kind.label() }}
                 {% endif %}
             </h2>
             <div class="flex items-center gap-2 text-sm">
                 {% if kind.is_dead() %}
-                {% if total > 0 %}
+                {% if page.total > 0 %}
                 <form method="POST" action="{{ base_path }}/dead/revive_all" onsubmit="return confirmReviveAllDead()">
                     <button type="submit" class="px-3 py-1 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 transition-colors">Revive All</button>
                 </form>
@@ -34,32 +34,32 @@
                 {% endif %}
                 {% endif %}
                 {% if kind.is_retries() %}
-                {% if total > 0 %}
+                {% if page.total > 0 %}
                 <form method="POST" action="{{ base_path }}/retries/retry_all_now" onsubmit="return confirmRetryAllNow()">
                     <button type="submit" class="px-3 py-1 rounded bg-orange-900/50 border border-orange-800 hover:bg-orange-800 text-orange-300 transition-colors">Retry All Now</button>
                 </form>
                 {% endif %}
                 {% endif %}
-                {% if page > 1 %}
-                <a href="?page={{ page - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
+                {% if page.number > 1 %}
+                <a href="?page={{ page.number - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
                 {% else %}
                 <span class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed">&larr; Prev</span>
                 {% endif %}
-                {% if has_next %}
-                <a href="?page={{ page + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
+                {% if page.has_next %}
+                <a href="?page={{ page.number + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
                 {% else %}
                 <span class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed">Next &rarr;</span>
                 {% endif %}
             </div>
         </div>
 
-        {% if jobs.is_empty() %}
+        {% if page.jobs.is_empty() %}
         <div class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500">
             {{ kind.empty_label() }}
         </div>
         {% else %}
         <div class="space-y-3">
-            {% for job in &jobs %}
+            {% for job in &page.jobs %}
             <div class="bg-gray-900 border {{ kind.border_class() }} rounded-lg p-4">
                 <div class="flex items-start justify-between mb-2">
                     <div class="flex items-center gap-2">
@@ -111,8 +111,8 @@
                 {% match job.meta.state %}
                 {% when Some with (state) %}
                 {% if state|has_args %}
-                {% if state|show_job_progress %}
                 {% let progress_started_at = job.meta.started_at %}
+                {% if let Some(progress) = state|job_progress(progress_started_at) %}
                 {% include "_job_progress.html" %}
                 {% else %}
                 <details class="mt-3">
@@ -151,13 +151,13 @@
         </div>
 
         <div class="flex items-center justify-between mt-6 text-sm">
-            <span class="text-gray-500">{{ self.range_start() }}&ndash;{{ self.range_end() }} of {{ total }}</span>
+            <span class="text-gray-500">{{ page.range_start() }}&ndash;{{ page.range_end() }} of {{ page.total }}</span>
             <div class="flex items-center gap-2">
-                {% if page > 1 %}
-                <a href="?page={{ page - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
+                {% if page.number > 1 %}
+                <a href="?page={{ page.number - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
                 {% endif %}
-                {% if has_next %}
-                <a href="?page={{ page + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
+                {% if page.has_next %}
+                <a href="?page={{ page.number + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
                 {% endif %}
             </div>
         </div>

--- a/oxana-web/templates/job_detail.html
+++ b/oxana-web/templates/job_detail.html
@@ -80,8 +80,8 @@
 
             {% match job.meta.state %}
             {% when Some with (state) %}
-            {% if state|show_job_progress %}
             {% let progress_started_at = job.meta.started_at %}
+            {% if let Some(progress) = state|job_progress(progress_started_at) %}
             {% include "_job_progress.html" %}
             {% else %}
             <details class="mt-3" open>

--- a/oxana-web/templates/metric_detail.html
+++ b/oxana-web/templates/metric_detail.html
@@ -5,36 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Metric: {{ metrics.identity.worker }} - Oxana</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.min.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.iife.min.js"></script>
-    <style>
-        .uplot {
-            color: #d1d5db;
-            background: transparent;
-        }
-        .chart-tooltip {
-            position: absolute;
-            z-index: 10;
-            min-width: 10rem;
-            pointer-events: none;
-            border: 1px solid #374151;
-            border-radius: 0.375rem;
-            background: rgba(17, 24, 39, 0.96);
-            color: #f9fafb;
-            padding: 0.5rem 0.625rem;
-            font-size: 0.75rem;
-            line-height: 1.25rem;
-            white-space: nowrap;
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.35);
-            transform: translate(-50%, -100%);
-        }
-        .chart-tooltip.hidden {
-            display: none;
-        }
-        .chart-tooltip-label {
-            color: #9ca3af;
-        }
-    </style>
+    {% let tooltip_min_width = 10 %}
+    {% include "_chart_head.html" %}
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
     <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -125,19 +97,11 @@
         </section>
     </div>
 
+    {% include "_charts.html" %}
     <script>
         window.addEventListener('DOMContentLoaded', function () {
             if (typeof uPlot === 'undefined') {
                 return;
-            }
-
-            function formatTime(ts) {
-                return new Date(ts * 1000).toLocaleString(undefined, {
-                    month: 'numeric',
-                    day: 'numeric',
-                    hour: 'numeric',
-                    minute: '2-digit'
-                });
             }
 
             function formatMillis(value) {
@@ -147,251 +111,29 @@
                 return value.toFixed(0) + 'ms';
             }
 
-            function formatCount(value) {
-                return Math.round(value).toLocaleString();
-            }
-
-            function formatShortTime(ts) {
-                return new Date(ts * 1000).toLocaleString(undefined, {
-                    hour: 'numeric',
-                    minute: '2-digit'
-                });
-            }
-
-            function buildTooltip(chartEl, data, label, formatter) {
-                var tooltip = document.createElement('div');
-                tooltip.className = 'chart-tooltip hidden';
-                chartEl.appendChild(tooltip);
-
-                chartEl.addEventListener('mouseleave', function () {
-                    tooltip.classList.add('hidden');
-                });
-
-                return function (u) {
-                    var idx = u.cursor.idx;
-                    if (idx == null || idx < 0 || idx >= data[0].length) {
-                        tooltip.classList.add('hidden');
-                        return;
-                    }
-
-                    tooltip.innerHTML =
-                        '<div><span class="chart-tooltip-label">Time:</span> ' + formatTime(data[0][idx]) + '</div>' +
-                        '<div><span class="chart-tooltip-label">' + label + ':</span> ' + formatter(data[1][idx]) + '</div>';
-
-                    tooltip.classList.remove('hidden');
-
-                    var x = u.over.offsetLeft + u.cursor.left;
-                    var y = u.over.offsetTop + u.cursor.top;
-                    var halfWidth = tooltip.offsetWidth / 2;
-                    var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
-                    var top = Math.max(y - 12, tooltip.offsetHeight + 8);
-
-                    tooltip.style.left = left + 'px';
-                    tooltip.style.top = top + 'px';
-                };
-            }
-
-            function renderChart(chartId, data, label, stroke, fill, valueFormatter) {
-                var chartEl = document.getElementById(chartId);
-                if (!chartEl) {
-                    return;
-                }
-
-                new uPlot({
-                    width: Math.max(chartEl.clientWidth, 320),
-                    height: 300,
-                    legend: { show: false },
-                    tzDate: function (ts) { return uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'); },
-                    scales: {
-                        x: { time: true },
-                        y: { range: [0, null] }
-                    },
-                    axes: [
-                        {
-                            stroke: '#9ca3af',
-                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
-                            ticks: { stroke: '#374151' }
-                        },
-                        {
-                            size: 72,
-                            stroke: '#9ca3af',
-                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
-                            ticks: { stroke: '#374151' },
-                            values: function (_u, vals) {
-                                return vals.map(valueFormatter);
-                            }
-                        }
-                    ],
-                    series: [
-                        {},
-                        {
-                            label: label,
-                            stroke: stroke,
-                            fill: fill,
-                            width: 2
-                        }
-                    ],
-                    hooks: {
-                        setCursor: [buildTooltip(chartEl, data, label, valueFormatter)]
-                    }
-                }, data, chartEl);
-            }
-
-            function svgEl(name) {
-                return document.createElementNS('http://www.w3.org/2000/svg', name);
-            }
-
-            function renderExecutionsChart(chartId, data) {
-                var chartEl = document.getElementById(chartId);
-                if (!chartEl) {
-                    return;
-                }
-
-                var width = Math.max(chartEl.clientWidth, 320);
-                var height = 300;
-                var margin = { top: 12, right: 16, bottom: 44, left: 72 };
-                var plotWidth = width - margin.left - margin.right;
-                var plotHeight = height - margin.top - margin.bottom;
-                var timestamps = data[0];
-                var succeeded = data[1];
-                var failed = data[2];
-                var panicked = data[3];
-                var totals = timestamps.map(function (_ts, idx) {
-                    return (succeeded[idx] || 0) + (failed[idx] || 0) + (panicked[idx] || 0);
-                });
-                var maxTotal = Math.max.apply(null, totals.concat([1]));
-                var barStep = plotWidth / Math.max(timestamps.length, 1);
-                var barWidth = Math.max(1, Math.min(18, barStep * 0.72));
-                var bottom = margin.top + plotHeight;
-
-                chartEl.replaceChildren();
-
-                var tooltip = document.createElement('div');
-                tooltip.className = 'chart-tooltip hidden';
-                chartEl.appendChild(tooltip);
-
-                var svg = svgEl('svg');
-                svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
-                svg.setAttribute('width', '100%');
-                svg.setAttribute('height', height.toString());
-                svg.setAttribute('role', 'img');
-                svg.setAttribute('aria-label', 'Total executions by minute');
-                chartEl.appendChild(svg);
-
-                for (var tick = 0; tick <= 4; tick += 1) {
-                    var value = Math.round((maxTotal * tick) / 4);
-                    var y = bottom - (plotHeight * value / maxTotal);
-
-                    var grid = svgEl('line');
-                    grid.setAttribute('x1', margin.left.toString());
-                    grid.setAttribute('x2', (width - margin.right).toString());
-                    grid.setAttribute('y1', y.toString());
-                    grid.setAttribute('y2', y.toString());
-                    grid.setAttribute('stroke', 'rgba(31, 41, 55, 0.7)');
-                    svg.appendChild(grid);
-
-                    var label = svgEl('text');
-                    label.setAttribute('x', (margin.left - 14).toString());
-                    label.setAttribute('y', (y + 4).toString());
-                    label.setAttribute('text-anchor', 'end');
-                    label.setAttribute('fill', '#9ca3af');
-                    label.setAttribute('font-size', '12');
-                    label.textContent = formatCount(value);
-                    svg.appendChild(label);
-                }
-
-                var xTickIndexes = Array.from(new Set([
-                    0,
-                    Math.floor((timestamps.length - 1) / 3),
-                    Math.floor(((timestamps.length - 1) * 2) / 3),
-                    timestamps.length - 1
-                ])).filter(function (idx) {
-                    return idx >= 0 && idx < timestamps.length;
-                });
-
-                xTickIndexes.forEach(function (idx) {
-                    var x = margin.left + (idx + 0.5) * barStep;
-                    var label = svgEl('text');
-                    label.setAttribute('x', x.toString());
-                    label.setAttribute('y', (height - 14).toString());
-                    label.setAttribute('text-anchor', 'middle');
-                    label.setAttribute('fill', '#9ca3af');
-                    label.setAttribute('font-size', '12');
-                    label.textContent = formatShortTime(timestamps[idx]);
-                    svg.appendChild(label);
-                });
-
-                function appendSegment(idx, value, offset, color, stroke) {
-                    if (value <= 0) {
-                        return;
-                    }
-
-                    var segmentHeight = Math.max(1, plotHeight * value / maxTotal);
-                    var y = bottom - (plotHeight * (offset + value) / maxTotal);
-                    var rect = svgEl('rect');
-                    rect.setAttribute('x', (margin.left + idx * barStep + (barStep - barWidth) / 2).toString());
-                    rect.setAttribute('y', y.toString());
-                    rect.setAttribute('width', barWidth.toString());
-                    rect.setAttribute('height', segmentHeight.toString());
-                    rect.setAttribute('fill', color);
-                    if (stroke) {
-                        rect.setAttribute('stroke', stroke);
-                        rect.setAttribute('stroke-width', '0.75');
-                    }
-                    svg.appendChild(rect);
-                }
-
-                timestamps.forEach(function (_ts, idx) {
-                    var success = succeeded[idx] || 0;
-                    var failure = failed[idx] || 0;
-                    var panic = panicked[idx] || 0;
-
-                    appendSegment(idx, success, 0, '#34d399');
-                    appendSegment(idx, failure, success, '#ef4444');
-                    appendSegment(idx, panic, success + failure, '#000000', '#6b7280');
-                });
-
-                svg.addEventListener('mousemove', function (event) {
-                    var rect = svg.getBoundingClientRect();
-                    var localX = ((event.clientX - rect.left) / rect.width) * width;
-                    var idx = Math.round((localX - margin.left) / barStep - 0.5);
-                    idx = Math.max(0, Math.min(timestamps.length - 1, idx));
-
-                    tooltip.innerHTML =
-                        '<div><span class="chart-tooltip-label">Time:</span> ' + formatTime(timestamps[idx]) + '</div>' +
-                        '<div><span class="chart-tooltip-label">Succeeded:</span> ' + formatCount(succeeded[idx] || 0) + '</div>' +
-                        '<div><span class="chart-tooltip-label">Failed:</span> ' + formatCount(failed[idx] || 0) + '</div>' +
-                        '<div><span class="chart-tooltip-label">Panicked:</span> ' + formatCount(panicked[idx] || 0) + '</div>' +
-                        '<div><span class="chart-tooltip-label">Total:</span> ' + formatCount(totals[idx] || 0) + '</div>';
-                    tooltip.classList.remove('hidden');
-
-                    var x = event.clientX - rect.left;
-                    var y = event.clientY - rect.top;
-                    var halfWidth = tooltip.offsetWidth / 2;
-                    var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
-                    var top = Math.max(y - 12, tooltip.offsetHeight + 8);
-
-                    tooltip.style.left = left + 'px';
-                    tooltip.style.top = top + 'px';
-                });
-
-                svg.addEventListener('mouseleave', function () {
-                    tooltip.classList.add('hidden');
-                });
-            }
-
-            renderChart(
-                'average-chart',
-                {{ self.detail_average_chart_data_json()|safe }},
-                'Avg',
-                '#c084fc',
-                'rgba(192, 132, 252, 0.10)',
-                formatMillis
-            );
-            renderExecutionsChart(
-                'executions-chart',
-                {{ self.detail_total_chart_data_json()|safe }}
-            );
+            var average = {{ self.detail_average_chart_data_json()|safe }};
+            oxanaCharts.renderChart('average-chart', {
+                timestamps: average[0],
+                series: [{ label: 'Avg', data: average[1], color: '#c084fc', fill: 'rgba(192, 132, 252, 0.10)' }]
+            }, formatMillis, function (idx) {
+                return [{ label: 'Avg', value: formatMillis(average[1][idx]) }];
+            });
+            var executions = {{ self.detail_total_chart_data_json()|safe }};
+            oxanaCharts.renderStackedChart('executions-chart', {
+                timestamps: executions[0],
+                series: [
+                    { label: 'Succeeded', data: executions[1], color: '#34d399' },
+                    { label: 'Failed', data: executions[2], color: '#ef4444' },
+                    { label: 'Panicked', data: executions[3], color: '#000000', border: '#6b7280' }
+                ]
+            }, 'Total executions by minute', function (idx, total) {
+                return [
+                    { label: 'Succeeded', value: oxanaCharts.formatCount(executions[1][idx] || 0) },
+                    { label: 'Failed', value: oxanaCharts.formatCount(executions[2][idx] || 0) },
+                    { label: 'Panicked', value: oxanaCharts.formatCount(executions[3][idx] || 0) },
+                    { label: 'Total', value: oxanaCharts.formatCount(total) }
+                ];
+            });
         });
     </script>
 </body>

--- a/oxana-web/templates/metrics.html
+++ b/oxana-web/templates/metrics.html
@@ -5,36 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Metrics - Oxana</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.min.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.iife.min.js"></script>
-    <style>
-        .uplot {
-            color: #d1d5db;
-            background: transparent;
-        }
-        .chart-tooltip {
-            position: absolute;
-            z-index: 10;
-            min-width: 9rem;
-            pointer-events: none;
-            border: 1px solid #374151;
-            border-radius: 0.375rem;
-            background: rgba(17, 24, 39, 0.96);
-            color: #f9fafb;
-            padding: 0.5rem 0.625rem;
-            font-size: 0.75rem;
-            line-height: 1.25rem;
-            white-space: nowrap;
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.35);
-            transform: translate(-50%, -100%);
-        }
-        .chart-tooltip.hidden {
-            display: none;
-        }
-        .chart-tooltip-label {
-            color: #9ca3af;
-        }
-    </style>
+    {% let tooltip_min_width = 9 %}
+    {% include "_chart_head.html" %}
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
     <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -143,19 +115,11 @@
         </section>
     </div>
 
+    {% include "_charts.html" %}
     <script>
         window.addEventListener('DOMContentLoaded', function () {
             if (typeof uPlot === 'undefined') {
                 return;
-            }
-
-            function formatTime(ts) {
-                return new Date(ts * 1000).toLocaleString(undefined, {
-                    month: 'numeric',
-                    day: 'numeric',
-                    hour: 'numeric',
-                    minute: '2-digit'
-                });
             }
 
             function formatSeconds(value) {
@@ -165,320 +129,18 @@
                 return value.toFixed(1) + 's';
             }
 
-            function formatCount(value) {
-                return Math.round(value).toLocaleString();
-            }
-
-            var palette = [
-                '#60a5fa',
-                '#4ade80',
-                '#f472b6',
-                '#facc15',
-                '#a78bfa',
-                '#2dd4bf',
-                '#fb923c',
-                '#94a3b8'
-            ];
-
-            function seriesColor(index) {
-                return palette[index % palette.length];
-            }
-
-            function sortedSeriesRows(payload, idx) {
-                return payload.series.map(function (series, seriesIdx) {
-                    return {
-                        series: series,
-                        seriesIdx: seriesIdx,
-                        value: series.data[idx] || 0
-                    };
-                }).sort(function (a, b) {
-                    return (b.value - a.value) || (a.seriesIdx - b.seriesIdx);
-                });
-            }
-
-            function buildTooltip(chartEl, payload, formatter, options) {
-                options = options || {};
-                var tooltip = document.createElement('div');
-                tooltip.className = 'chart-tooltip hidden';
-                chartEl.appendChild(tooltip);
-
-                chartEl.addEventListener('mouseleave', function () {
-                    tooltip.classList.add('hidden');
-                });
-
-                return function (u) {
-                    var idx = u.cursor.idx;
-                    if (idx == null || idx < 0 || idx >= payload.timestamps.length) {
-                        tooltip.classList.add('hidden');
-                        return;
-                    }
-
-                    tooltip.replaceChildren();
-
-                    var time = document.createElement('div');
-                    var timeLabel = document.createElement('span');
-                    timeLabel.className = 'chart-tooltip-label';
-                    timeLabel.textContent = 'Time: ';
-                    time.appendChild(timeLabel);
-                    time.append(formatTime(payload.timestamps[idx]));
-                    tooltip.appendChild(time);
-
-                    sortedSeriesRows(payload, idx).filter(function (entry) {
-                        return options.includeZeroValues !== false || entry.value !== 0;
-                    }).forEach(function (entry) {
-                        var row = document.createElement('div');
-                        var label = document.createElement('span');
-                        label.className = 'chart-tooltip-label';
-                        label.textContent = (entry.series.fullLabel || entry.series.label) + ': ';
-                        label.style.color = seriesColor(entry.seriesIdx);
-                        row.appendChild(label);
-                        row.append(formatter(entry.value));
-                        tooltip.appendChild(row);
-                    });
-
-                    tooltip.classList.remove('hidden');
-
-                    var x = u.over.offsetLeft + u.cursor.left;
-                    var y = u.over.offsetTop + u.cursor.top;
-                    var halfWidth = tooltip.offsetWidth / 2;
-                    var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
-                    var top = Math.max(y - 12, tooltip.offsetHeight + 8);
-
-                    tooltip.style.left = left + 'px';
-                    tooltip.style.top = top + 'px';
-                };
-            }
-
-            function renderChart(chartId, payload, valueFormatter, options) {
-                var chartEl = document.getElementById(chartId);
-                if (!chartEl) {
-                    return;
+            var execution = {{ self.execution_chart_data_json()|safe }};
+            oxanaCharts.renderChart('execution-chart', execution, formatSeconds, function (idx) {
+                return oxanaCharts.seriesTooltipRows(execution, idx, formatSeconds);
+            });
+            var processed = {{ self.processed_chart_data_json()|safe }};
+            oxanaCharts.renderStackedChart('processed-chart', processed, 'Total processed by worker', function (idx, total) {
+                var rows = oxanaCharts.seriesTooltipRows(processed, idx, oxanaCharts.formatCount);
+                if (total !== 0) {
+                    rows.push({ label: 'Total', value: oxanaCharts.formatCount(total) });
                 }
-
-                var data = [payload.timestamps].concat(payload.series.map(function (series) {
-                    return series.data;
-                }));
-
-                new uPlot({
-                    width: Math.max(chartEl.clientWidth, 320),
-                    height: 300,
-                    legend: { show: false },
-                    tzDate: function (ts) { return uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'); },
-                    scales: {
-                        x: { time: true },
-                        y: { range: [0, null] }
-                    },
-                    axes: [
-                        {
-                            stroke: '#9ca3af',
-                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
-                            ticks: { stroke: '#374151' }
-                        },
-                        {
-                            size: 72,
-                            stroke: '#9ca3af',
-                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
-                            ticks: { stroke: '#374151' },
-                            values: function (_u, vals) {
-                                return vals.map(valueFormatter);
-                            }
-                        }
-                    ],
-                    series: [
-                        {}
-                    ].concat(payload.series.map(function (series, index) {
-                        return {
-                            label: series.label,
-                            stroke: seriesColor(index),
-                            width: 2
-                        };
-                    })),
-                    hooks: {
-                        setCursor: [buildTooltip(chartEl, payload, valueFormatter, options)]
-                    }
-                }, data, chartEl);
-            }
-
-            function svgEl(name) {
-                return document.createElementNS('http://www.w3.org/2000/svg', name);
-            }
-
-            function formatShortTime(ts) {
-                return new Date(ts * 1000).toLocaleString(undefined, {
-                    hour: 'numeric',
-                    minute: '2-digit'
-                });
-            }
-
-            function renderStackedProcessedChart(chartId, payload) {
-                var chartEl = document.getElementById(chartId);
-                if (!chartEl) {
-                    return;
-                }
-
-                var width = Math.max(chartEl.clientWidth, 320);
-                var height = 300;
-                var margin = { top: 12, right: 16, bottom: 44, left: 72 };
-                var plotWidth = width - margin.left - margin.right;
-                var plotHeight = height - margin.top - margin.bottom;
-                var timestamps = payload.timestamps;
-                var totals = timestamps.map(function (_ts, idx) {
-                    return payload.series.reduce(function (sum, series) {
-                        return sum + (series.data[idx] || 0);
-                    }, 0);
-                });
-                var maxTotal = Math.max.apply(null, totals.concat([1]));
-                var barStep = plotWidth / Math.max(timestamps.length, 1);
-                var barWidth = Math.max(1, Math.min(18, barStep * 0.72));
-                var bottom = margin.top + plotHeight;
-
-                chartEl.replaceChildren();
-
-                var tooltip = document.createElement('div');
-                tooltip.className = 'chart-tooltip hidden';
-                chartEl.appendChild(tooltip);
-
-                var svg = svgEl('svg');
-                svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
-                svg.setAttribute('width', '100%');
-                svg.setAttribute('height', height.toString());
-                svg.setAttribute('role', 'img');
-                svg.setAttribute('aria-label', 'Total processed by worker');
-                chartEl.appendChild(svg);
-
-                for (var tick = 0; tick <= 4; tick += 1) {
-                    var value = Math.round((maxTotal * tick) / 4);
-                    var y = bottom - (plotHeight * value / maxTotal);
-
-                    var grid = svgEl('line');
-                    grid.setAttribute('x1', margin.left.toString());
-                    grid.setAttribute('x2', (width - margin.right).toString());
-                    grid.setAttribute('y1', y.toString());
-                    grid.setAttribute('y2', y.toString());
-                    grid.setAttribute('stroke', 'rgba(31, 41, 55, 0.7)');
-                    svg.appendChild(grid);
-
-                    var label = svgEl('text');
-                    label.setAttribute('x', (margin.left - 14).toString());
-                    label.setAttribute('y', (y + 4).toString());
-                    label.setAttribute('text-anchor', 'end');
-                    label.setAttribute('fill', '#9ca3af');
-                    label.setAttribute('font-size', '12');
-                    label.textContent = formatCount(value);
-                    svg.appendChild(label);
-                }
-
-                var xTickIndexes = Array.from(new Set([
-                    0,
-                    Math.floor((timestamps.length - 1) / 3),
-                    Math.floor(((timestamps.length - 1) * 2) / 3),
-                    timestamps.length - 1
-                ])).filter(function (idx) {
-                    return idx >= 0 && idx < timestamps.length;
-                });
-
-                xTickIndexes.forEach(function (idx) {
-                    var x = margin.left + (idx + 0.5) * barStep;
-                    var label = svgEl('text');
-                    label.setAttribute('x', x.toString());
-                    label.setAttribute('y', (height - 14).toString());
-                    label.setAttribute('text-anchor', 'middle');
-                    label.setAttribute('fill', '#9ca3af');
-                    label.setAttribute('font-size', '12');
-                    label.textContent = formatShortTime(timestamps[idx]);
-                    svg.appendChild(label);
-                });
-
-                function appendSegment(idx, value, offset, seriesIdx) {
-                    if (value <= 0) {
-                        return;
-                    }
-
-                    var segmentHeight = Math.max(1, plotHeight * value / maxTotal);
-                    var y = bottom - (plotHeight * (offset + value) / maxTotal);
-                    var rect = svgEl('rect');
-                    rect.setAttribute('x', (margin.left + idx * barStep + (barStep - barWidth) / 2).toString());
-                    rect.setAttribute('y', y.toString());
-                    rect.setAttribute('width', barWidth.toString());
-                    rect.setAttribute('height', segmentHeight.toString());
-                    rect.setAttribute('fill', seriesColor(seriesIdx));
-                    svg.appendChild(rect);
-                }
-
-                timestamps.forEach(function (_ts, idx) {
-                    var offset = 0;
-                    payload.series.forEach(function (series, seriesIdx) {
-                        var value = series.data[idx] || 0;
-                        appendSegment(idx, value, offset, seriesIdx);
-                        offset += value;
-                    });
-                });
-
-                svg.addEventListener('mousemove', function (event) {
-                    var rect = svg.getBoundingClientRect();
-                    var localX = ((event.clientX - rect.left) / rect.width) * width;
-                    var idx = Math.round((localX - margin.left) / barStep - 0.5);
-                    idx = Math.max(0, Math.min(timestamps.length - 1, idx));
-
-                    tooltip.replaceChildren();
-
-                    var time = document.createElement('div');
-                    var timeLabel = document.createElement('span');
-                    timeLabel.className = 'chart-tooltip-label';
-                    timeLabel.textContent = 'Time: ';
-                    time.appendChild(timeLabel);
-                    time.append(formatTime(timestamps[idx]));
-                    tooltip.appendChild(time);
-
-                    sortedSeriesRows(payload, idx).filter(function (entry) {
-                        return entry.value !== 0;
-                    }).forEach(function (entry) {
-                        var row = document.createElement('div');
-                        var label = document.createElement('span');
-                        label.className = 'chart-tooltip-label';
-                        label.textContent = (entry.series.fullLabel || entry.series.label) + ': ';
-                        label.style.color = seriesColor(entry.seriesIdx);
-                        row.appendChild(label);
-                        row.append(formatCount(entry.value));
-                        tooltip.appendChild(row);
-                    });
-
-                    if ((totals[idx] || 0) !== 0) {
-                        var total = document.createElement('div');
-                        var totalLabel = document.createElement('span');
-                        totalLabel.className = 'chart-tooltip-label';
-                        totalLabel.textContent = 'Total: ';
-                        total.appendChild(totalLabel);
-                        total.append(formatCount(totals[idx] || 0));
-                        tooltip.appendChild(total);
-                    }
-                    tooltip.classList.remove('hidden');
-
-                    var x = event.clientX - rect.left;
-                    var y = event.clientY - rect.top;
-                    var halfWidth = tooltip.offsetWidth / 2;
-                    var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
-                    var top = Math.max(y - 12, tooltip.offsetHeight + 8);
-
-                    tooltip.style.left = left + 'px';
-                    tooltip.style.top = top + 'px';
-                });
-
-                svg.addEventListener('mouseleave', function () {
-                    tooltip.classList.add('hidden');
-                });
-            }
-
-            renderChart(
-                'execution-chart',
-                {{ self.execution_chart_data_json()|safe }},
-                formatSeconds,
-                { includeZeroValues: false }
-            );
-            renderStackedProcessedChart(
-                'processed-chart',
-                {{ self.processed_chart_data_json()|safe }}
-            );
+                return rows;
+            });
         });
     </script>
 </body>

--- a/oxana-web/templates/queue_detail.html
+++ b/oxana-web/templates/queue_detail.html
@@ -144,8 +144,8 @@
                     {% match item.job_envelope.meta.state %}
                     {% when Some with (state) %}
                     {% if state|has_args %}
-                    {% if state|show_job_progress %}
                     {% let progress_started_at = item.job_envelope.meta.started_at %}
+                    {% if let Some(progress) = state|job_progress(progress_started_at) %}
                     {% include "_job_progress.html" %}
                     {% else %}
                     <details class="mt-3">
@@ -171,34 +171,34 @@
             <div>
                 <h2 class="text-lg font-semibold">Enqueued</h2>
                 <div class="mt-1 text-sm text-gray-400">
-                {% if total > 0 %}
-                {{ self.range_start() }}&ndash;{{ self.range_end() }} of {{ total }} jobs
+                {% if page.total > 0 %}
+                {{ page.range_start() }}&ndash;{{ page.range_end() }} of {{ page.total }} jobs
                 {% else %}
                 0 jobs
                 {% endif %}
                 </div>
             </div>
             <div class="flex items-center gap-2 text-sm">
-                {% if page > 1 %}
-                <a href="?page={{ page - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
+                {% if page.number > 1 %}
+                <a href="?page={{ page.number - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
                 {% else %}
                 <span class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed">&larr; Prev</span>
                 {% endif %}
-                {% if has_next %}
-                <a href="?page={{ page + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
+                {% if page.has_next %}
+                <a href="?page={{ page.number + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
                 {% else %}
                 <span class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed">Next &rarr;</span>
                 {% endif %}
             </div>
         </div>
 
-        {% if jobs.is_empty() %}
+        {% if page.jobs.is_empty() %}
         <div class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500">
             No jobs in this queue
         </div>
         {% else %}
         <div class="space-y-3">
-            {% for job in &jobs %}
+            {% for job in &page.jobs %}
             <div class="bg-gray-900 border border-gray-800 rounded-lg p-4">
                 <div class="flex items-start justify-between mb-2">
                     <span class="font-semibold text-sm">{{ job.job.name }}</span>
@@ -229,8 +229,8 @@
                 {% match job.meta.state %}
                 {% when Some with (state) %}
                 {% if state|has_args %}
-                {% if state|show_job_progress %}
                 {% let progress_started_at = job.meta.started_at %}
+                {% if let Some(progress) = state|job_progress(progress_started_at) %}
                 {% include "_job_progress.html" %}
                 {% else %}
                 <details class="mt-3">
@@ -251,13 +251,13 @@
         </div>
 
         <div class="flex items-center justify-between mt-6 text-sm">
-            <span class="text-gray-500">{{ self.range_start() }}&ndash;{{ self.range_end() }} of {{ total }}</span>
+            <span class="text-gray-500">{{ page.range_start() }}&ndash;{{ page.range_end() }} of {{ page.total }}</span>
             <div class="flex items-center gap-2">
-                {% if page > 1 %}
-                <a href="?page={{ page - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
+                {% if page.number > 1 %}
+                <a href="?page={{ page.number - 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">&larr; Prev</a>
                 {% endif %}
-                {% if has_next %}
-                <a href="?page={{ page + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
+                {% if page.has_next %}
+                <a href="?page={{ page.number + 1 }}" class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300">Next &rarr;</a>
                 {% endif %}
             </div>
         </div>

--- a/oxana-web/templates/queues.html
+++ b/oxana-web/templates/queues.html
@@ -5,36 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Queues - Oxana</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.min.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.iife.min.js"></script>
-    <style>
-        .uplot {
-            color: #d1d5db;
-            background: transparent;
-        }
-        .chart-tooltip {
-            position: absolute;
-            z-index: 10;
-            min-width: 9rem;
-            pointer-events: none;
-            border: 1px solid #374151;
-            border-radius: 0.375rem;
-            background: rgba(17, 24, 39, 0.96);
-            color: #f9fafb;
-            padding: 0.5rem 0.625rem;
-            font-size: 0.75rem;
-            line-height: 1.25rem;
-            white-space: nowrap;
-            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.35);
-            transform: translate(-50%, -100%);
-        }
-        .chart-tooltip.hidden {
-            display: none;
-        }
-        .chart-tooltip-label {
-            color: #9ca3af;
-        }
-    </style>
+    {% let tooltip_min_width = 9 %}
+    {% include "_chart_head.html" %}
 </head>
 <body class="bg-gray-950 text-gray-100 min-h-screen">
     <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -127,161 +99,17 @@
         </div>
         {% endif %}
     </div>
+    {% include "_charts.html" %}
     <script>
         window.addEventListener('DOMContentLoaded', function () {
             if (typeof uPlot === 'undefined') {
                 return;
             }
 
-            function formatTime(ts) {
-                return new Date(ts * 1000).toLocaleString(undefined, {
-                    month: 'numeric',
-                    day: 'numeric',
-                    hour: 'numeric',
-                    minute: '2-digit'
-                });
-            }
-
-            function formatCount(value) {
-                return Math.round(value).toLocaleString();
-            }
-
-            var palette = [
-                '#60a5fa',
-                '#4ade80',
-                '#f472b6',
-                '#facc15',
-                '#a78bfa',
-                '#2dd4bf',
-                '#fb923c',
-                '#94a3b8'
-            ];
-
-            function seriesColor(index) {
-                return palette[index % palette.length];
-            }
-
-            function sortedSeriesRows(payload, idx) {
-                return payload.series.map(function (series, seriesIdx) {
-                    return {
-                        series: series,
-                        seriesIdx: seriesIdx,
-                        value: series.data[idx] || 0
-                    };
-                }).sort(function (a, b) {
-                    return (b.value - a.value) || (a.seriesIdx - b.seriesIdx);
-                });
-            }
-
-            function buildTooltip(chartEl, payload, formatter, options) {
-                options = options || {};
-                var tooltip = document.createElement('div');
-                tooltip.className = 'chart-tooltip hidden';
-                chartEl.appendChild(tooltip);
-
-                chartEl.addEventListener('mouseleave', function () {
-                    tooltip.classList.add('hidden');
-                });
-
-                return function (u) {
-                    var idx = u.cursor.idx;
-                    if (idx == null || idx < 0 || idx >= payload.timestamps.length) {
-                        tooltip.classList.add('hidden');
-                        return;
-                    }
-
-                    tooltip.replaceChildren();
-
-                    var time = document.createElement('div');
-                    var timeLabel = document.createElement('span');
-                    timeLabel.className = 'chart-tooltip-label';
-                    timeLabel.textContent = 'Time: ';
-                    time.appendChild(timeLabel);
-                    time.append(formatTime(payload.timestamps[idx]));
-                    tooltip.appendChild(time);
-
-                    sortedSeriesRows(payload, idx).filter(function (entry) {
-                        return options.includeZeroValues !== false || entry.value !== 0;
-                    }).forEach(function (entry) {
-                        var row = document.createElement('div');
-                        var label = document.createElement('span');
-                        label.className = 'chart-tooltip-label';
-                        label.textContent = entry.series.label + ': ';
-                        label.style.color = seriesColor(entry.seriesIdx);
-                        row.appendChild(label);
-                        row.append(formatter(entry.value));
-                        tooltip.appendChild(row);
-                    });
-
-                    tooltip.classList.remove('hidden');
-
-                    var x = u.over.offsetLeft + u.cursor.left;
-                    var y = u.over.offsetTop + u.cursor.top;
-                    var halfWidth = tooltip.offsetWidth / 2;
-                    var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
-                    var top = Math.max(y - 12, tooltip.offsetHeight + 8);
-
-                    tooltip.style.left = left + 'px';
-                    tooltip.style.top = top + 'px';
-                };
-            }
-
-            function renderChart(chartId, payload, valueFormatter, options) {
-                var chartEl = document.getElementById(chartId);
-                if (!chartEl) {
-                    return;
-                }
-
-                var data = [payload.timestamps].concat(payload.series.map(function (series) {
-                    return series.data;
-                }));
-
-                new uPlot({
-                    width: Math.max(chartEl.clientWidth, 320),
-                    height: 300,
-                    legend: { show: false },
-                    tzDate: function (ts) { return uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'); },
-                    scales: {
-                        x: { time: true },
-                        y: { range: [0, null] }
-                    },
-                    axes: [
-                        {
-                            stroke: '#9ca3af',
-                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
-                            ticks: { stroke: '#374151' }
-                        },
-                        {
-                            size: 72,
-                            stroke: '#9ca3af',
-                            grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
-                            ticks: { stroke: '#374151' },
-                            values: function (_u, vals) {
-                                return vals.map(valueFormatter);
-                            }
-                        }
-                    ],
-                    series: [
-                        {}
-                    ].concat(payload.series.map(function (series, index) {
-                        return {
-                            label: series.label,
-                            stroke: seriesColor(index),
-                            width: 2
-                        };
-                    })),
-                    hooks: {
-                        setCursor: [buildTooltip(chartEl, payload, valueFormatter, options)]
-                    }
-                }, data, chartEl);
-            }
-
-            renderChart(
-                'queue-length-chart',
-                {{ self.queue_length_chart_data_json()|safe }},
-                formatCount,
-                { includeZeroValues: false }
-            );
+            var payload = {{ self.queue_length_chart_data_json()|safe }};
+            oxanaCharts.renderChart('queue-length-chart', payload, oxanaCharts.formatCount, function (idx) {
+                return oxanaCharts.seriesTooltipRows(payload, idx, oxanaCharts.formatCount);
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
The dashboard repeats chart rendering, pagination assembly, and progress parsing across several pages. Share these implementations within `oxana-web` while preserving the public Rust API, routes, and displayed behavior. This removes 400 lines overall.

- Extract shared chart styles, line and stacked-bar renderers, and tooltip handling while retaining each page's formatting and series ordering.
- Use one private pagination model for queue, scheduled, dead, and retry lists, preserving the 50-job page size and lookahead behavior.
- Parse and format progress once per rendered component, preserving notes, ETA, escaping, and fallback state display.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace --all-targets -- -D warnings`
- `cargo test -p oxana-web --lib --quiet`: 67 tests passed, including new pagination and progress regressions.
- Temporary verification harnesses: 108 old/new chart scenarios matched and 34 HTTP checks passed against isolated Redis data. The harnesses are outside the repository; they add no project dependencies.

Visual browser verification was unavailable because this host has no attached browser panes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only changes to templates and private web helpers with regression tests; no auth, storage API, or routing changes beyond equivalent pagination assembly.
> 
> **Overview**
> Consolidates repeated **oxana-web** dashboard logic so charting, job list paging, and in-job progress UI share one implementation while keeping routes and on-screen behavior the same.
> 
> **Job progress** replaces several Askama filters (`show_job_progress`, percent/summary/note/ETA) with a single `job_progress` filter that returns an optional `ProgressView`. Templates branch on `Some(progress)` and `_job_progress.html` reads preformatted fields, with new unit tests for tuple/object states, percent clamping, and HTML escaping of notes.
> 
> **Pagination** introduces `JobPage` (`list_opts`, 50-item pages + one lookahead row, `has_next`, range labels). Scheduled, dead, retry, and queue detail handlers route through `global_jobs` or `JobPage::new` instead of duplicating truncate/offset logic; list templates use `page.jobs`, `page.number`, and `page.has_next`.
> 
> **Charts** move uPlot assets, tooltip styling, line charts, and stacked bar rendering into `_chart_head.html` and `_charts.html` (`oxanaCharts`). Metrics, metric detail, and queues pages keep their formatters and series but drop large inline script blocks in favor of thin page-specific init code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326c311af554f67c726b9c89ac10b66cb0f07abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->