### PR TITLE
Refactor queue stats aggregation out of Redis reads

### DIFF
--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -15,18 +15,19 @@ use crate::{
     metrics::*,
     queue::{QueueRuntimeConfig, QueueState},
     result_collector::QueueResultStats,
-    stats::{
-        DynamicQueueStats, Process, QueueRateStats, QueueStats, Stats, StatsGlobal, StatsProcessing,
-    },
+    stats::{Process, QueueRateStats, QueueStats, Stats, StatsGlobal, StatsProcessing},
     storage_keys::StorageKeys,
     storage_types::QueueListOpts,
     worker_registry::CronJob,
 };
 
+mod queue_stats;
+
+use queue_stats::{aggregate_queue_stats, queue_rate_stats};
+
 const JOB_EXPIRE_TIME: i64 = 7 * 24 * 3600; // 7 days
 const SCAN_BATCH_SIZE: usize = 500;
 const ENQUEUE_LIST_CHUNK_SIZE: usize = 100;
-const QUEUE_LENGTH_SNAPSHOT_TTL_SECS: i64 = 120;
 
 #[derive(Debug, PartialEq, Eq)]
 enum UniqueCronAction {
@@ -77,12 +78,6 @@ enum JobEnqueueAction {
 enum JobDestination {
     Queue,
     Schedule,
-}
-
-#[derive(Default)]
-struct QueueLengthSnapshot {
-    enqueued: Option<i64>,
-    refreshed_at: Option<i64>,
 }
 
 struct QueueStatsInputs {
@@ -1168,127 +1163,17 @@ impl StorageInternal {
         let rate_minutes = metric_minutes(now, JobMetricsQuery::new(QUEUE_RATE_WINDOW_MINUTES));
         let inputs = self.queue_stats_inputs(redis, &rate_minutes).await?;
 
-        let mut map = HashMap::new();
-        let mut queue_values: Vec<(String, String, i64)> = Vec::new();
-        let mut queue_length_snapshots: HashMap<String, QueueLengthSnapshot> = HashMap::new();
-
-        for queue in queues {
-            queue_values.push((queue.clone(), "processed".to_string(), 0));
-        }
-
-        for (key, value) in inputs.stats {
-            let (queue_full_key, stat_key) = match Self::stats_key_parts(&key) {
-                Some(parts) => parts,
-                None => continue,
-            };
-
-            if filter && !Self::stats_key_matches_filter(queue_full_key, queues) {
-                continue;
-            }
-
-            match stat_key {
-                "enqueued" => {
-                    queue_length_snapshots
-                        .entry(queue_full_key.to_string())
-                        .or_default()
-                        .enqueued = Some(value);
-                }
-                "enqueued_at" => {
-                    queue_length_snapshots
-                        .entry(queue_full_key.to_string())
-                        .or_default()
-                        .refreshed_at = Some(value);
-                }
-                _ => {
-                    queue_values.push((queue_full_key.to_string(), stat_key.to_string(), value));
-                }
-            }
-        }
-
-        for (queue_full_key, stat_key, value) in queue_values {
-            let Some((queue_key, queue_dynamic_key)) = Self::split_queue_stats_key(&queue_full_key)
-            else {
-                continue;
-            };
-
-            let queue_stats = map
-                .entry(queue_key.to_string())
-                .or_insert_with(|| QueueStats {
-                    key: queue_key.to_string(),
-                    enqueued: 0,
-                    processed: 0,
-                    succeeded: 0,
-                    panicked: 0,
-                    failed: 0,
-                    latency_s: 0.0,
-                    rate: QueueRateStats::default(),
-                    queues: vec![],
-                });
-
-            if let Some(queue_dynamic_key) = queue_dynamic_key {
-                if !queue_stats
-                    .queues
-                    .iter_mut()
-                    .any(|q| q.suffix == queue_dynamic_key)
-                {
-                    queue_stats.queues.push(DynamicQueueStats {
-                        suffix: queue_dynamic_key.to_string(),
-                        enqueued: 0,
-                        processed: 0,
-                        succeeded: 0,
-                        panicked: 0,
-                        failed: 0,
-                        latency_s: 0.0,
-                        rate: QueueRateStats::default(),
-                    });
-                }
-
-                if let Some(existing) = queue_stats
-                    .queues
-                    .iter_mut()
-                    .find(|q| q.suffix == queue_dynamic_key)
-                {
-                    match stat_key.as_str() {
-                        "processed" => existing.processed += value,
-                        "succeeded" => existing.succeeded += value,
-                        "panicked" => existing.panicked += value,
-                        "failed" => existing.failed += value,
-                        _ => {}
-                    }
-                }
-            }
-
-            match stat_key.as_str() {
-                "processed" => queue_stats.processed += value,
-                "succeeded" => queue_stats.succeeded += value,
-                "panicked" => queue_stats.panicked += value,
-                "failed" => queue_stats.failed += value,
-                _ => {}
-            }
-        }
-
-        for queue_full_key in queue_length_snapshots.keys() {
-            if Self::fresh_queue_length_snapshot(&queue_length_snapshots, queue_full_key, now)
-                .is_some_and(|enqueued| enqueued > 0)
-            {
-                Self::ensure_queue_stats_entry(&mut map, queue_full_key);
-            }
-        }
-
-        let mut values: Vec<QueueStats> = map.into_values().collect();
+        let (mut values, enqueued_snapshots) =
+            aggregate_queue_stats(queues, inputs.stats, filter, now);
 
         for value in values.iter_mut() {
             if value.queues.is_empty() {
-                value.enqueued = match Self::fresh_queue_length_snapshot(
-                    &queue_length_snapshots,
-                    &value.key,
-                    now,
-                ) {
+                value.enqueued = match enqueued_snapshots.get(&value.key).copied() {
                     Some(enqueued) => enqueued,
                     None => self.enqueued_count_w_conn(redis, &value.key).await?,
                 };
                 value.latency_s = self.latency_s_w_conn(redis, &value.key).await?;
-                value.rate = Self::queue_rate_stats(
+                value.rate = queue_rate_stats(
                     &value.key,
                     value.enqueued,
                     &inputs.queue_length_rate_hashes,
@@ -1297,11 +1182,7 @@ impl StorageInternal {
             } else {
                 for dynamic_queue in value.queues.iter_mut() {
                     let dynamic_queue_key = format!("{}#{}", value.key, dynamic_queue.suffix);
-                    let enqueued = match Self::fresh_queue_length_snapshot(
-                        &queue_length_snapshots,
-                        &dynamic_queue_key,
-                        now,
-                    ) {
+                    let enqueued = match enqueued_snapshots.get(&dynamic_queue_key).copied() {
                         Some(enqueued) => enqueued,
                         None => {
                             self.enqueued_count_w_conn(redis, &dynamic_queue_key)
@@ -1312,7 +1193,7 @@ impl StorageInternal {
 
                     dynamic_queue.enqueued = enqueued;
                     dynamic_queue.latency_s = latency_s;
-                    dynamic_queue.rate = Self::queue_rate_stats(
+                    dynamic_queue.rate = queue_rate_stats(
                         &dynamic_queue_key,
                         dynamic_queue.enqueued,
                         &inputs.queue_length_rate_hashes,
@@ -1370,105 +1251,6 @@ impl StorageInternal {
             queue_length_rate_hashes,
             queue_counter_totals,
         })
-    }
-
-    fn stats_key_parts(key: &str) -> Option<(&str, &str)> {
-        key.rsplit_once(':')
-    }
-
-    fn split_queue_stats_key(queue_full_key: &str) -> Option<(&str, Option<&str>)> {
-        let mut queue_key_parts = queue_full_key.splitn(2, '#');
-        let queue_key = queue_key_parts.next()?;
-        Some((queue_key, queue_key_parts.next()))
-    }
-
-    fn ensure_queue_stats_entry(map: &mut HashMap<String, QueueStats>, queue_full_key: &str) {
-        let Some((queue_key, queue_dynamic_key)) = Self::split_queue_stats_key(queue_full_key)
-        else {
-            return;
-        };
-
-        let queue_stats = map
-            .entry(queue_key.to_string())
-            .or_insert_with(|| QueueStats {
-                key: queue_key.to_string(),
-                enqueued: 0,
-                processed: 0,
-                succeeded: 0,
-                panicked: 0,
-                failed: 0,
-                latency_s: 0.0,
-                rate: QueueRateStats::default(),
-                queues: vec![],
-            });
-
-        if let Some(queue_dynamic_key) = queue_dynamic_key
-            && !queue_stats
-                .queues
-                .iter()
-                .any(|q| q.suffix == queue_dynamic_key)
-        {
-            queue_stats.queues.push(DynamicQueueStats {
-                suffix: queue_dynamic_key.to_string(),
-                enqueued: 0,
-                processed: 0,
-                succeeded: 0,
-                panicked: 0,
-                failed: 0,
-                latency_s: 0.0,
-                rate: QueueRateStats::default(),
-            });
-        }
-    }
-
-    fn stats_key_matches_filter(queue_full_key: &str, queues: &[String]) -> bool {
-        let base_key = queue_full_key
-            .split_once('#')
-            .map_or(queue_full_key, |(base, _)| base);
-
-        queues.iter().any(|queue| {
-            let queue_base = queue
-                .split_once('#')
-                .map_or(queue.as_str(), |(base, _)| base);
-            queue_base == base_key || queue.as_str() == queue_full_key
-        })
-    }
-
-    fn fresh_queue_length_snapshot(
-        queue_length_snapshots: &HashMap<String, QueueLengthSnapshot>,
-        queue: &str,
-        now: i64,
-    ) -> Option<usize> {
-        let snapshot = queue_length_snapshots.get(queue)?;
-        let refreshed_at = snapshot.refreshed_at?;
-        if now.saturating_sub(refreshed_at) > QUEUE_LENGTH_SNAPSHOT_TTL_SECS {
-            return None;
-        }
-
-        usize::try_from(snapshot.enqueued?).ok()
-    }
-
-    fn queue_rate_stats(
-        queue: &str,
-        enqueued: usize,
-        queue_length_hashes: &[HashMap<String, i64>],
-        queue_counter_totals: &HashMap<String, QueueCounterTotals>,
-    ) -> QueueRateStats {
-        let window_start_enqueued = queue_length_hashes
-            .first()
-            .and_then(|hash| hash.get(queue))
-            .and_then(|value| usize::try_from(*value).ok())
-            .unwrap_or_default();
-        let counters = queue_counter_totals.get(queue).copied().unwrap_or_default();
-
-        QueueRateStats::calculate(
-            QUEUE_RATE_WINDOW_MINUTES,
-            enqueued,
-            window_start_enqueued,
-            counters.processed,
-            counters.succeeded,
-            counters.failed,
-        )
     }
 
     pub(crate) async fn flush_result_stats(
@@ -3278,7 +3060,7 @@ mod tests {
             .await?;
 
         let stale_refreshed_at =
-            chrono::Utc::now().timestamp() - QUEUE_LENGTH_SNAPSHOT_TTL_SECS - 1;
+            chrono::Utc::now().timestamp() - queue_stats::QUEUE_LENGTH_SNAPSHOT_TTL_SECS - 1;
         let mut redis = storage.connection().await?;
         let _: () = redis::pipe()
             .hset(&storage.keys.stats, format!("{queue}:enqueued"), 42)

--- a/oxana/src/storage_internal/queue_stats.rs
+++ b/oxana/src/storage_internal/queue_stats.rs
@@ -1,0 +1,318 @@
+//! Pure aggregation of queue counters and cached lengths before live Redis reads.
+
+use std::collections::HashMap;
+
+use crate::{
+    metrics::{QUEUE_RATE_WINDOW_MINUTES, QueueCounterTotals},
+    result_collector::QueueResultStats,
+    stats::{DynamicQueueStats, QueueRateStats, QueueStats},
+};
+
+pub(super) const QUEUE_LENGTH_SNAPSHOT_TTL_SECS: i64 = 120;
+
+#[derive(Default)]
+struct QueueLengthSnapshot {
+    enqueued: Option<i64>,
+    refreshed_at: Option<i64>,
+}
+
+impl QueueLengthSnapshot {
+    fn fresh_enqueued(&self, now: i64) -> Option<usize> {
+        if now.saturating_sub(self.refreshed_at?) > QUEUE_LENGTH_SNAPSHOT_TTL_SECS {
+            return None;
+        }
+
+        usize::try_from(self.enqueued?).ok()
+    }
+}
+
+pub(super) fn aggregate_queue_stats(
+    queues: &[String],
+    stats: HashMap<String, i64>,
+    filter: bool,
+    now: i64,
+) -> (Vec<QueueStats>, HashMap<String, usize>) {
+    let mut counters: HashMap<String, QueueResultStats> = queues
+        .iter()
+        .map(|queue| (queue.clone(), QueueResultStats::default()))
+        .collect();
+    let mut snapshots: HashMap<String, QueueLengthSnapshot> = HashMap::new();
+
+    for (key, value) in stats {
+        let Some((queue, stat)) = key.rsplit_once(':') else {
+            continue;
+        };
+        if filter
+            && !queues
+                .iter()
+                .any(|selected| queue_base(selected) == queue_base(queue))
+        {
+            continue;
+        }
+
+        match stat {
+            "enqueued" => snapshots.entry(queue.to_string()).or_default().enqueued = Some(value),
+            "enqueued_at" => {
+                snapshots.entry(queue.to_string()).or_default().refreshed_at = Some(value);
+            }
+            _ => {
+                // Even an unrecognized counter keeps a historical queue visible.
+                let counts = counters.entry(queue.to_string()).or_default();
+                match stat {
+                    "processed" => counts.processed += value,
+                    "succeeded" => counts.succeeded += value,
+                    "panicked" => counts.panicked += value,
+                    "failed" => counts.failed += value,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    let enqueued_snapshots: HashMap<String, usize> = snapshots
+        .into_iter()
+        .filter_map(|(queue, snapshot)| Some((queue, snapshot.fresh_enqueued(now)?)))
+        .collect();
+    for (queue, enqueued) in &enqueued_snapshots {
+        // A zero snapshot can serve an existing queue, but cannot create one.
+        if *enqueued > 0 {
+            counters.entry(queue.clone()).or_default();
+        }
+    }
+
+    let mut groups: HashMap<String, QueueStats> = HashMap::new();
+    for (queue, counts) in counters {
+        let base = queue_base(&queue);
+        let parent = groups
+            .entry(base.to_string())
+            .or_insert_with(|| QueueStats {
+                key: base.to_string(),
+                enqueued: 0,
+                processed: 0,
+                succeeded: 0,
+                panicked: 0,
+                failed: 0,
+                latency_s: 0.0,
+                rate: QueueRateStats::default(),
+                queues: vec![],
+            });
+        parent.processed += counts.processed;
+        parent.succeeded += counts.succeeded;
+        parent.panicked += counts.panicked;
+        parent.failed += counts.failed;
+
+        if let Some((_, suffix)) = queue.split_once('#') {
+            parent.queues.push(DynamicQueueStats {
+                suffix: suffix.to_string(),
+                enqueued: 0,
+                processed: counts.processed,
+                succeeded: counts.succeeded,
+                panicked: counts.panicked,
+                failed: counts.failed,
+                latency_s: 0.0,
+                rate: QueueRateStats::default(),
+            });
+        }
+    }
+
+    (groups.into_values().collect(), enqueued_snapshots)
+}
+
+fn queue_base(queue: &str) -> &str {
+    queue.split_once('#').map_or(queue, |(base, _)| base)
+}
+
+pub(super) fn queue_rate_stats(
+    queue: &str,
+    enqueued: usize,
+    queue_length_hashes: &[HashMap<String, i64>],
+    queue_counter_totals: &HashMap<String, QueueCounterTotals>,
+) -> QueueRateStats {
+    let window_start_enqueued = queue_length_hashes
+        .first()
+        .and_then(|hash| hash.get(queue))
+        .and_then(|value| usize::try_from(*value).ok())
+        .unwrap_or_default();
+    let counters = queue_counter_totals.get(queue).copied().unwrap_or_default();
+
+    QueueRateStats::calculate(
+        QUEUE_RATE_WINDOW_MINUTES,
+        enqueued,
+        window_start_enqueued,
+        counters.processed,
+        counters.succeeded,
+        counters.failed,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats(entries: &[(&str, i64)]) -> HashMap<String, i64> {
+        entries
+            .iter()
+            .map(|(key, value)| (key.to_string(), *value))
+            .collect()
+    }
+
+    fn queue<'a>(queues: &'a [QueueStats], key: &str) -> &'a QueueStats {
+        queues
+            .iter()
+            .find(|queue| queue.key == key)
+            .expect("queue should exist")
+    }
+
+    #[test]
+    fn groups_live_and_historical_queues_without_duplicate_children() {
+        let (queues, snapshots) = aggregate_queue_stats(
+            &["active".into(), "batch#north".into(), "batch#north".into()],
+            stats(&[
+                ("static:processed", 10),
+                ("batch:processed", 2),
+                ("batch#north:processed", 4),
+                ("batch#north:succeeded", 3),
+                ("batch#north:panicked", 1),
+                ("batch#north:failed", 1),
+                ("batch#south:processed", 6),
+                ("batch#south:succeeded", 6),
+                ("tenant:jobs#a#b:processed", 7),
+                ("legacy:unknown", 99),
+                ("malformed", 99),
+            ]),
+            false,
+            1_000,
+        );
+
+        assert!(snapshots.is_empty());
+        assert_eq!(queues.len(), 5);
+        assert_eq!(queue(&queues, "active").processed, 0);
+        assert_eq!(queue(&queues, "static").processed, 10);
+        assert_eq!(queue(&queues, "legacy").processed, 0);
+
+        let batch = queue(&queues, "batch");
+        assert_eq!(
+            (
+                batch.processed,
+                batch.succeeded,
+                batch.panicked,
+                batch.failed
+            ),
+            (12, 9, 1, 1)
+        );
+        assert_eq!(batch.queues.len(), 2);
+        let north = batch
+            .queues
+            .iter()
+            .find(|queue| queue.suffix == "north")
+            .unwrap();
+        assert_eq!(
+            (
+                north.processed,
+                north.succeeded,
+                north.panicked,
+                north.failed
+            ),
+            (4, 3, 1, 1)
+        );
+
+        let tenant = queue(&queues, "tenant:jobs");
+        assert_eq!(tenant.processed, 7);
+        assert_eq!(tenant.queues.len(), 1);
+        assert_eq!(tenant.queues.first().unwrap().suffix, "a#b");
+    }
+
+    #[test]
+    fn filtering_keeps_sibling_counters_and_snapshots() {
+        let stored = stats(&[
+            ("batch:processed", 9),
+            ("batch#south:processed", 4),
+            ("batch#east:enqueued", 2),
+            ("batch#east:enqueued_at", 1_000),
+            ("other:processed", 99),
+            ("other:enqueued", 99),
+            ("other:enqueued_at", 1_000),
+        ]);
+        let (queues, snapshots) =
+            aggregate_queue_stats(&["batch#north".into()], stored.clone(), true, 1_000);
+
+        assert_eq!(queues.len(), 1);
+        let batch = queue(&queues, "batch");
+        assert_eq!(batch.processed, 13);
+        let mut suffixes: Vec<_> = batch
+            .queues
+            .iter()
+            .map(|queue| queue.suffix.as_str())
+            .collect();
+        suffixes.sort_unstable();
+        assert_eq!(suffixes, ["east", "north", "south"]);
+        assert_eq!(snapshots, HashMap::from([("batch#east".into(), 2)]));
+
+        let (queues, snapshots) = aggregate_queue_stats(&[], stored, true, 1_000);
+        assert!(queues.is_empty());
+        assert!(snapshots.is_empty());
+    }
+
+    #[test]
+    fn only_positive_fresh_snapshots_create_queues() {
+        let (queues, snapshots) = aggregate_queue_stats(
+            &["live".into()],
+            stats(&[
+                ("live:enqueued", 0),
+                ("live:enqueued_at", 1_000),
+                ("historical:processed", 3),
+                ("historical:enqueued", 0),
+                ("historical:enqueued_at", 1_000),
+                ("snapshot#busy:enqueued", 5),
+                ("snapshot#busy:enqueued_at", 1_000),
+                ("snapshot#empty:enqueued", 0),
+                ("snapshot#empty:enqueued_at", 1_000),
+                ("empty:enqueued", 0),
+                ("empty:enqueued_at", 1_000),
+                ("stale:enqueued", 7),
+                ("stale:enqueued_at", 879),
+                ("incomplete:enqueued", 8),
+                ("negative:enqueued", -1),
+                ("negative:enqueued_at", 1_000),
+            ]),
+            false,
+            1_000,
+        );
+
+        assert_eq!(queues.len(), 3);
+        assert_eq!(queue(&queues, "live").processed, 0);
+        assert_eq!(queue(&queues, "historical").processed, 3);
+        let snapshot = queue(&queues, "snapshot");
+        assert_eq!(snapshot.queues.len(), 1);
+        assert_eq!(snapshot.queues.first().unwrap().suffix, "busy");
+        assert_eq!(
+            snapshots,
+            HashMap::from([
+                ("live".into(), 0),
+                ("historical".into(), 0),
+                ("snapshot#busy".into(), 5),
+                ("snapshot#empty".into(), 0),
+                ("empty".into(), 0),
+            ])
+        );
+    }
+
+    #[test]
+    fn snapshot_freshness_includes_the_ttl_boundary_and_future_timestamps() {
+        for (enqueued, refreshed_at, expected) in [
+            (Some(5), Some(880), Some(5)),
+            (Some(5), Some(879), None),
+            (Some(5), Some(1_001), Some(5)),
+            (Some(0), Some(1_000), Some(0)),
+            (Some(-1), Some(1_000), None),
+            (None, Some(1_000), None),
+            (Some(5), None, None),
+        ] {
+            let snapshot = QueueLengthSnapshot {
+                enqueued,
+                refreshed_at,
+            };
+            assert_eq!(snapshot.fresh_enqueued(1_000), expected);
+        }
+    }
+}


### PR DESCRIPTION
Queue statistics mixed Redis reads with counter grouping and repeated dynamic queue construction. Move the pure aggregation and rate calculation into a private module, accumulating counters by full queue key before constructing each parent and child once.

Preserve the public stats types, Redis pool selection, live length fallback, latency reads, sorting, and rate calculations. Four new tests cover parent totals, sibling filtering, historical queues, zero snapshots, and snapshot freshness boundaries.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace --all-targets -- -D warnings`
- `cargo nextest run -p oxana --all-features --lib --test integration --test-threads 2 --no-fail-fast` — 176 passed
- `cargo test -p oxana --lib --no-default-features --quiet` — 108 passed

Redis-backed tests ran against an isolated local Redis instance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how queue dashboard stats are derived (filtering, dynamic queues, snapshot TTL); regressions would affect observability rather than job execution, but the logic is subtle and user-facing.
> 
> **Overview**
> Moves **pure queue counter grouping**, **length snapshot TTL handling**, and **rate math** out of `StorageInternal` into a new `storage_internal/queue_stats` module so `build_queue_stats` only orchestrates Redis input fetch and live `enqueued` / latency reads.
> 
> `build_queue_stats` now calls `aggregate_queue_stats` and `queue_rate_stats` instead of ~200 lines of inline map building; snapshot freshness uses a returned `enqueued_snapshots` map with the same live `LLEN` fallback when a snapshot is missing or stale.
> 
> The aggregation pass is reworked to accumulate counters per full queue key (including `#` dynamic suffixes) before assembling each parent `QueueStats` and its children once. **Four unit tests** in `queue_stats.rs` lock in filtering (siblings stay visible), historical queues, zero vs positive snapshots, and TTL edge cases; an integration test now references `queue_stats::QUEUE_LENGTH_SNAPSHOT_TTL_SECS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3a8228b4e51dfb37067dadf6098d676248988a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->