### PR TITLE
refactor: share Redis background polling loop

### DIFF
--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -48,6 +48,7 @@ rand = "^0.10"
 sentry-core = { version = "=0.48.5", features = ["test"] }
 sentry-panic = "=0.48.5"
 testresult = "^0.4"
+tokio = { version = "^1.52", features = ["test-util"] }
 tracing-subscriber = { version = "^0.3", features = ["env-filter"] }
 trybuild = "1.0"
 

--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -1685,6 +1685,27 @@ impl StorageInternal {
         })
     }
 
+    async fn poll_redis<T, F, Fut>(
+        &self,
+        cancel_token: CancellationToken,
+        poll_interval: Duration,
+        failure_tolerance: u32,
+        mut operation: F,
+    ) -> Result<(), OxanaError>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<T, OxanaError>>,
+    {
+        loop {
+            tokio::select! {
+                _ = cancel_token.cancelled() => return Ok(()),
+                _ = tokio::time::sleep(poll_interval) => {
+                    self.track_redis_result(operation().await, failure_tolerance)?;
+                }
+            }
+        }
+    }
+
     pub async fn retry_loop(
         &self,
         cancel_token: CancellationToken,
@@ -1693,16 +1714,10 @@ impl StorageInternal {
     ) -> Result<(), OxanaError> {
         tracing::info!("Starting retry loop");
 
-        loop {
-            tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    return Ok(());
-                }
-                _ = tokio::time::sleep(poll_interval) => {
-                    self.track_redis_result(self.enqueue_scheduled(&self.keys.retry).await, failure_tolerance)?;
-                }
-            }
-        }
+        self.poll_redis(cancel_token, poll_interval, failure_tolerance, || {
+            self.enqueue_scheduled(&self.keys.retry)
+        })
+        .await
     }
 
     pub async fn schedule_loop(
@@ -1713,16 +1728,10 @@ impl StorageInternal {
     ) -> Result<(), OxanaError> {
         tracing::info!("Starting schedule loop");
 
-        loop {
-            tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    return Ok(());
-                }
-                _ = tokio::time::sleep(poll_interval) => {
-                    self.track_redis_result(self.enqueue_scheduled(&self.keys.schedule).await, failure_tolerance)?;
-                }
-            }
-        }
+        self.poll_redis(cancel_token, poll_interval, failure_tolerance, || {
+            self.enqueue_scheduled(&self.keys.schedule)
+        })
+        .await
     }
 
     pub async fn cleanup_loop(
@@ -1732,16 +1741,13 @@ impl StorageInternal {
     ) -> Result<(), OxanaError> {
         tracing::info!("Starting cleanup loop");
 
-        loop {
-            tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    return Ok(());
-                }
-                _ = tokio::time::sleep(tokio::time::Duration::from_secs(600)) => {
-                    self.track_redis_result(self.cleanup().await, failure_tolerance)?;
-                }
-            }
-        }
+        self.poll_redis(
+            cancel_token,
+            Duration::from_secs(600),
+            failure_tolerance,
+            || self.cleanup(),
+        )
+        .await
     }
 
     pub async fn ping_loop(
@@ -1750,16 +1756,10 @@ impl StorageInternal {
         heartbeat_interval: Duration,
         failure_tolerance: u32,
     ) -> Result<(), OxanaError> {
-        loop {
-            tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    return Ok(());
-                }
-                _ = tokio::time::sleep(heartbeat_interval) => {
-                    self.track_redis_result(self.ping().await, failure_tolerance)?;
-                }
-            }
-        }
+        self.poll_redis(cancel_token, heartbeat_interval, failure_tolerance, || {
+            self.ping()
+        })
+        .await
     }
 
     pub async fn ping(&self) -> Result<(), OxanaError> {
@@ -1885,16 +1885,10 @@ impl StorageInternal {
             tokio::time::sleep(scan_interval).await;
         }
 
-        loop {
-            tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    return Ok(());
-                }
-                _ = tokio::time::sleep(scan_interval) => {
-                    self.track_redis_result(self.resurrect(dead_process_threshold).await, failure_tolerance)?;
-                }
-            }
-        }
+        self.poll_redis(cancel_token, scan_interval, failure_tolerance, || {
+            self.resurrect(dead_process_threshold)
+        })
+        .await
     }
 
     pub async fn cron_job_loop<F>(
@@ -2315,6 +2309,7 @@ fn redis_metric_increment(value: u64) -> i64 {
 mod tests {
     use super::*;
     use crate::test_helper::{random_string, redis_pool};
+    use futures::FutureExt;
     use rand::RngExt;
     use serde::Serialize;
     use testresult::TestResult;
@@ -2323,6 +2318,98 @@ mod tests {
     struct TestJob {}
 
     impl crate::worker::Job for TestJob {}
+
+    #[tokio::test(start_paused = true)]
+    async fn polling_waits_before_each_operation_and_finishes_in_flight_work() -> TestResult {
+        let storage = crate::Storage::from_url("redis://127.0.0.1/0")?.internal;
+        let cancel = CancellationToken::new();
+        let calls = std::cell::Cell::new(0);
+        let poll = storage.poll_redis(cancel.clone(), Duration::from_secs(10), 3, || {
+            calls.set(calls.get() + 1);
+            async {
+                tokio::time::sleep(Duration::from_secs(4)).await;
+                Ok(())
+            }
+        });
+        tokio::pin!(poll);
+
+        assert!(poll.as_mut().now_or_never().is_none());
+        tokio::time::advance(Duration::from_secs(9)).await;
+        assert!(poll.as_mut().now_or_never().is_none());
+        assert_eq!(calls.get(), 0);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(poll.as_mut().now_or_never().is_none());
+        assert_eq!(calls.get(), 1);
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert!(poll.as_mut().now_or_never().is_none());
+        tokio::time::advance(Duration::from_secs(9)).await;
+        assert!(poll.as_mut().now_or_never().is_none());
+        assert_eq!(calls.get(), 1);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert!(poll.as_mut().now_or_never().is_none());
+        assert_eq!(calls.get(), 2);
+        cancel.cancel();
+        assert!(poll.as_mut().now_or_never().is_none());
+        tokio::time::advance(Duration::from_secs(4)).await;
+        poll.await?;
+        assert_eq!(calls.get(), 2);
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn polling_cancels_while_waiting_without_starting_an_operation() -> TestResult {
+        let storage = crate::Storage::from_url("redis://127.0.0.1/0")?.internal;
+        let cancel = CancellationToken::new();
+        let calls = std::cell::Cell::new(0);
+        let poll = storage.poll_redis(cancel.clone(), Duration::from_secs(10), 3, || {
+            calls.set(calls.get() + 1);
+            std::future::ready(Ok(()))
+        });
+        tokio::pin!(poll);
+
+        assert!(poll.as_mut().now_or_never().is_none());
+        cancel.cancel();
+        poll.await?;
+        assert_eq!(calls.get(), 0);
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn polling_shares_failure_tracking_and_resets_it_after_success() -> TestResult {
+        let storage = crate::Storage::from_url("redis://127.0.0.1/0")?.internal;
+        let failure = || Err::<(), _>(OxanaError::GenericError("redis failure".to_string()));
+        assert!(storage.clone().track_redis_result(failure(), 2)?.is_none());
+
+        let calls = std::cell::Cell::new(0);
+        let result = storage
+            .poll_redis(CancellationToken::new(), Duration::from_secs(1), 2, || {
+                calls.set(calls.get() + 1);
+                std::future::ready(failure())
+            })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 1);
+
+        calls.set(0);
+        let mut successes = [true, false, true, false, false].into_iter();
+        let result = storage
+            .poll_redis(CancellationToken::new(), Duration::from_secs(1), 2, || {
+                calls.set(calls.get() + 1);
+                std::future::ready(
+                    if successes.next().expect("loop should stop at threshold") {
+                        Ok(())
+                    } else {
+                        failure()
+                    },
+                )
+            })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(calls.get(), 5);
+        Ok(())
+    }
 
     #[test]
     fn unique_cron_skips_an_observed_occurrence_if_it_vanishes_after_due() {


### PR DESCRIPTION
Five background loops repeat the same sleep, cancellation, and Redis failure handling. Extract one private `poll_redis` helper used by retries, scheduling, cleanup, heartbeat, and the recurring resurrection scan.

Each operation still waits before its first run and after the previous operation completes. Cancellation waits for an in-flight operation to finish; the shared Redis failure counter and resurrection's initial ping sequence retain their existing behavior. Public API and Redis commands are unchanged.

Validation:

- Three deterministic tests cover polling cadence, cancellation, and shared failure tracking/reset. Tokio's `test-util` feature is enabled only for development tests.
- `cargo nextest run -p oxana --all-features --lib --test integration --test-threads 2 --no-fail-fast`: 171 passed.
- `cargo test -p oxana --lib --no-default-features`: 103 passed.
- Workspace formatting and `cargo clippy --all-features --workspace --all-targets -- -D warnings` passed.

Redis tests ran against an isolated Redis 8 instance with persistence disabled after the shared instance rejected writes because its persistence disk was full.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no public API or Redis command changes, backed by new deterministic polling tests; risk is mainly regressions in background loop timing or shutdown semantics.
> 
> **Overview**
> Duplicates the same **sleep → run Redis op → track failures → repeat** pattern across retry, schedule, cleanup, heartbeat, and resurrection background loops into a private **`poll_redis`** helper that takes a closure for each operation.
> 
> **`retry_loop`**, **`schedule_loop`**, **`cleanup_loop`**, **`ping_loop`**, and the post-startup phase of **`resurrect_loop`** now delegate to that helper; resurrection still runs its initial ping bootstrap before polling. Intended behavior is unchanged: wait the full interval before the first run and between completed runs, honor cancellation (including finishing in-flight work), and reuse the shared consecutive Redis failure counter via **`track_redis_result`**.
> 
> Adds three **`#[tokio::test(start_paused = true)]`** unit tests for polling cadence, cancel-during-wait, and failure-threshold/reset behavior, and enables Tokio’s **`test-util`** feature only under **`dev-dependencies`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5a7978b1d33c759c06ddf554887003561fa9a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->