### PR TITLE
refactor: simplify worker execution outcomes

### DIFF
--- a/oxana/src/coordinator.rs
+++ b/oxana/src/coordinator.rs
@@ -8,10 +8,10 @@ use tokio::time::MissedTickBehavior;
 use crate::WorkerBatchConfig;
 use crate::context::ContextValue;
 use crate::error::OxanaError;
-use crate::executor::{ExecutionError, ExecutionOutcome};
+use crate::executor::ExecutionOutcome;
 use crate::job_envelope::JobEnvelope;
 use crate::queue::{QueueConcurrency, QueueConfig, QueueKind, QueueRuntimeConfig};
-use crate::result_collector::{WorkerResult, WorkerResultKind};
+use crate::result_collector::WorkerResult;
 use crate::runtime::Runtime;
 use crate::semaphores_map::{QueueControlsMap, QueuePermit};
 use crate::worker_event::WorkerJob;
@@ -562,23 +562,18 @@ async fn process_result(
     outcome: ExecutionOutcome,
     envelopes: Vec<JobEnvelope>,
 ) {
-    let kind = match outcome.result {
-        Ok(()) => WorkerResultKind::Success,
-        Err(e) => match e {
-            ExecutionError::NotPanic => WorkerResultKind::Failed,
-            ExecutionError::Panic() => WorkerResultKind::Panicked,
-        },
-    };
-
     let job_count = u64::try_from(envelopes.len()).unwrap_or(u64::MAX);
     let Some(first_envelope) = envelopes.into_iter().next() else {
-        tracing::warn!("Worker result with no envelopes, dropping {:?}", kind);
+        tracing::warn!(
+            "Worker result with no envelopes, dropping {:?}",
+            outcome.kind
+        );
         return;
     };
 
     result_tx
         .send(WorkerResult {
-            kind,
+            kind: outcome.kind,
             worker_name: first_envelope.job.name,
             queue: first_envelope.queue,
             execution_ms: outcome.duration_ms,

--- a/oxana/src/executor.rs
+++ b/oxana/src/executor.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use crate::job_envelope::JobEnvelope;
 use crate::job_state::JobState;
+use crate::result_collector::WorkerResultKind;
 use crate::runtime::Runtime;
 use crate::worker::{BoxedProcessable, WorkerError};
 use crate::{
@@ -13,8 +14,9 @@ use crate::{
 
 #[derive(Debug)]
 enum ExecutionResult {
-    NotPanic(Result<(), WorkerError>),
-    Panic(String),
+    Success,
+    Failed(WorkerError),
+    Panicked(String),
 }
 
 struct ProcessResult {
@@ -22,13 +24,8 @@ struct ProcessResult {
     sentry_hub: crate::failure::ExecutionSentryHub,
 }
 
-pub(crate) enum ExecutionError {
-    NotPanic,
-    Panic(),
-}
-
 pub(crate) struct ExecutionOutcome {
-    pub(crate) result: Result<(), ExecutionError>,
+    pub(crate) kind: WorkerResultKind,
     pub(crate) duration_ms: u64,
 }
 
@@ -59,7 +56,7 @@ where
 {
     if envelopes.is_empty() {
         return Ok(ExecutionOutcome {
-            result: Ok(()),
+            kind: WorkerResultKind::Success,
             duration_ms: 0,
         });
     }
@@ -123,14 +120,14 @@ where
 
     let duration = start.elapsed();
     let duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
-    let is_err = !matches!(process_result.result, ExecutionResult::NotPanic(Ok(_)));
+    let success = matches!(process_result.result, ExecutionResult::Success);
     if envelopes.len() == 1 {
         tracing::info!(
             job_id = first_envelope.id,
             queue = queue,
             job = names.job,
             worker = names.worker,
-            success = !is_err,
+            success,
             duration = duration_ms,
             retries = first_envelope.meta.retries,
             "Job finished"
@@ -141,18 +138,15 @@ where
             queue = queue,
             job = names.job,
             worker = names.worker,
-            success = !is_err,
+            success,
             duration = duration_ms,
             "Job batch finished"
         );
     }
 
-    let result =
+    let kind =
         finish_batch_result(config.as_ref(), process_result, envelopes, &policies, names).await;
-    Ok(ExecutionOutcome {
-        result,
-        duration_ms,
-    })
+    Ok(ExecutionOutcome { kind, duration_ms })
 }
 
 struct JobExecutionPolicy {
@@ -179,8 +173,9 @@ async fn run_process(
     let future = AssertUnwindSafe(process(worker, job_contexts, envelope)).catch_unwind();
     let (result, sentry_hub) = crate::failure::with_execution_sentry_hub(future).await;
     let result = match result {
-        Ok(result) => ExecutionResult::NotPanic(result),
-        Err(panic) => ExecutionResult::Panic(panic_message(panic)),
+        Ok(Ok(())) => ExecutionResult::Success,
+        Ok(Err(error)) => ExecutionResult::Failed(error),
+        Err(panic) => ExecutionResult::Panicked(panic_message(panic)),
     };
     ProcessResult { result, sentry_hub }
 }
@@ -201,13 +196,13 @@ async fn finish_batch_result<DT>(
     envelopes: &[JobEnvelope],
     policies: &[JobExecutionPolicy],
     names: ExecutionNames,
-) -> Result<(), ExecutionError>
+) -> WorkerResultKind
 where
     DT: Send + Sync + Clone + 'static,
 {
     let ProcessResult { result, sentry_hub } = process_result;
     match result {
-        ExecutionResult::NotPanic(Ok(())) => {
+        ExecutionResult::Success => {
             if let Err(e) = config
                 .storage
                 .internal
@@ -216,9 +211,9 @@ where
             {
                 tracing::error!("Failed to finish job batch: {}", e);
             }
-            Ok(())
+            WorkerResultKind::Success
         }
-        ExecutionResult::NotPanic(Err(e)) => {
+        ExecutionResult::Failed(e) => {
             let failure_metadata = failure_metadata(envelopes, policies, names);
             config.settings.report_failure(
                 WorkerFailureReport {
@@ -260,9 +255,9 @@ where
                 .await;
             }
 
-            Err(ExecutionError::NotPanic)
+            WorkerResultKind::Failed
         }
-        ExecutionResult::Panic(panic_msg) => {
+        ExecutionResult::Panicked(panic_msg) => {
             let failure_metadata = failure_metadata(envelopes, policies, names);
             config.settings.report_failure(
                 WorkerFailureReport {
@@ -285,7 +280,7 @@ where
                 .await;
             }
 
-            Err(ExecutionError::Panic())
+            WorkerResultKind::Panicked
         }
     }
 }


### PR DESCRIPTION
Worker outcomes currently pass through nested success/error results, a separate `ExecutionError` enum, and a coordinator conversion to `WorkerResultKind`. Make the internal execution result explicit (`Success`, `Failed`, `Panicked`) and pass `WorkerResultKind` directly from execution finalization to the result collector.

Remove the intermediate enum and mapping while preserving error payloads for reporting, panic capture, retry decisions, metrics, and the outer `Result` used for infrastructure errors. Public API and storage behavior are unchanged.

Validation:

- `cargo nextest run -p oxana --all-features --lib --test integration --test-threads 2 --no-fail-fast`: 168 passed, including success/failure/panic, batch, retry override, failure-reporting, and metrics coverage.
- `cargo test -p oxana --lib --no-default-features`: 100 passed.
- Workspace formatting and `cargo clippy --all-features --workspace --all-targets -- -D warnings` passed.

Redis tests used an isolated Redis 8 instance with persistence disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no public API or storage contract changes; outcome classification is the same, just routed through one type.
> 
> **Overview**
> **Worker execution outcomes** no longer flow through a nested `Result<(), ExecutionError>` plus a coordinator-side mapping to `WorkerResultKind`.
> 
> The executor now models process results as explicit **`Success` / `Failed` / `Panicked`** variants (instead of `NotPanic(Result<...>)` and `Panic`), and **`ExecutionOutcome` carries `kind: WorkerResultKind`** set in `finish_batch_result`. The coordinator’s `process_result` forwards that kind straight into `WorkerResult` for metrics/collector.
> 
> The removed **`ExecutionError`** enum and duplicate conversion logic are gone; **`Result<ExecutionOutcome, OxanaError>`** is still used only for infrastructure/batch validation errors. Failure reporting, retries, panic handling, and storage finish paths are unchanged in behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3098a99672e922c78c9562a10fc422adb624dde8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->