### PR TITLE
Add Topcoat dashboard alongside oxana-web

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           cargo test --lib --no-default-features
           cargo nextest run --all-features --no-fail-fast
+          cargo test -p oxana-web-topcoat --all-targets
 
       - name: Lint
         run: cargo clippy --all-features --workspace --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +75,18 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "anymap3"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5dfbc6d8d2675589ccbe4d0fd61df2419075625f8c1a62325e718e2b0049f9"
 
 [[package]]
 name = "arcstr"
@@ -75,7 +122,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -121,7 +168,7 @@ checksum = "940074e50ab8a902980dec23d265697dd1e8789e66be664d183dbb24c79b8e7c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -143,7 +190,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -174,7 +221,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -226,6 +273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +298,24 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -275,7 +352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -291,6 +368,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -349,10 +436,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cookie"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
+dependencies = [
+ "aes-gcm",
+ "base64 0.22.1",
+ "hkdf",
+ "hmac",
+ "percent-encoding",
+ "rand 0.8.7",
+ "sha2 0.10.9",
+ "subtle",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -382,6 +502,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,7 +550,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -412,7 +561,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -462,6 +611,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,7 +640,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -494,7 +665,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -508,6 +679,31 @@ name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "elsa"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "email-encoding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420b9da095f052ea597503e39073b5b3c522f7db933fbac202d91d24492693fd"
+dependencies = [
+ "base64 0.23.1",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 
 [[package]]
 name = "equivalent"
@@ -545,6 +741,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -617,7 +819,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -650,6 +852,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +869,19 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -678,9 +903,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -718,6 +955,35 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -763,6 +1029,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f864f10dfb56725ce5ce5472bc52252c8f93a4ab86327122cebf62c5f59a17"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -943,6 +1218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1257,23 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lettre"
+version = "0.11.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c646bd5cc763b1087b15493e29a64be6147ba8f19342004fa52048ee596eae"
+dependencies = [
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "hostname",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "quoted_printable",
+]
 
 [[package]]
 name = "libc"
@@ -1023,6 +1324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matchit"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1359,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1104,6 +1420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "oxana"
 version = "2.1.4"
 dependencies = [
@@ -1143,7 +1465,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1160,6 +1482,24 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tower",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "oxana-web-topcoat"
+version = "2.1.4"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "oxana",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "topcoat",
  "tower",
  "urlencoding",
  "uuid",
@@ -1230,7 +1570,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1247,6 +1587,18 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1273,6 +1625,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1652,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1323,7 +1684,7 @@ checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1334,6 +1695,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"
@@ -1353,6 +1720,8 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1362,7 +1731,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1375,6 +1744,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1392,6 +1771,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -1438,6 +1820,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1596,7 +1998,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1643,6 +2045,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1711,10 +2135,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1735,7 +2176,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1786,7 +2227,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1863,7 +2304,7 @@ checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1904,6 +2345,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +2370,253 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "topcoat"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c199295b1c52e0a9c88a2b0518f6bc7522503cd0bb06d9f4742c515ac4df0a"
+dependencies = [
+ "serde",
+ "topcoat-asset",
+ "topcoat-cookie",
+ "topcoat-core",
+ "topcoat-core-macro",
+ "topcoat-font",
+ "topcoat-mail",
+ "topcoat-router",
+ "topcoat-router-macro",
+ "topcoat-runtime",
+ "topcoat-session",
+ "topcoat-view",
+ "topcoat-view-macro",
+]
+
+[[package]]
+name = "topcoat-asset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba199ae779d0409672929e7c32711ac35e87c9e39e0823d0b33b6293e3e0011"
+dependencies = [
+ "http",
+ "memchr",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror",
+ "toml",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
+]
+
+[[package]]
+name = "topcoat-cookie"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb0bf2f95c1931d32d579389695e8cf221d114f9629a57fc005d7a0bb459c0d"
+dependencies = [
+ "cookie",
+ "getrandom 0.2.17",
+ "http",
+ "serde",
+ "serde_json",
+ "topcoat-core",
+ "topcoat-router",
+]
+
+[[package]]
+name = "topcoat-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88c5ed693dd383ba8a4112f5b665bdb7e979ada413a7b5f9ede6935fe18e8e6"
+dependencies = [
+ "anyhow",
+ "anymap3",
+ "elsa",
+ "http",
+ "pin-project-lite",
+ "siphasher",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "topcoat-core-grammar"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce257f5c2248b4d7bf1bbd76a0e71709221f06d690462a49aad5929732c42001"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "topcoat-core-macro"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d239098a8c674f16120e7bfcba6f670865c807eec2a0e2648cb319d300fab39"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+ "topcoat-core-grammar",
+]
+
+[[package]]
+name = "topcoat-font"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccc2da492bfdcf2d23d761b60338eb20ad178fd754ef19570abe6030663137d"
+dependencies = [
+ "heck",
+ "serde",
+ "serde_json",
+ "topcoat-asset",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
+ "topcoat-view-macro",
+]
+
+[[package]]
+name = "topcoat-mail"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8fa0e1ad5a4f4419c50b783ac565426df5c30dfa3dc9ca9602c8cd1c3535a3"
+dependencies = [
+ "lettre",
+ "thiserror",
+ "time",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
+]
+
+[[package]]
+name = "topcoat-router"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f452945373fac2b61a4050639681829e99afeea872faebc93ef0b03c4211335"
+dependencies = [
+ "bytes",
+ "form_urlencoded",
+ "futures-core",
+ "futures-util",
+ "heck",
+ "http",
+ "http-body",
+ "http-body-util",
+ "matchit 0.9.2",
+ "percent-encoding",
+ "pin-project-lite",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "tokio",
+ "topcoat-core",
+ "topcoat-view",
+ "tower",
+]
+
+[[package]]
+name = "topcoat-router-grammar"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188df45ec401d790e3dd84564580c5c436a456331a187bdbfb7441f8e48fa1ca"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "topcoat-core-grammar",
+]
+
+[[package]]
+name = "topcoat-router-macro"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6f9a61d3ecfe1252b861795070c4317aca6b816382919d9c941eccad2fe42d"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+ "topcoat-router-grammar",
+]
+
+[[package]]
+name = "topcoat-runtime"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75367a6fb32878f28bb1e42fe97385c9b14f1d3455b0bb69afb399260a8995a"
+dependencies = [
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "topcoat-asset",
+ "topcoat-core",
+ "topcoat-router",
+ "topcoat-view",
+]
+
+[[package]]
+name = "topcoat-session"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d432a276f3d7e4e0af0f9789ee0c919fbfbf8d2025d0dac7f8072a918521cf6d"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.4.3",
+ "sha2 0.11.0",
+ "thiserror",
+ "tokio",
+ "topcoat-core",
+ "topcoat-router",
+ "web-time",
+]
+
+[[package]]
+name = "topcoat-view"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acc959c83729cb4b967c2e7de8ee78a2fc3216cceb1be650ee9524fabd26baa"
+dependencies = [
+ "base64 0.22.1",
+ "futures-core",
+ "futures-util",
+ "http",
+ "memchr",
+ "pin-project-lite",
+ "siphasher",
+ "smallvec",
+ "topcoat-core",
+]
+
+[[package]]
+name = "topcoat-view-grammar"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa71393a00dba3ce203d3236e24311851134721f5bfae6a17bfacd709a983660"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "topcoat-core-grammar",
+ "topcoat-view",
+]
+
+[[package]]
+name = "topcoat-view-macro"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a625be243364f6674204ba412700d9eed2a1c9168f7add3b1020be4825f0e49"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+ "topcoat-view-grammar",
+]
 
 [[package]]
 name = "tower"
@@ -1966,7 +2666,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2024,10 +2724,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "url"
@@ -2071,6 +2787,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -2119,7 +2841,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2130,6 +2852,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2162,7 +2894,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2173,7 +2905,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2264,7 +2996,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2285,7 +3017,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2305,7 +3037,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2339,7 +3071,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["oxana", "oxana-macros", "oxana-web"]
+members = ["oxana", "oxana-macros", "oxana-web", "oxana-web-topcoat"]
 resolver = "3"
 default-members = ["oxana"]
 

--- a/oxana-web-topcoat/Cargo.toml
+++ b/oxana-web-topcoat/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "oxana-web-topcoat"
+version = "2.1.4"
+edition = "2024"
+rust-version = "1.98"
+license = "MIT"
+description = "Topcoat web UI for Oxana job queue system."
+repository = "https://github.com/pragmaplatform/oxana"
+keywords = ["job", "scheduler", "worker", "web"]
+categories = ["asynchronous", "web-programming"]
+exclude = [".*", "logo.jpg"]
+
+[lib]
+doctest = false
+test = true
+
+[dependencies]
+oxana = { workspace = true }
+
+axum = "0.8"
+topcoat = { version = "=0.8.0", default-features = false, features = ["router", "tower"] }
+chrono = { version = "^0.4", features = ["serde"] }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = { version = "^1.0", features = ["preserve_order"] }
+urlencoding = "2"
+uuid = { version = "^1.23", features = ["v4"] }
+
+[dev-dependencies]
+async-trait = "0.1"
+oxana = { path = "../oxana", default-features = false, features = [
+    "registry",
+] }
+serde = { version = "^1.0", features = ["derive"] }
+thiserror = "^2.0"
+tokio = { version = "^1.52", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }

--- a/oxana-web-topcoat/README.md
+++ b/oxana-web-topcoat/README.md
@@ -1,0 +1,46 @@
+# Oxana Web with Topcoat
+
+`oxana-web-topcoat` implements the Oxana dashboard with Topcoat routing and Rust
+views. It is an alternative to `oxana-web` and preserves its pages, forms, charts,
+and queue controls. It requires Rust 1.98 and Topcoat 0.8.0.
+
+Mount it in an Axum app using the same API as `oxana-web`:
+
+```rust
+use oxana_web_topcoat::{OxanaWebState, router};
+
+let catalog = runtime.catalog();
+let dashboard = router(OxanaWebState::new(
+    storage.clone(),
+    catalog,
+    "/oxana".to_string(),
+));
+let app = axum::Router::new().nest("/oxana", dashboard);
+```
+
+For a dashboard at `/`, use an empty `base_path` and serve `router(state)`
+directly. `topcoat_router(state)` also exposes the native Topcoat router, with
+routes relative to the dashboard root. An embedding host must strip the mount
+prefix from requests; `base_path` supplies that prefix for links and redirects.
+
+Run the example with Redis:
+
+```sh
+REDIS_URL=redis://localhost:6379 cargo run -p oxana-web-topcoat --example web
+```
+
+Open <http://localhost:3000/oxana>. The example starts workers and seeds sample
+jobs, including dynamic queues and progress reporting. Like `oxana-web`, the UI
+loads Tailwind CSS and uPlot from their existing CDN URLs. Other scripts and CSS
+are embedded in the crate; no frontend build step is needed.
+
+Run the tests and format views:
+
+```sh
+REDIS_URL=redis://localhost:6379 cargo test -p oxana-web-topcoat --all-targets
+topcoat fmt 'oxana-web-topcoat/src/views/*.rs'
+cargo fmt --all
+```
+
+Topcoat's formatter handles HTML inside `view!`; `cargo fmt` formats the
+surrounding Rust. Topcoat is experimental, so the dependency is pinned to 0.8.0.

--- a/oxana-web-topcoat/examples/web.rs
+++ b/oxana-web-topcoat/examples/web.rs
@@ -1,0 +1,438 @@
+// cargo run --package oxana-web-topcoat --example web
+
+use serde::Serialize;
+
+#[derive(oxana::Registry)]
+struct ComponentRegistry(oxana::ComponentRegistry<WorkerContext>);
+
+#[derive(Debug, thiserror::Error)]
+enum WorkerError {
+    #[error(transparent)]
+    Oxana(#[from] oxana::OxanaError),
+}
+
+#[derive(Debug, Clone)]
+struct WorkerContext {}
+
+mod demo {
+    pub(crate) mod crm {
+        pub(crate) mod customers {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+            #[oxana(on_demand)]
+            pub(crate) struct SyncCustomerProfileJob {
+                pub(crate) duration_ms: u64,
+            }
+
+            #[derive(oxana::Worker)]
+            #[oxana(max_retries = 0)]
+            struct SyncCustomerProfileWorker;
+
+            impl SyncCustomerProfileWorker {
+                async fn process(
+                    &self,
+                    job: SyncCustomerProfileJob,
+                    _ctx: &oxana::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    pub(crate) mod billing {
+        pub(crate) mod invoices {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+            #[oxana(on_demand)]
+            pub(crate) struct GenerateInvoiceJob {
+                pub(crate) duration_ms: u64,
+            }
+
+            #[derive(oxana::Worker)]
+            #[oxana(max_retries = 0)]
+            struct GenerateInvoiceWorker;
+
+            impl GenerateInvoiceWorker {
+                async fn process(
+                    &self,
+                    job: GenerateInvoiceJob,
+                    _ctx: &oxana::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    pub(crate) mod messaging {
+        pub(crate) mod receipts {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+            pub(crate) struct SendReceiptEmailJob {
+                pub(crate) duration_ms: u64,
+            }
+
+            #[derive(oxana::Worker)]
+            #[oxana(max_retries = 0)]
+            struct SendReceiptEmailWorker;
+
+            impl SendReceiptEmailWorker {
+                async fn process(
+                    &self,
+                    job: SendReceiptEmailJob,
+                    _ctx: &oxana::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(job.duration_ms)).await;
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    pub(crate) mod maintenance {
+        pub(crate) mod cleanup {
+            use crate::{ComponentRegistry, DefaultQueue, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+            pub(crate) struct CleanupExpiredSessionsJob {}
+
+            #[derive(oxana::Worker)]
+            #[oxana(max_retries = 0)]
+            #[oxana(cron(schedule = "*/30 * * * * *", queue = DefaultQueue))]
+            struct CleanupExpiredSessionsWorker;
+
+            impl CleanupExpiredSessionsWorker {
+                async fn process(
+                    &self,
+                    _job: CleanupExpiredSessionsJob,
+                    _ctx: &oxana::JobContext,
+                ) -> Result<(), WorkerError> {
+                    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                    Ok(())
+                }
+            }
+        }
+
+        pub(crate) mod progress {
+            use crate::{ComponentRegistry, WorkerContext, WorkerError};
+            use serde::{Deserialize, Serialize};
+
+            #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+            #[oxana(on_demand)]
+            pub(crate) struct LongRunningProgressJob {
+                pub(crate) duration_s: i64,
+            }
+
+            #[derive(oxana::Worker)]
+            #[oxana(max_retries = 0)]
+            struct LongRunningProgressWorker;
+
+            impl LongRunningProgressWorker {
+                async fn process(
+                    &self,
+                    job: LongRunningProgressJob,
+                    ctx: &oxana::JobContext,
+                ) -> Result<(), WorkerError> {
+                    ctx.state
+                        .update_progress((
+                            0,
+                            job.duration_s,
+                            "Starting long-running job".to_string(),
+                        ))
+                        .await?;
+
+                    for second in 1..=job.duration_s {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                        ctx.state
+                            .update_progress((
+                                second,
+                                job.duration_s,
+                                Some(format!("Completed second {second} of {}", job.duration_s)),
+                            ))
+                            .await?;
+                    }
+
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+use demo::billing::invoices::GenerateInvoiceJob;
+use demo::crm::customers::SyncCustomerProfileJob;
+use demo::maintenance::progress::LongRunningProgressJob;
+use demo::messaging::receipts::SendReceiptEmailJob;
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(key = "default", concurrency = 5)]
+struct DefaultQueue;
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(key = "priority", concurrency = 5)]
+struct PriorityQueue;
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(key = "progress", concurrency = 1)]
+struct ProgressQueue;
+
+#[derive(Serialize)]
+struct TenantQueueBase;
+
+impl oxana::Queue for TenantQueueBase {
+    fn key(&self) -> String {
+        "tenant".to_string()
+    }
+
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_dynamic("tenant").dynamic_concurrency(1)
+    }
+}
+
+#[derive(Serialize, oxana::Queue)]
+#[oxana(prefix = "tenant", concurrency = Dynamic(1))]
+struct TenantQueue {
+    tenant: &'static str,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = oxana::Storage::builder().build_from_env()?;
+    let worker_ctx = WorkerContext {};
+    let runtime = storage
+        .runtime(worker_ctx)
+        .register::<ComponentRegistry>()
+        .shutdown_on_ctrl_c();
+    let catalog = runtime.catalog();
+
+    seed_sample_jobs(&storage).await?;
+
+    let mut worker = tokio::spawn(async move {
+        if let Err(err) = runtime.run().await {
+            eprintln!("Oxana worker exited with error: {err}");
+        }
+    });
+
+    let base_path = "/oxana";
+    let oxana_state =
+        oxana_web_topcoat::OxanaWebState::new(storage, catalog, base_path.to_string());
+
+    let app = axum::Router::new().nest(base_path, oxana_web_topcoat::router(oxana_state));
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+    println!("Oxana web UI available at http://localhost:3000{base_path}");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    if !worker.is_finished() {
+        match tokio::time::timeout(std::time::Duration::from_secs(2), &mut worker).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) if err.is_cancelled() => {}
+            Ok(Err(err)) => return Err(Box::new(err) as Box<dyn std::error::Error>),
+            Err(_) => {
+                worker.abort();
+                match worker.await {
+                    Ok(()) => {}
+                    Err(err) if err.is_cancelled() => {}
+                    Err(err) => return Err(Box::new(err) as Box<dyn std::error::Error>),
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    if let Err(err) = tokio::signal::ctrl_c().await {
+        eprintln!("Failed to listen for Ctrl-C: {err}");
+    }
+    println!("Shutting down Oxana web example");
+}
+
+async fn seed_sample_jobs(storage: &oxana::Storage) -> Result<(), oxana::OxanaError> {
+    for _ in 0..3 {
+        storage
+            .enqueue(PriorityQueue, SyncCustomerProfileJob { duration_ms: 0 })
+            .await?;
+    }
+    for _ in 0..2 {
+        storage
+            .enqueue(DefaultQueue, SyncCustomerProfileJob { duration_ms: 0 })
+            .await?;
+    }
+    for _ in 0..2 {
+        storage
+            .enqueue(DefaultQueue, GenerateInvoiceJob { duration_ms: 0 })
+            .await?;
+    }
+    for _ in 0..3 {
+        storage
+            .enqueue(DefaultQueue, SendReceiptEmailJob { duration_ms: 0 })
+            .await?;
+    }
+
+    for duration_ms in [25, 50, 100, 250, 500, 1000, 2500, 1000] {
+        storage
+            .enqueue(PriorityQueue, SyncCustomerProfileJob { duration_ms })
+            .await?;
+    }
+    for duration_ms in [25, 50, 100, 250, 500, 1000, 2500, 2000] {
+        storage
+            .enqueue(DefaultQueue, SyncCustomerProfileJob { duration_ms })
+            .await?;
+    }
+    for duration_ms in [25, 50, 100, 250, 500, 1000, 2500, 2000] {
+        storage
+            .enqueue(DefaultQueue, GenerateInvoiceJob { duration_ms })
+            .await?;
+    }
+    for duration_ms in [25, 50, 100, 250, 500, 1000, 2500, 2000] {
+        storage
+            .enqueue(DefaultQueue, SendReceiptEmailJob { duration_ms })
+            .await?;
+    }
+
+    storage
+        .enqueue(
+            PriorityQueue,
+            SyncCustomerProfileJob {
+                duration_ms: seconds(15),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            DefaultQueue,
+            SyncCustomerProfileJob {
+                duration_ms: seconds(30),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            DefaultQueue,
+            GenerateInvoiceJob {
+                duration_ms: seconds(45),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            DefaultQueue,
+            SendReceiptEmailJob {
+                duration_ms: seconds(60),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            PriorityQueue,
+            SyncCustomerProfileJob {
+                duration_ms: seconds(75),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            DefaultQueue,
+            SyncCustomerProfileJob {
+                duration_ms: seconds(90),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            DefaultQueue,
+            GenerateInvoiceJob {
+                duration_ms: seconds(105),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            DefaultQueue,
+            SendReceiptEmailJob {
+                duration_ms: seconds(120),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            PriorityQueue,
+            SyncCustomerProfileJob {
+                duration_ms: seconds(135),
+            },
+        )
+        .await?;
+    storage
+        .enqueue(
+            PriorityQueue,
+            SyncCustomerProfileJob {
+                duration_ms: seconds(100),
+            },
+        )
+        .await?;
+    seed_dynamic_tenant_jobs(storage).await?;
+    storage
+        .enqueue(ProgressQueue, LongRunningProgressJob { duration_s: 150 })
+        .await?;
+
+    println!("Seeded sample jobs across default, priority, and tenant dynamic queues");
+
+    Ok(())
+}
+
+async fn seed_dynamic_tenant_jobs(storage: &oxana::Storage) -> Result<(), oxana::OxanaError> {
+    storage.set_queue_concurrency(TenantQueueBase, 2).await?;
+    storage
+        .set_queue_concurrency(TenantQueue { tenant: "acme" }, 3)
+        .await?;
+    storage
+        .set_queue_state(TenantQueue { tenant: "globex" }, oxana::QueueState::Paused)
+        .await?;
+
+    for duration_ms in [seconds(45), seconds(90), seconds(135), seconds(180)] {
+        storage
+            .enqueue(
+                TenantQueue { tenant: "acme" },
+                SyncCustomerProfileJob { duration_ms },
+            )
+            .await?;
+    }
+
+    for duration_ms in [seconds(60), seconds(120), seconds(180)] {
+        storage
+            .enqueue(
+                TenantQueue { tenant: "globex" },
+                GenerateInvoiceJob { duration_ms },
+            )
+            .await?;
+    }
+
+    for duration_ms in [seconds(30), seconds(75), seconds(150)] {
+        storage
+            .enqueue(
+                TenantQueue { tenant: "initech" },
+                SendReceiptEmailJob { duration_ms },
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+fn seconds(value: u64) -> u64 {
+    value * 1000
+}

--- a/oxana-web-topcoat/src/assets/busy.js
+++ b/oxana-web-topcoat/src/assets/busy.js
@@ -1,0 +1,3 @@
+function confirmDeleteJob(jobId) {
+    return confirm('Are you sure you want to delete job ' + jobId + '?');
+}

--- a/oxana-web-topcoat/src/assets/charts.css
+++ b/oxana-web-topcoat/src/assets/charts.css
@@ -1,0 +1,26 @@
+.uplot {
+    color: #d1d5db;
+    background: transparent;
+}
+.chart-tooltip {
+    position: absolute;
+    z-index: 10;
+    min-width: var(--chart-tooltip-min-width);
+    pointer-events: none;
+    border: 1px solid #374151;
+    border-radius: 0.375rem;
+    background: rgba(17, 24, 39, 0.96);
+    color: #f9fafb;
+    padding: 0.5rem 0.625rem;
+    font-size: 0.75rem;
+    line-height: 1.25rem;
+    white-space: nowrap;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.35);
+    transform: translate(-50%, -100%);
+}
+.chart-tooltip.hidden {
+    display: none;
+}
+.chart-tooltip-label {
+    color: #9ca3af;
+}

--- a/oxana-web-topcoat/src/assets/charts.js
+++ b/oxana-web-topcoat/src/assets/charts.js
@@ -1,0 +1,277 @@
+const oxanaCharts = (function () {
+    function formatTime(ts) {
+        return new Date(ts * 1000).toLocaleString(undefined, {
+            month: 'numeric',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit'
+        });
+    }
+
+    function formatCount(value) {
+        return Math.round(value).toLocaleString();
+    }
+
+    function formatShortTime(ts) {
+        return new Date(ts * 1000).toLocaleString(undefined, {
+            hour: 'numeric',
+            minute: '2-digit'
+        });
+    }
+
+    var palette = [
+        '#60a5fa', '#4ade80', '#f472b6', '#facc15',
+        '#a78bfa', '#2dd4bf', '#fb923c', '#94a3b8'
+    ];
+
+    function seriesColor(series, index) {
+        return series.color || palette[index % palette.length];
+    }
+
+    function seriesTooltipRows(payload, idx, formatter) {
+        return payload.series.map(function (series, seriesIdx) {
+            return { series: series, seriesIdx: seriesIdx, value: series.data[idx] || 0 };
+        }).sort(function (a, b) {
+            return (b.value - a.value) || (a.seriesIdx - b.seriesIdx);
+        }).filter(function (entry) {
+            return entry.value !== 0;
+        }).map(function (entry) {
+            return {
+                label: entry.series.fullLabel || entry.series.label,
+                value: formatter(entry.value),
+                color: seriesColor(entry.series, entry.seriesIdx)
+            };
+        });
+    }
+
+    function createTooltip(chartEl) {
+        var tooltip = document.createElement('div');
+        tooltip.className = 'chart-tooltip hidden';
+        chartEl.appendChild(tooltip);
+        return tooltip;
+    }
+
+    function fillTooltip(tooltip, timestamp, rows) {
+        tooltip.replaceChildren();
+        [{ label: 'Time', value: formatTime(timestamp) }].concat(rows).forEach(function (entry) {
+            var row = document.createElement('div');
+            var label = document.createElement('span');
+            label.className = 'chart-tooltip-label';
+            label.textContent = entry.label + ':';
+            if (entry.color) {
+                label.style.color = entry.color;
+            }
+            row.appendChild(label);
+            row.append(' ' + entry.value);
+            tooltip.appendChild(row);
+        });
+        tooltip.classList.remove('hidden');
+    }
+
+    function positionTooltip(chartEl, tooltip, x, y) {
+        var halfWidth = tooltip.offsetWidth / 2;
+        var left = Math.min(Math.max(x, halfWidth + 8), chartEl.clientWidth - halfWidth - 8);
+        var top = Math.max(y - 12, tooltip.offsetHeight + 8);
+        tooltip.style.left = left + 'px';
+        tooltip.style.top = top + 'px';
+    }
+
+    function buildTooltip(chartEl, timestamps, rowsForIndex) {
+        var tooltip = createTooltip(chartEl);
+        chartEl.addEventListener('mouseleave', function () {
+            tooltip.classList.add('hidden');
+        });
+        return function (u) {
+            var idx = u.cursor.idx;
+            if (idx == null || idx < 0 || idx >= timestamps.length) {
+                tooltip.classList.add('hidden');
+                return;
+            }
+            fillTooltip(tooltip, timestamps[idx], rowsForIndex(idx));
+            positionTooltip(chartEl, tooltip, u.over.offsetLeft + u.cursor.left, u.over.offsetTop + u.cursor.top);
+        };
+    }
+
+    function renderChart(chartId, payload, valueFormatter, rowsForIndex) {
+        var chartEl = document.getElementById(chartId);
+        if (!chartEl) {
+            return;
+        }
+
+        var data = [payload.timestamps].concat(payload.series.map(function (series) {
+            return series.data;
+        }));
+
+        new uPlot({
+            width: Math.max(chartEl.clientWidth, 320),
+            height: 300,
+            legend: { show: false },
+            tzDate: function (ts) { return uPlot.tzDate(new Date(ts * 1e3), 'Etc/UTC'); },
+            scales: {
+                x: { time: true },
+                y: { range: [0, null] }
+            },
+            axes: [
+                {
+                    stroke: '#9ca3af',
+                    grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
+                    ticks: { stroke: '#374151' }
+                },
+                {
+                    size: 72,
+                    stroke: '#9ca3af',
+                    grid: { stroke: 'rgba(31, 41, 55, 0.7)' },
+                    ticks: { stroke: '#374151' },
+                    values: function (_u, vals) {
+                        return vals.map(valueFormatter);
+                    }
+                }
+            ],
+            series: [
+                {}
+            ].concat(payload.series.map(function (series, index) {
+                return {
+                    label: series.label,
+                    stroke: seriesColor(series, index),
+                    fill: series.fill,
+                    width: 2
+                };
+            })),
+            hooks: {
+                setCursor: [buildTooltip(chartEl, payload.timestamps, rowsForIndex)]
+            }
+        }, data, chartEl);
+    }
+
+    function svgEl(name) {
+        return document.createElementNS('http://www.w3.org/2000/svg', name);
+    }
+
+    function renderStackedChart(chartId, payload, ariaLabel, rowsForIndex) {
+        var chartEl = document.getElementById(chartId);
+        if (!chartEl) {
+            return;
+        }
+
+        var width = Math.max(chartEl.clientWidth, 320);
+        var height = 300;
+        var margin = { top: 12, right: 16, bottom: 44, left: 72 };
+        var plotWidth = width - margin.left - margin.right;
+        var plotHeight = height - margin.top - margin.bottom;
+        var timestamps = payload.timestamps;
+        var totals = timestamps.map(function (_ts, idx) {
+            return payload.series.reduce(function (sum, series) {
+                return sum + (series.data[idx] || 0);
+            }, 0);
+        });
+        var maxTotal = Math.max.apply(null, totals.concat([1]));
+        var barStep = plotWidth / Math.max(timestamps.length, 1);
+        var barWidth = Math.max(1, Math.min(18, barStep * 0.72));
+        var bottom = margin.top + plotHeight;
+
+        chartEl.replaceChildren();
+
+        var tooltip = createTooltip(chartEl);
+
+        var svg = svgEl('svg');
+        svg.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
+        svg.setAttribute('width', '100%');
+        svg.setAttribute('height', height.toString());
+        svg.setAttribute('role', 'img');
+        svg.setAttribute('aria-label', ariaLabel);
+        chartEl.appendChild(svg);
+
+        for (var tick = 0; tick <= 4; tick += 1) {
+            var value = Math.round((maxTotal * tick) / 4);
+            var y = bottom - (plotHeight * value / maxTotal);
+
+            var grid = svgEl('line');
+            grid.setAttribute('x1', margin.left.toString());
+            grid.setAttribute('x2', (width - margin.right).toString());
+            grid.setAttribute('y1', y.toString());
+            grid.setAttribute('y2', y.toString());
+            grid.setAttribute('stroke', 'rgba(31, 41, 55, 0.7)');
+            svg.appendChild(grid);
+
+            var label = svgEl('text');
+            label.setAttribute('x', (margin.left - 14).toString());
+            label.setAttribute('y', (y + 4).toString());
+            label.setAttribute('text-anchor', 'end');
+            label.setAttribute('fill', '#9ca3af');
+            label.setAttribute('font-size', '12');
+            label.textContent = formatCount(value);
+            svg.appendChild(label);
+        }
+
+        var xTickIndexes = Array.from(new Set([
+            0,
+            Math.floor((timestamps.length - 1) / 3),
+            Math.floor(((timestamps.length - 1) * 2) / 3),
+            timestamps.length - 1
+        ])).filter(function (idx) {
+            return idx >= 0 && idx < timestamps.length;
+        });
+
+        xTickIndexes.forEach(function (idx) {
+            var x = margin.left + (idx + 0.5) * barStep;
+            var label = svgEl('text');
+            label.setAttribute('x', x.toString());
+            label.setAttribute('y', (height - 14).toString());
+            label.setAttribute('text-anchor', 'middle');
+            label.setAttribute('fill', '#9ca3af');
+            label.setAttribute('font-size', '12');
+            label.textContent = formatShortTime(timestamps[idx]);
+            svg.appendChild(label);
+        });
+
+        function appendSegment(idx, value, offset, series, seriesIdx) {
+            if (value <= 0) {
+                return;
+            }
+
+            var segmentHeight = Math.max(1, plotHeight * value / maxTotal);
+            var y = bottom - (plotHeight * (offset + value) / maxTotal);
+            var rect = svgEl('rect');
+            rect.setAttribute('x', (margin.left + idx * barStep + (barStep - barWidth) / 2).toString());
+            rect.setAttribute('y', y.toString());
+            rect.setAttribute('width', barWidth.toString());
+            rect.setAttribute('height', segmentHeight.toString());
+            rect.setAttribute('fill', seriesColor(series, seriesIdx));
+            if (series.border) {
+                rect.setAttribute('stroke', series.border);
+                rect.setAttribute('stroke-width', '0.75');
+            }
+            svg.appendChild(rect);
+        }
+
+        timestamps.forEach(function (_ts, idx) {
+            var offset = 0;
+            payload.series.forEach(function (series, seriesIdx) {
+                var value = series.data[idx] || 0;
+                appendSegment(idx, value, offset, series, seriesIdx);
+                offset += value;
+            });
+        });
+
+        svg.addEventListener('mousemove', function (event) {
+            var rect = svg.getBoundingClientRect();
+            var localX = ((event.clientX - rect.left) / rect.width) * width;
+            var idx = Math.round((localX - margin.left) / barStep - 0.5);
+            idx = Math.max(0, Math.min(timestamps.length - 1, idx));
+
+            fillTooltip(tooltip, timestamps[idx], rowsForIndex(idx, totals[idx] || 0));
+            positionTooltip(chartEl, tooltip, event.clientX - rect.left, event.clientY - rect.top);
+        });
+
+        svg.addEventListener('mouseleave', function () {
+            tooltip.classList.add('hidden');
+        });
+    }
+
+    return {
+        renderChart: renderChart,
+        renderStackedChart: renderStackedChart,
+        seriesTooltipRows: seriesTooltipRows,
+        formatCount: formatCount
+    };
+})();

--- a/oxana-web-topcoat/src/assets/global_jobs.js
+++ b/oxana-web-topcoat/src/assets/global_jobs.js
@@ -1,0 +1,40 @@
+function toggleFullError(btn) {
+    var container = btn.parentElement;
+    var truncated = container.querySelector('.error-truncated');
+    var full = container.querySelector('.error-full');
+    if (full.style.display === 'none') {
+        truncated.style.display = 'none';
+        full.style.display = '';
+        btn.textContent = 'Show less';
+    } else {
+        truncated.style.display = '';
+        full.style.display = 'none';
+        btn.textContent = 'View full error';
+    }
+}
+function copyErrorInfo(btn) {
+    var info = [
+        'Job: ' + btn.dataset.jobName,
+        'Queue: ' + btn.dataset.queue,
+        'Created: ' + btn.dataset.created,
+        'Arguments: ' + btn.dataset.args,
+        'Error: ' + btn.dataset.error
+    ].join('\n');
+    navigator.clipboard.writeText(info).then(function() {
+        btn.textContent = 'Copied!';
+        setTimeout(function() { btn.textContent = 'Copy Error Info'; }, 1500);
+    }, function() {
+        btn.textContent = 'Copy failed';
+        setTimeout(function() { btn.textContent = 'Copy Error Info'; }, 1500);
+    });
+}
+function confirmWipeDead() {
+    var input = prompt('Type WIPE to permanently remove all dead jobs.');
+    return input === 'WIPE';
+}
+function confirmReviveAllDead() {
+    return confirm('Revive all dead jobs now?');
+}
+function confirmRetryAllNow() {
+    return confirm('Retry all pending retry jobs now?');
+}

--- a/oxana-web-topcoat/src/assets/metric_detail.js
+++ b/oxana-web-topcoat/src/assets/metric_detail.js
@@ -1,0 +1,36 @@
+window.addEventListener('DOMContentLoaded', function () {
+    if (typeof uPlot === 'undefined') {
+        return;
+    }
+
+    function formatMillis(value) {
+        if (value >= 1000) {
+            return (value / 1000).toFixed(2) + 's';
+        }
+        return value.toFixed(0) + 'ms';
+    }
+
+    var average = JSON.parse(document.getElementById('metric-detail-data-0').textContent);
+    oxanaCharts.renderChart('average-chart', {
+        timestamps: average[0],
+        series: [{ label: 'Avg', data: average[1], color: '#c084fc', fill: 'rgba(192, 132, 252, 0.10)' }]
+    }, formatMillis, function (idx) {
+        return [{ label: 'Avg', value: formatMillis(average[1][idx]) }];
+    });
+    var executions = JSON.parse(document.getElementById('metric-detail-data-1').textContent);
+    oxanaCharts.renderStackedChart('executions-chart', {
+        timestamps: executions[0],
+        series: [
+            { label: 'Succeeded', data: executions[1], color: '#34d399' },
+            { label: 'Failed', data: executions[2], color: '#ef4444' },
+            { label: 'Panicked', data: executions[3], color: '#000000', border: '#6b7280' }
+        ]
+    }, 'Total executions by minute', function (idx, total) {
+        return [
+            { label: 'Succeeded', value: oxanaCharts.formatCount(executions[1][idx] || 0) },
+            { label: 'Failed', value: oxanaCharts.formatCount(executions[2][idx] || 0) },
+            { label: 'Panicked', value: oxanaCharts.formatCount(executions[3][idx] || 0) },
+            { label: 'Total', value: oxanaCharts.formatCount(total) }
+        ];
+    });
+});

--- a/oxana-web-topcoat/src/assets/metrics.js
+++ b/oxana-web-topcoat/src/assets/metrics.js
@@ -1,0 +1,25 @@
+window.addEventListener('DOMContentLoaded', function () {
+    if (typeof uPlot === 'undefined') {
+        return;
+    }
+
+    function formatSeconds(value) {
+        if (value >= 60) {
+            return (value / 60).toFixed(1) + 'm';
+        }
+        return value.toFixed(1) + 's';
+    }
+
+    var execution = JSON.parse(document.getElementById('metrics-data-0').textContent);
+    oxanaCharts.renderChart('execution-chart', execution, formatSeconds, function (idx) {
+        return oxanaCharts.seriesTooltipRows(execution, idx, formatSeconds);
+    });
+    var processed = JSON.parse(document.getElementById('metrics-data-1').textContent);
+    oxanaCharts.renderStackedChart('processed-chart', processed, 'Total processed by worker', function (idx, total) {
+        var rows = oxanaCharts.seriesTooltipRows(processed, idx, oxanaCharts.formatCount);
+        if (total !== 0) {
+            rows.push({ label: 'Total', value: oxanaCharts.formatCount(total) });
+        }
+        return rows;
+    });
+});

--- a/oxana-web-topcoat/src/assets/notices.js
+++ b/oxana-web-topcoat/src/assets/notices.js
@@ -1,0 +1,10 @@
+document.addEventListener("DOMContentLoaded", () => {
+        for (const notice of document.querySelectorAll("[data-auto-dismiss-notice]")) {
+            setTimeout(() => {
+                notice.style.transition = "opacity 200ms ease, transform 200ms ease";
+                notice.style.opacity = "0";
+                notice.style.transform = "translateY(-4px)";
+                setTimeout(() => notice.remove(), 220);
+            }, 3000);
+        }
+    });

--- a/oxana-web-topcoat/src/assets/notices.js
+++ b/oxana-web-topcoat/src/assets/notices.js
@@ -1,10 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
-        for (const notice of document.querySelectorAll("[data-auto-dismiss-notice]")) {
-            setTimeout(() => {
-                notice.style.transition = "opacity 200ms ease, transform 200ms ease";
-                notice.style.opacity = "0";
-                notice.style.transform = "translateY(-4px)";
-                setTimeout(() => notice.remove(), 220);
-            }, 3000);
-        }
-    });
+    for (const notice of document.querySelectorAll("[data-auto-dismiss-notice]")) {
+        setTimeout(() => {
+            notice.style.transition = "opacity 200ms ease, transform 200ms ease";
+            notice.style.opacity = "0";
+            notice.style.transform = "translateY(-4px)";
+            setTimeout(() => notice.remove(), 220);
+        }, 3000);
+    }
+});

--- a/oxana-web-topcoat/src/assets/on_demand.css
+++ b/oxana-web-topcoat/src/assets/on_demand.css
@@ -1,0 +1,6 @@
+summary::-webkit-details-marker {
+    display: none;
+}
+summary::marker {
+    content: "";
+}

--- a/oxana-web-topcoat/src/assets/queue_detail.js
+++ b/oxana-web-topcoat/src/assets/queue_detail.js
@@ -1,0 +1,32 @@
+function promptConcurrency(form) {
+    var current = form.dataset.currentConcurrency || '';
+    var defaultConcurrency = form.dataset.defaultConcurrency || '';
+    var queueKey = form.dataset.queueKey || 'queue';
+    var promptText = 'Set concurrency for ' + queueKey;
+
+    if (defaultConcurrency) {
+        promptText += ' (default ' + defaultConcurrency + ')';
+    }
+
+    var input = prompt(promptText, current);
+    if (input === null) {
+        return false;
+    }
+
+    input = input.trim();
+    if (!/^[1-9][0-9]*$/.test(input)) {
+        alert('Concurrency must be a positive integer.');
+        return false;
+    }
+
+    form.elements.concurrency.value = input;
+    return true;
+}
+
+function confirmWipe(queueKey) {
+    var input = prompt('Type the queue name to confirm wipe: ' + queueKey);
+    return input === queueKey;
+}
+function confirmDeleteJob(jobId) {
+    return confirm('Are you sure you want to delete job ' + jobId + '?');
+}

--- a/oxana-web-topcoat/src/assets/queues.js
+++ b/oxana-web-topcoat/src/assets/queues.js
@@ -1,0 +1,10 @@
+window.addEventListener('DOMContentLoaded', function () {
+    if (typeof uPlot === 'undefined') {
+        return;
+    }
+
+    var payload = JSON.parse(document.getElementById('queues-data-0').textContent);
+    oxanaCharts.renderChart('queue-length-chart', payload, oxanaCharts.formatCount, function (idx) {
+        return oxanaCharts.seriesTooltipRows(payload, idx, oxanaCharts.formatCount);
+    });
+});

--- a/oxana-web-topcoat/src/filters.rs
+++ b/oxana-web-topcoat/src/filters.rs
@@ -1,0 +1,499 @@
+pub fn relative_time(ts: &i64) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let diff_secs = now - ts;
+    format_relative(diff_secs)
+}
+
+fn format_relative(diff_secs: i64) -> String {
+    if diff_secs.abs() < 15 {
+        return "now".to_string();
+    }
+
+    let abs = diff_secs.abs();
+    let (prefix, suffix) = if diff_secs > 0 {
+        ("", " ago")
+    } else {
+        ("in ", "")
+    };
+
+    if abs < 60 {
+        format!("{prefix}{abs}s{suffix}")
+    } else if abs < 3600 {
+        format!("{prefix}{}m{suffix}", abs / 60)
+    } else {
+        let h = abs / 3600;
+        let m = (abs % 3600) / 60;
+        if m == 0 {
+            format!("{prefix}{h}h{suffix}")
+        } else {
+            format!("{prefix}{h}h{m}m{suffix}")
+        }
+    }
+}
+
+pub fn relative_time_micros(ts: &i64) -> String {
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let diff_secs = (now_micros - ts) / 1_000_000;
+    format_relative(diff_secs)
+}
+
+pub fn format_latency(secs: &f64) -> String {
+    if *secs > 3600.0 {
+        format!("{:.1}h", secs / 3600.0)
+    } else if *secs > 600.0 {
+        format!("{:.1}m", secs / 60.0)
+    } else {
+        format!("{secs:.1}s")
+    }
+}
+
+fn format_duration_from_ms(ms: f64) -> String {
+    if ms >= 3_600_000.0 {
+        format!("{:.1}h", ms / 3_600_000.0)
+    } else if ms >= 60_000.0 {
+        format!("{:.1}m", ms / 60_000.0)
+    } else if ms >= 1_000.0 {
+        format!("{:.2}s", ms / 1_000.0)
+    } else {
+        format!("{ms:.0}ms")
+    }
+}
+
+pub fn format_duration_ms(val: &u64) -> String {
+    format_duration_from_ms(*val as f64)
+}
+
+pub fn format_duration_ms_f64(val: f64) -> String {
+    format_duration_from_ms(val)
+}
+
+fn format_duration_from_secs(secs: f64) -> String {
+    if secs >= 3600.0 {
+        format!("{:.1}h", secs / 3600.0)
+    } else if secs >= 60.0 {
+        format!("{:.1}m", secs / 60.0)
+    } else {
+        format!("{secs:.1}s")
+    }
+}
+
+pub fn format_rate_per_minute(val: &f64) -> String {
+    format!("{val:.1}/min")
+}
+
+pub fn format_signed_rate_per_minute(val: &f64) -> String {
+    format!("{val:+.1}/min")
+}
+
+pub fn format_eta_s(val: &Option<f64>) -> String {
+    val.map(format_duration_from_secs)
+        .unwrap_or_else(|| "—".to_string())
+}
+
+pub fn pretty_json(val: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(val).unwrap_or_else(|_| val.to_string())
+}
+
+pub fn relative_time_micros_opt(ts: &Option<i64>) -> String {
+    let Some(ts) = ts else {
+        return "—".to_string();
+    };
+
+    let now_micros = chrono::Utc::now().timestamp_micros();
+    let diff_secs = (now_micros - ts) / 1_000_000;
+    format_relative(diff_secs)
+}
+
+fn format_with_commas(mut n: u64) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+
+    let mut groups = Vec::new();
+    while n > 0 {
+        groups.push(n % 1000);
+        n /= 1000;
+    }
+
+    let mut result = groups.last().map_or_else(String::new, |g| g.to_string());
+    for g in groups.iter().rev().skip(1) {
+        result.push_str(&format!(",{g:03}"));
+    }
+    result
+}
+
+pub fn format_number(val: &usize) -> String {
+    format_with_commas(*val as u64)
+}
+
+pub fn format_number_u64(val: &u64) -> String {
+    format_with_commas(*val)
+}
+
+pub fn format_number_i64(val: &i64) -> String {
+    let (prefix, abs) = if *val < 0 {
+        ("-", val.unsigned_abs())
+    } else {
+        ("", *val as u64)
+    };
+    format!("{prefix}{}", format_with_commas(abs))
+}
+
+pub fn has_args(val: &serde_json::Value) -> bool {
+    let empty = match val {
+        serde_json::Value::Null => true,
+        serde_json::Value::Object(m) => m.is_empty(),
+        _ => false,
+    };
+    !empty
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimpleArgPill {
+    pub key: String,
+    pub value: String,
+}
+
+fn simple_arg_value(val: &serde_json::Value) -> Option<String> {
+    match val {
+        serde_json::Value::Null => Some("null".to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::String(value) => Some(if value.is_empty() {
+            "\"\"".to_string()
+        } else {
+            value.clone()
+        }),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => None,
+    }
+}
+
+fn simple_args_for(val: &serde_json::Value) -> Vec<SimpleArgPill> {
+    let serde_json::Value::Object(args) = val else {
+        return Vec::new();
+    };
+
+    args.iter()
+        .filter_map(|(key, value)| {
+            simple_arg_value(value).map(|value| SimpleArgPill {
+                key: key.clone(),
+                value,
+            })
+        })
+        .collect()
+}
+
+pub fn simple_args(val: &serde_json::Value) -> Vec<SimpleArgPill> {
+    simple_args_for(val)
+}
+
+fn should_show_args_json(val: &serde_json::Value) -> bool {
+    match val {
+        serde_json::Value::Null => false,
+        serde_json::Value::Object(args) if args.is_empty() => false,
+        serde_json::Value::Object(args) => {
+            args.values().any(|value| simple_arg_value(value).is_none())
+        }
+        serde_json::Value::Array(_)
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => true,
+    }
+}
+
+pub fn show_args_json(val: &serde_json::Value) -> bool {
+    should_show_args_json(val)
+}
+
+fn progress_parts(val: &serde_json::Value) -> Option<oxana::JobProgress> {
+    serde_json::from_value(val.clone()).ok()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ProgressView {
+    pub summary: String,
+    pub percent: String,
+    pub note: String,
+    pub eta: String,
+}
+
+impl ProgressView {
+    fn from_state(
+        state: &serde_json::Value,
+        started_at_micros: Option<i64>,
+        now_micros: i64,
+    ) -> Option<Self> {
+        let progress = progress_parts(state)?;
+        if progress.total <= 0 {
+            return None;
+        }
+
+        let percent =
+            ((progress.cursor.max(0) as f64 / progress.total as f64) * 100.0).clamp(0.0, 100.0);
+        let eta = progress_eta_s(&progress, started_at_micros, now_micros)
+            .map(format_duration_from_secs)
+            .unwrap_or_else(|| "—".to_string());
+
+        Some(Self {
+            summary: format!(
+                "{} / {} ({percent:.0}%)",
+                format_with_commas(progress.cursor.max(0) as u64),
+                format_with_commas(progress.total as u64),
+            ),
+            percent: format!("{percent:.0}"),
+            note: progress.note.unwrap_or_default(),
+            eta,
+        })
+    }
+}
+
+fn progress_eta_s(
+    progress: &oxana::JobProgress,
+    started_at_micros: Option<i64>,
+    now_micros: i64,
+) -> Option<f64> {
+    let started_at_micros = started_at_micros?;
+    if progress.total <= 0 || progress.cursor <= 0 || started_at_micros <= 0 {
+        return None;
+    }
+
+    let remaining = progress.total.saturating_sub(progress.cursor).max(0);
+    if remaining == 0 {
+        return Some(0.0);
+    }
+
+    let elapsed_s = (now_micros - started_at_micros) as f64 / 1_000_000.0;
+    if elapsed_s <= 0.0 {
+        return None;
+    }
+
+    let cursor = progress.cursor.max(0) as f64;
+    Some(elapsed_s * (remaining as f64 / cursor))
+}
+
+pub fn job_progress(
+    state: &serde_json::Value,
+    started_at_micros: &Option<i64>,
+) -> Option<ProgressView> {
+    ProgressView::from_state(
+        state,
+        *started_at_micros,
+        chrono::Utc::now().timestamp_micros(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ProgressView, SimpleArgPill, progress_parts, should_show_args_json, simple_args_for,
+    };
+    use serde_json::json;
+
+    fn progress_eta_s(state: &serde_json::Value, started_at: Option<i64>, now: i64) -> Option<f64> {
+        super::progress_eta_s(&progress_parts(state)?, started_at, now)
+    }
+
+    fn should_show_progress(state: &serde_json::Value) -> bool {
+        ProgressView::from_state(state, None, 0).is_some()
+    }
+
+    #[test]
+    fn progress_view_formats_object_and_tuple_states_identically() {
+        let expected = ProgressView {
+            summary: "1,250 / 5,000 (25%)".to_string(),
+            percent: "25".to_string(),
+            note: "Importing".to_string(),
+            eta: "30.0s".to_string(),
+        };
+        for state in [
+            json!({"cursor": 1250, "total": 5000, "note": "Importing"}),
+            json!([1250, 5000, "Importing"]),
+        ] {
+            assert_eq!(
+                ProgressView::from_state(&state, Some(1_000_000), 11_000_000).as_ref(),
+                Some(&expected)
+            );
+        }
+    }
+
+    #[test]
+    fn progress_view_clamps_percent_and_preserves_unknown_eta() {
+        let negative = ProgressView::from_state(&json!([-1, 10]), None, 0).unwrap();
+        assert_eq!(negative.summary, "0 / 10 (0%)");
+        assert_eq!(negative.percent, "0");
+        assert_eq!(negative.eta, "—");
+        assert!(negative.note.is_empty());
+
+        let complete =
+            ProgressView::from_state(&json!([15, 10]), Some(1_000_000), 11_000_000).unwrap();
+        assert_eq!(complete.summary, "15 / 10 (100%)");
+        assert_eq!(complete.percent, "100");
+        assert_eq!(complete.eta, "0.0s");
+    }
+
+    #[test]
+    fn simple_args_include_top_level_scalar_values() {
+        let value = json!({
+            "game_id": 12345,
+            "league": "nba",
+            "dry_run": true,
+            "missing": null,
+        });
+
+        assert_eq!(
+            simple_args_for(&value),
+            vec![
+                SimpleArgPill {
+                    key: "game_id".to_string(),
+                    value: "12345".to_string(),
+                },
+                SimpleArgPill {
+                    key: "league".to_string(),
+                    value: "nba".to_string(),
+                },
+                SimpleArgPill {
+                    key: "dry_run".to_string(),
+                    value: "true".to_string(),
+                },
+                SimpleArgPill {
+                    key: "missing".to_string(),
+                    value: "null".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn simple_args_include_scalar_values_from_mixed_args() {
+        let value = json!({
+            "game_id": 12345,
+            "metadata": { "season": 2026 },
+        });
+
+        assert_eq!(
+            simple_args_for(&value),
+            vec![SimpleArgPill {
+                key: "game_id".to_string(),
+                value: "12345".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn simple_args_require_an_object() {
+        assert!(simple_args_for(&json!(12345)).is_empty());
+        assert!(simple_args_for(&json!(["game_id", 12345])).is_empty());
+    }
+
+    #[test]
+    fn args_json_only_shows_when_pills_do_not_cover_everything() {
+        assert!(!should_show_args_json(&json!({})));
+        assert!(!should_show_args_json(&json!({
+            "game_id": 12345,
+            "dry_run": false,
+        })));
+        assert!(should_show_args_json(&json!({
+            "game_id": 12345,
+            "metadata": { "season": 2026 },
+        })));
+        assert!(should_show_args_json(&json!(12345)));
+    }
+
+    #[test]
+    fn progress_parts_recognizes_update_progress_state() {
+        let value = json!({
+            "cursor": 25,
+            "total": 100,
+            "note": "importing users"
+        });
+
+        assert_eq!(
+            progress_parts(&value),
+            Some(oxana::JobProgress {
+                cursor: 25,
+                total: 100,
+                note: Some("importing users".to_string()),
+            })
+        );
+        assert_eq!(
+            progress_parts(&json!(42)),
+            Some(oxana::JobProgress::from(42))
+        );
+        assert_eq!(
+            progress_parts(&json!([25, 100])),
+            Some(oxana::JobProgress {
+                cursor: 25,
+                total: 100,
+                note: None,
+            })
+        );
+    }
+
+    #[test]
+    fn progress_display_requires_total() {
+        assert!(!should_show_progress(&json!(42)));
+        assert!(!should_show_progress(&json!({
+            "cursor": 42,
+            "total": 0
+        })));
+        assert!(should_show_progress(&json!([1, 100])));
+        assert!(should_show_progress(&json!({
+            "cursor": 42,
+            "total": 100
+        })));
+    }
+
+    #[test]
+    fn progress_eta_uses_started_time_and_progress_rate() {
+        let state = json!({
+            "cursor": 25,
+            "total": 100
+        });
+
+        assert_eq!(
+            progress_eta_s(&state, Some(9_000_000), 19_000_000),
+            Some(30.0)
+        );
+    }
+
+    #[test]
+    fn progress_eta_ignores_time_spent_waiting_in_queue() {
+        let state = json!({
+            "cursor": 25,
+            "total": 100
+        });
+
+        assert_eq!(
+            progress_eta_s(&state, Some(43_201_000_000), 43_211_000_000),
+            Some(30.0)
+        );
+    }
+
+    #[test]
+    fn progress_eta_is_unknown_without_rate() {
+        assert_eq!(
+            progress_eta_s(
+                &json!({
+                    "cursor": 0,
+                    "total": 100
+                }),
+                Some(1_000_000),
+                11_000_000
+            ),
+            None
+        );
+        assert_eq!(progress_eta_s(&json!([25, 100]), None, 11_000_000), None);
+    }
+
+    #[test]
+    fn progress_eta_is_zero_when_complete() {
+        assert_eq!(
+            progress_eta_s(&json!([100, 100]), Some(1_000_000), 11_000_000),
+            Some(0.0)
+        );
+        assert_eq!(
+            progress_eta_s(&json!([125, 100]), Some(1_000_000), 11_000_000),
+            Some(0.0)
+        );
+    }
+}

--- a/oxana-web-topcoat/src/handlers.rs
+++ b/oxana-web-topcoat/src/handlers.rs
@@ -1,0 +1,1939 @@
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use topcoat::router::error::{SeeOther, see_other};
+
+use crate::OxanaWebState;
+use crate::models::{
+    BusyTemplate, CronRow, CronTemplate, CronWorkerView, DashboardTemplate, GlobalJobsTemplate,
+    JobDetailTemplate, JobListKind, MetricDetailTemplate, MetricsTemplate, OnDemandJobView,
+    OnDemandQueueView, OnDemandRow, OnDemandTemplate, QueueConcurrencyStatus, QueueDetailTemplate,
+    QueueRuntimeConfigView, QueuesTemplate,
+};
+use crate::pagination::JobPage;
+use topcoat::Error as OxanaWebError;
+
+const DEFAULT_QUEUE_SORT: &str = "enqueued";
+const DEFAULT_QUEUE_SORT_DIRECTION: &str = "desc";
+
+pub(crate) async fn dashboard(state: OxanaWebState) -> Result<DashboardTemplate, OxanaWebError> {
+    let stats = state.storage.stats().await?;
+    let queue_configs = queue_config_map(&state.storage, &state.catalog, &stats).await?;
+
+    Ok(DashboardTemplate {
+        base_path: state.base_path,
+        active_tab: "",
+        stats,
+        queue_configs,
+    })
+}
+
+pub(crate) async fn busy(state: OxanaWebState) -> Result<BusyTemplate, OxanaWebError> {
+    let stats = state.storage.stats().await?;
+    let queue_configs = queue_config_map(&state.storage, &state.catalog, &stats).await?;
+
+    Ok(BusyTemplate {
+        base_path: state.base_path,
+        active_tab: "/busy",
+        stats,
+        queue_configs,
+    })
+}
+
+pub(crate) async fn queues_list(
+    state: OxanaWebState,
+    params: QueuesParams,
+) -> Result<QueuesTemplate, OxanaWebError> {
+    let mut stats = state.storage.stats().await?;
+    let queue_configs = queue_config_map(&state.storage, &state.catalog, &stats).await?;
+    let query = oxana::JobMetricsQuery::new(params.minutes.unwrap_or(0));
+    let queue_lengths = state.storage.queue_length_metrics(query).await?;
+
+    let (sort, dir) = sort_queues_for_params(&mut stats.queues, &queue_configs, &params);
+
+    Ok(QueuesTemplate {
+        base_path: state.base_path,
+        active_tab: "/queues",
+        stats,
+        queue_configs,
+        queue_lengths,
+        sort: sort.to_string(),
+        dir: dir.to_string(),
+    })
+}
+
+pub(crate) async fn metrics(
+    state: OxanaWebState,
+    params: MetricsParams,
+) -> Result<MetricsTemplate, OxanaWebError> {
+    let query = oxana::JobMetricsQuery::new(params.minutes.unwrap_or(0));
+    let metrics = state.storage.job_metrics(query).await?;
+    let sort = params
+        .sort
+        .as_deref()
+        .filter(|sort| valid_metric_sort(sort))
+        .unwrap_or("");
+    let dir = if !sort.is_empty() && params.dir.as_deref() == Some("asc") {
+        "asc"
+    } else {
+        "desc"
+    };
+    let sort_key = if sort.is_empty() { "total_time" } else { sort };
+    let table_workers = sorted_worker_metrics(&metrics.workers, sort_key, dir == "desc");
+
+    Ok(MetricsTemplate {
+        base_path: state.base_path,
+        active_tab: "/metrics",
+        metrics,
+        table_workers,
+        sort: sort.to_string(),
+        dir: dir.to_string(),
+    })
+}
+
+pub(crate) async fn metric_detail(
+    state: OxanaWebState,
+    params: MetricDetailParams,
+) -> Result<MetricDetailTemplate, OxanaWebError> {
+    let identity = oxana::MetricIdentity {
+        worker: params.worker,
+    };
+    let metrics = state
+        .storage
+        .job_metrics_for(
+            &identity,
+            oxana::JobMetricsQuery::new(params.minutes.unwrap_or(0)),
+        )
+        .await?;
+
+    Ok(MetricDetailTemplate {
+        base_path: state.base_path,
+        active_tab: "/metrics",
+        metrics,
+    })
+}
+
+pub(crate) async fn cron_jobs(state: OxanaWebState, params: CronParams) -> CronTemplate {
+    let now = chrono::Utc::now();
+    let rows = build_cron_rows(&state.catalog.cron_workers, &now);
+    let total = state.catalog.cron_workers.len();
+
+    CronTemplate {
+        base_path: state.base_path,
+        active_tab: "/cron",
+        rows,
+        total,
+        enqueued: params.enqueued.as_deref() == Some("1"),
+    }
+}
+
+pub(crate) async fn enqueue_cron_job(
+    state: OxanaWebState,
+    form: CronEnqueueJobForm,
+) -> Result<SeeOther, OxanaWebError> {
+    let envelope = cron_envelope_from_form(&state.catalog, &form)?;
+    state.storage.enqueue_envelope(envelope).await?;
+
+    Ok(cron_enqueued_redirect(&state.base_path))
+}
+
+pub(crate) async fn on_demand_jobs(
+    state: OxanaWebState,
+    params: OnDemandParams,
+) -> OnDemandTemplate {
+    let rows = build_on_demand_rows(&state.catalog.on_demand_jobs);
+    let queues = build_on_demand_queue_views(&state.catalog.queues);
+
+    OnDemandTemplate {
+        base_path: state.base_path,
+        active_tab: "/on-demand",
+        total: state.catalog.on_demand_jobs.len(),
+        rows,
+        queues,
+        scheduled: params.scheduled.as_deref() == Some("1"),
+        invalid_json: params.invalid_json.as_deref() == Some("1"),
+    }
+}
+
+pub(crate) async fn enqueue_on_demand_job(
+    state: OxanaWebState,
+    form: OnDemandEnqueueJobForm,
+) -> Result<SeeOther, OxanaWebError> {
+    let envelope = match on_demand_envelope_from_form(&state.catalog, &form) {
+        Ok(envelope) => envelope,
+        Err(oxana::OxanaError::JsonError(_)) => {
+            return Ok(see_other(format!(
+                "{}/on-demand?invalid_json=1",
+                state.base_path
+            )));
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    state.storage.enqueue_envelope(envelope).await?;
+
+    Ok(see_other(format!(
+        "{}/on-demand?scheduled=1",
+        state.base_path
+    )))
+}
+
+async fn global_jobs(
+    state: OxanaWebState,
+    params: PaginationParams,
+    kind: JobListKind,
+) -> Result<GlobalJobsTemplate, OxanaWebError> {
+    let opts = JobPage::list_opts(params.page);
+    let (total, jobs) = match kind {
+        JobListKind::Scheduled => (
+            state.storage.scheduled_count().await?,
+            state.storage.list_scheduled(&opts).await?,
+        ),
+        JobListKind::Dead => (
+            state.storage.dead_count().await?,
+            state.storage.list_dead(&opts).await?,
+        ),
+        JobListKind::Retries => (
+            state.storage.retries_count().await?,
+            state.storage.list_retries(&opts).await?,
+        ),
+    };
+
+    Ok(GlobalJobsTemplate {
+        base_path: state.base_path,
+        active_tab: kind.path(),
+        kind,
+        page: JobPage::new(params.page, total, jobs),
+    })
+}
+
+pub(crate) async fn scheduled_jobs(
+    state: OxanaWebState,
+    params: PaginationParams,
+) -> Result<GlobalJobsTemplate, OxanaWebError> {
+    global_jobs(state, params, JobListKind::Scheduled).await
+}
+
+pub(crate) async fn dead_jobs(
+    state: OxanaWebState,
+    params: PaginationParams,
+) -> Result<GlobalJobsTemplate, OxanaWebError> {
+    global_jobs(state, params, JobListKind::Dead).await
+}
+
+pub(crate) async fn wipe_dead(state: OxanaWebState) -> Result<SeeOther, OxanaWebError> {
+    state.storage.wipe_dead().await?;
+
+    Ok(see_other(format!("{}/dead", state.base_path)))
+}
+
+pub(crate) async fn revive_all_dead(state: OxanaWebState) -> Result<SeeOther, OxanaWebError> {
+    state.storage.revive_all_dead().await?;
+
+    Ok(see_other(format!("{}/dead", state.base_path)))
+}
+
+pub(crate) async fn retry_jobs(
+    state: OxanaWebState,
+    params: PaginationParams,
+) -> Result<GlobalJobsTemplate, OxanaWebError> {
+    global_jobs(state, params, JobListKind::Retries).await
+}
+
+pub(crate) async fn retry_all_now(state: OxanaWebState) -> Result<SeeOther, OxanaWebError> {
+    state.storage.retry_all_now().await?;
+
+    Ok(see_other(format!("{}/retries", state.base_path)))
+}
+
+pub(crate) async fn job_detail(
+    state: OxanaWebState,
+    job_id: String,
+) -> Result<JobDetailTemplate, OxanaWebError> {
+    let (job, is_dead) = find_job(&state.storage, &job_id).await?;
+
+    Ok(JobDetailTemplate {
+        base_path: state.base_path,
+        active_tab: "/jobs",
+        job_id,
+        job,
+        is_dead,
+    })
+}
+
+pub(crate) async fn queue_detail(
+    state: OxanaWebState,
+    queue_key: String,
+    params: PaginationParams,
+) -> Result<Option<QueueDetailTemplate>, OxanaWebError> {
+    if is_dynamic_parent_queue(&state.catalog, &queue_key) {
+        return Ok(None);
+    }
+
+    let opts = JobPage::list_opts(params.page);
+
+    let stats = state.storage.stats().await?;
+    let queue_config = queue_runtime_config_for(&state, &queue_key).await?;
+    let live_enqueued = state
+        .storage
+        .enqueued_count(RawQueue::fixed(queue_key.clone()))
+        .await?;
+    let queue_stats = queue_detail_queue_stats(&stats, &queue_key, live_enqueued);
+    let active_jobs = stats
+        .processing
+        .iter()
+        .filter(|p| p.job_envelope.queue == queue_key)
+        .cloned()
+        .collect::<Vec<_>>();
+    let busy = active_jobs.len();
+
+    let jobs = state
+        .storage
+        .list_queue_jobs(RawQueue::fixed(queue_key.clone()), &opts)
+        .await?;
+
+    Ok(Some(QueueDetailTemplate {
+        base_path: state.base_path,
+        active_tab: "/queues",
+        queue_key,
+        queue_stats,
+        queue_config,
+        active_jobs,
+        busy,
+        page: JobPage::new(params.page, live_enqueued, jobs),
+    }))
+}
+
+fn is_dynamic_parent_queue(catalog: &oxana::Catalog, queue_key: &str) -> bool {
+    !queue_key.contains('#')
+        && catalog
+            .queues
+            .iter()
+            .any(|queue| queue.key == queue_key && queue.dynamic)
+}
+
+fn queue_detail_queue_stats(
+    stats: &oxana::Stats,
+    queue_key: &str,
+    live_enqueued: usize,
+) -> Option<oxana::QueueStats> {
+    if let Some(queue_stats) = stats.queues.iter().find(|q| q.key == queue_key).cloned() {
+        return Some(queue_stats_with_live_enqueued(queue_stats, live_enqueued));
+    }
+
+    let (prefix, suffix) = queue_key.split_once('#')?;
+    let parent = stats.queues.iter().find(|q| q.key == prefix)?;
+    let dynamic_queue = parent.queues.iter().find(|q| q.suffix == suffix)?;
+
+    Some(queue_stats_with_live_enqueued(
+        oxana::QueueStats {
+            key: queue_key.to_string(),
+            enqueued: dynamic_queue.enqueued,
+            processed: dynamic_queue.processed,
+            succeeded: dynamic_queue.succeeded,
+            panicked: dynamic_queue.panicked,
+            failed: dynamic_queue.failed,
+            latency_s: dynamic_queue.latency_s,
+            rate: dynamic_queue.rate,
+            queues: Vec::new(),
+        },
+        live_enqueued,
+    ))
+}
+
+fn queue_stats_with_live_enqueued(
+    mut queue_stats: oxana::QueueStats,
+    live_enqueued: usize,
+) -> oxana::QueueStats {
+    let effective_drain_per_minute = queue_stats.rate.effective_drain_per_minute;
+    queue_stats.rate.eta_s = if live_enqueued == 0 {
+        Some(0.0)
+    } else if effective_drain_per_minute > 0.0 {
+        Some(live_enqueued as f64 / (effective_drain_per_minute / 60.0))
+    } else {
+        None
+    };
+    queue_stats.enqueued = live_enqueued;
+    queue_stats
+}
+
+async fn find_job(
+    storage: &oxana::Storage,
+    job_id: &str,
+) -> Result<(Option<oxana::JobEnvelope>, bool), oxana::OxanaError> {
+    let job_id = job_id.to_string();
+    if let Some(job) = storage.get_job(&job_id).await? {
+        return Ok((Some(job), false));
+    }
+
+    let dead_count = storage.dead_count().await?;
+    if dead_count == 0 {
+        return Ok((None, false));
+    }
+
+    let dead_jobs = storage
+        .list_dead(&oxana::QueueListOpts {
+            count: dead_count,
+            offset: 0,
+        })
+        .await?;
+    let Some(dead_job) = dead_jobs.into_iter().find(|job| job.id == job_id) else {
+        return Ok((None, false));
+    };
+
+    Ok((Some(dead_job), true))
+}
+
+pub(crate) async fn wipe_queue(
+    state: OxanaWebState,
+    queue_key: String,
+) -> Result<SeeOther, OxanaWebError> {
+    state
+        .storage
+        .wipe_queue(RawQueue::fixed(queue_key.clone()))
+        .await?;
+
+    Ok(see_other(format!(
+        "{}/queues/{}",
+        state.base_path,
+        urlencoding::encode(&queue_key)
+    )))
+}
+
+pub(crate) async fn pause_queue(
+    state: OxanaWebState,
+    queue_key: String,
+) -> Result<SeeOther, OxanaWebError> {
+    set_queue_state(&state, &queue_key, oxana::QueueState::Paused).await?;
+
+    Ok(queue_redirect(&state.base_path, &queue_key))
+}
+
+pub(crate) async fn unpause_queue(
+    state: OxanaWebState,
+    queue_key: String,
+) -> Result<SeeOther, OxanaWebError> {
+    set_queue_state(&state, &queue_key, oxana::QueueState::Active).await?;
+
+    Ok(queue_redirect(&state.base_path, &queue_key))
+}
+
+pub(crate) async fn set_queue_concurrency(
+    state: OxanaWebState,
+    queue_key: String,
+    form: QueueConcurrencyForm,
+) -> Result<SeeOther, OxanaWebError> {
+    if form.concurrency == 0 {
+        return Err(oxana::OxanaError::ConfigError(
+            "Queue concurrency must be at least 1".to_string(),
+        )
+        .into());
+    }
+
+    state
+        .storage
+        .set_queue_concurrency(
+            RawQueue::from_catalog(&state.catalog, &queue_key),
+            form.concurrency,
+        )
+        .await?;
+
+    Ok(queue_redirect(&state.base_path, &queue_key))
+}
+
+pub(crate) async fn delete_job(
+    state: OxanaWebState,
+    queue_key: String,
+    job_id: String,
+) -> Result<SeeOther, OxanaWebError> {
+    state.storage.delete_job(&job_id).await?;
+
+    Ok(see_other(format!(
+        "{}/queues/{}",
+        state.base_path,
+        urlencoding::encode(&queue_key)
+    )))
+}
+
+pub(crate) async fn enqueue_job(
+    state: OxanaWebState,
+    form: EnqueueJobForm,
+) -> Result<SeeOther, OxanaWebError> {
+    let envelope = immediate_envelope(
+        form.queue,
+        form.name,
+        parse_json(&form.args)?,
+        parse_optional_json(form.state.as_deref())?,
+        true,
+    );
+
+    state.storage.enqueue_envelope(envelope).await?;
+
+    let redirect = form.redirect.as_deref().unwrap_or("/dead");
+    Ok(see_other(format!("{}{}", state.base_path, redirect)))
+}
+
+// --- Helpers ---
+
+#[derive(Serialize)]
+struct RawQueue {
+    key: String,
+    #[serde(skip_serializing)]
+    base_key: String,
+    #[serde(skip_serializing)]
+    dynamic: bool,
+    #[serde(skip_serializing)]
+    concurrency: oxana::QueueConcurrency,
+}
+
+impl RawQueue {
+    fn fixed(key: String) -> Self {
+        Self {
+            base_key: key.clone(),
+            key,
+            dynamic: false,
+            concurrency: oxana::QueueConcurrency::Fixed(1),
+        }
+    }
+
+    fn from_catalog(catalog: &oxana::Catalog, key: &str) -> Self {
+        let base_key = base_queue_key(key);
+        let queue_info = catalog.queues.iter().find(|queue| queue.key == base_key);
+        let concurrency = queue_info.map_or(oxana::QueueConcurrency::Fixed(1), |queue| {
+            if queue.dynamic_concurrency {
+                oxana::QueueConcurrency::Dynamic {
+                    default: queue.concurrency,
+                }
+            } else {
+                oxana::QueueConcurrency::Fixed(queue.concurrency)
+            }
+        });
+
+        Self {
+            key: key.to_string(),
+            base_key: base_key.to_string(),
+            dynamic: queue_info.is_some_and(|queue| queue.dynamic),
+            concurrency,
+        }
+    }
+}
+
+impl oxana::Queue for RawQueue {
+    fn key(&self) -> String {
+        self.key.clone()
+    }
+
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_static("")
+    }
+
+    fn config(&self) -> oxana::QueueConfig {
+        let config = if self.dynamic {
+            oxana::QueueConfig::as_dynamic(self.base_key.clone())
+        } else {
+            oxana::QueueConfig::as_static(self.key.clone())
+        };
+
+        match self.concurrency {
+            oxana::QueueConcurrency::Fixed(concurrency) => config.concurrency(concurrency),
+            oxana::QueueConcurrency::Dynamic { default } => config.dynamic_concurrency(default),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct PaginationParams {
+    #[serde(default = "default_page")]
+    page: usize,
+}
+
+fn default_page() -> usize {
+    1
+}
+
+#[derive(Deserialize)]
+pub(crate) struct QueuesParams {
+    #[serde(default)]
+    sort: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
+    #[serde(default)]
+    minutes: Option<usize>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MetricsParams {
+    #[serde(default)]
+    sort: Option<String>,
+    #[serde(default)]
+    dir: Option<String>,
+    #[serde(default)]
+    minutes: Option<usize>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct MetricDetailParams {
+    worker: String,
+    #[serde(default)]
+    minutes: Option<usize>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct EnqueueJobForm {
+    queue: String,
+    name: String,
+    args: String,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    redirect: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct CronEnqueueJobForm {
+    name: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct OnDemandEnqueueJobForm {
+    queue: String,
+    name: String,
+    args: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct QueueConcurrencyForm {
+    concurrency: usize,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct OnDemandParams {
+    #[serde(default)]
+    scheduled: Option<String>,
+    #[serde(default)]
+    invalid_json: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct CronParams {
+    #[serde(default)]
+    enqueued: Option<String>,
+}
+
+async fn queue_config_map(
+    storage: &oxana::Storage,
+    catalog: &oxana::Catalog,
+    stats: &oxana::Stats,
+) -> Result<HashMap<String, QueueRuntimeConfigView>, oxana::OxanaError> {
+    let mut keys = queue_config_keys(catalog, stats);
+    keys.sort();
+    keys.dedup();
+
+    let stored_configs = storage.queue_configs(&keys).await?;
+
+    Ok(keys
+        .into_iter()
+        .map(|key| {
+            let config = queue_runtime_config_view_from_map(catalog, &stored_configs, &key);
+            (key, config)
+        })
+        .collect())
+}
+
+fn queue_config_keys(catalog: &oxana::Catalog, stats: &oxana::Stats) -> Vec<String> {
+    let mut keys = catalog
+        .queues
+        .iter()
+        .map(|queue| queue.key.clone())
+        .collect::<Vec<_>>();
+
+    for queue in &stats.queues {
+        keys.push(queue.key.clone());
+        keys.extend(
+            queue
+                .queues
+                .iter()
+                .map(|dynamic_queue| format!("{}#{}", queue.key, dynamic_queue.suffix)),
+        );
+    }
+
+    keys
+}
+
+fn merge_queue_runtime_config(
+    catalog: &oxana::Catalog,
+    queue_key: &str,
+    mut config: oxana::QueueRuntimeConfig,
+    default_config: oxana::QueueRuntimeConfig,
+) -> oxana::QueueRuntimeConfig {
+    if !queue_uses_dynamic_concurrency(catalog, queue_key) {
+        config.concurrency = None;
+    }
+
+    config.with_defaults(default_config)
+}
+
+fn queue_runtime_config_from_map(
+    catalog: &oxana::Catalog,
+    stored_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> oxana::QueueRuntimeConfig {
+    let base_key = base_queue_key(queue_key);
+    let base_default = default_queue_runtime_config(catalog, base_key);
+    let base_config = stored_configs
+        .get(base_key)
+        .cloned()
+        .map(|config| merge_queue_runtime_config(catalog, base_key, config, base_default.clone()))
+        .unwrap_or(base_default);
+
+    if queue_key == base_key {
+        return base_config;
+    }
+
+    stored_configs
+        .get(queue_key)
+        .cloned()
+        .map(|config| merge_queue_runtime_config(catalog, queue_key, config, base_config.clone()))
+        .unwrap_or(base_config)
+}
+
+fn queue_runtime_config_view_from_map(
+    catalog: &oxana::Catalog,
+    stored_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> QueueRuntimeConfigView {
+    let config = queue_runtime_config_from_map(catalog, stored_configs, queue_key);
+    let concurrency_status = queue_concurrency_status_from_map(catalog, stored_configs, queue_key);
+
+    QueueRuntimeConfigView {
+        config,
+        concurrency_status,
+    }
+}
+
+fn queue_concurrency_status_from_map(
+    catalog: &oxana::Catalog,
+    stored_configs: &HashMap<String, oxana::QueueRuntimeConfig>,
+    queue_key: &str,
+) -> QueueConcurrencyStatus {
+    if !queue_uses_dynamic_concurrency(catalog, queue_key) {
+        return QueueConcurrencyStatus::Fixed;
+    }
+
+    let base_key = base_queue_key(queue_key);
+    let configured_default = default_queue_runtime_config(catalog, base_key)
+        .concurrency
+        .unwrap_or(1);
+    let direct_concurrency = stored_configs
+        .get(queue_key)
+        .and_then(|config| config.concurrency);
+
+    if queue_key == base_key {
+        return match direct_concurrency {
+            Some(concurrency) if concurrency != configured_default => {
+                QueueConcurrencyStatus::Override {
+                    default: configured_default,
+                }
+            }
+            _ => QueueConcurrencyStatus::Default {
+                default: configured_default,
+            },
+        };
+    }
+
+    let inherited_default = queue_runtime_config_from_map(catalog, stored_configs, base_key)
+        .concurrency
+        .unwrap_or(configured_default);
+
+    if let Some(concurrency) = direct_concurrency {
+        return if concurrency != inherited_default {
+            QueueConcurrencyStatus::Override {
+                default: inherited_default,
+            }
+        } else {
+            QueueConcurrencyStatus::Default {
+                default: inherited_default,
+            }
+        };
+    }
+
+    QueueConcurrencyStatus::Default {
+        default: inherited_default,
+    }
+}
+
+fn queue_uses_dynamic_concurrency(catalog: &oxana::Catalog, queue_key: &str) -> bool {
+    let base_key = base_queue_key(queue_key);
+    catalog
+        .queues
+        .iter()
+        .find(|queue| queue.key == base_key)
+        .is_some_and(|queue| queue.dynamic_concurrency)
+}
+
+async fn queue_runtime_config_for(
+    state: &OxanaWebState,
+    queue_key: &str,
+) -> Result<QueueRuntimeConfigView, oxana::OxanaError> {
+    let keys = queue_runtime_config_keys(queue_key);
+    let stored_configs = state.storage.queue_configs(&keys).await?;
+
+    Ok(queue_runtime_config_view_from_map(
+        &state.catalog,
+        &stored_configs,
+        queue_key,
+    ))
+}
+
+fn queue_runtime_config_keys(queue_key: &str) -> Vec<String> {
+    let base_key = base_queue_key(queue_key);
+    if base_key == queue_key {
+        vec![base_key.to_string()]
+    } else {
+        vec![base_key.to_string(), queue_key.to_string()]
+    }
+}
+
+fn default_queue_runtime_config(
+    catalog: &oxana::Catalog,
+    queue_key: &str,
+) -> oxana::QueueRuntimeConfig {
+    let base_key = base_queue_key(queue_key);
+
+    catalog
+        .queues
+        .iter()
+        .find(|queue| queue.key == base_key)
+        .map_or_else(
+            || oxana::QueueRuntimeConfig::new(1),
+            |queue| oxana::QueueRuntimeConfig::new(queue.concurrency),
+        )
+}
+
+fn base_queue_key(queue_key: &str) -> &str {
+    queue_key
+        .split_once('#')
+        .map_or(queue_key, |(base, _)| base)
+}
+
+async fn set_queue_state(
+    state: &OxanaWebState,
+    queue_key: &str,
+    queue_state: oxana::QueueState,
+) -> Result<(), oxana::OxanaError> {
+    state
+        .storage
+        .set_queue_state(
+            RawQueue::from_catalog(&state.catalog, queue_key),
+            queue_state,
+        )
+        .await
+}
+
+fn queue_redirect(base_path: &str, queue_key: &str) -> SeeOther {
+    see_other(format!(
+        "{}/queues/{}",
+        base_path,
+        urlencoding::encode(queue_key)
+    ))
+}
+
+fn sort_queues(
+    queues: &mut [oxana::QueueStats],
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
+    sort: &str,
+    desc: bool,
+) {
+    queues.sort_by(|a, b| {
+        let cmp = if sort == "eta" {
+            compare_eta(a.rate.eta_s, b.rate.eta_s, desc)
+        } else {
+            let cmp = match sort {
+                "enqueued" => a.enqueued.cmp(&b.enqueued),
+                "processed" => a.processed.cmp(&b.processed),
+                "succeeded" => a.succeeded.cmp(&b.succeeded),
+                "failed" => a.failed.cmp(&b.failed),
+                "panicked" => a.panicked.cmp(&b.panicked),
+                "rate" => a
+                    .rate
+                    .processed_per_minute
+                    .partial_cmp(&b.rate.processed_per_minute)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                "concurrency" => {
+                    let ca = queue_configs
+                        .get(&a.key)
+                        .and_then(|config| config.config.concurrency)
+                        .unwrap_or(0);
+                    let cb = queue_configs
+                        .get(&b.key)
+                        .and_then(|config| config.config.concurrency)
+                        .unwrap_or(0);
+                    ca.cmp(&cb)
+                }
+                "state" => queue_state_order(queue_configs, &a.key)
+                    .cmp(&queue_state_order(queue_configs, &b.key)),
+                "latency" => a
+                    .latency_s
+                    .partial_cmp(&b.latency_s)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+                _ => a.key.cmp(&b.key),
+            };
+            if desc { cmp.reverse() } else { cmp }
+        };
+        cmp.then_with(|| a.key.cmp(&b.key))
+    });
+}
+
+fn sort_queues_for_params<'params>(
+    queues: &mut [oxana::QueueStats],
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
+    params: &'params QueuesParams,
+) -> (&'params str, &'params str) {
+    let sort = params.sort.as_deref().unwrap_or(DEFAULT_QUEUE_SORT);
+    let default_dir = if params.sort.is_none() {
+        DEFAULT_QUEUE_SORT_DIRECTION
+    } else {
+        "asc"
+    };
+    let dir = params.dir.as_deref().unwrap_or(default_dir);
+
+    sort_queues(queues, queue_configs, sort, dir == "desc");
+
+    (sort, dir)
+}
+
+fn queue_state_order(queue_configs: &HashMap<String, QueueRuntimeConfigView>, key: &str) -> u8 {
+    match queue_configs.get(key).map(|config| config.config.state) {
+        Some(oxana::QueueState::Paused) => 1,
+        _ => 0,
+    }
+}
+
+fn valid_metric_sort(sort: &str) -> bool {
+    matches!(
+        sort,
+        "processed" | "succeeded" | "failed" | "total_time" | "avg_time"
+    )
+}
+
+fn sorted_worker_metrics(
+    workers: &[oxana::WorkerMetricsSummary],
+    sort: &str,
+    desc: bool,
+) -> Vec<oxana::WorkerMetricsSummary> {
+    let mut workers = workers.to_vec();
+
+    workers.sort_by(|a, b| {
+        let cmp = match sort {
+            "processed" => a.totals.processed.cmp(&b.totals.processed),
+            "succeeded" => a.totals.succeeded.cmp(&b.totals.succeeded),
+            "failed" => a.totals.failed.cmp(&b.totals.failed),
+            "avg_time" => a
+                .totals
+                .average_execution_ms()
+                .partial_cmp(&b.totals.average_execution_ms())
+                .unwrap_or(std::cmp::Ordering::Equal),
+            _ => a.totals.execution_ms.cmp(&b.totals.execution_ms),
+        };
+        let cmp = if desc { cmp.reverse() } else { cmp };
+
+        cmp.then_with(|| a.identity.worker.cmp(&b.identity.worker))
+    });
+
+    workers
+}
+
+fn compare_eta(a: Option<f64>, b: Option<f64>, desc: bool) -> std::cmp::Ordering {
+    let cmp = match (a, b) {
+        (Some(a), Some(b)) => a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    };
+
+    if desc { cmp.reverse() } else { cmp }
+}
+
+fn on_demand_envelope_from_form(
+    catalog: &oxana::Catalog,
+    form: &OnDemandEnqueueJobForm,
+) -> Result<oxana::JobEnvelope, oxana::OxanaError> {
+    if !catalog
+        .queues
+        .iter()
+        .any(|queue| !queue.dynamic && queue.key == form.queue)
+    {
+        return Err(oxana::OxanaError::GenericError(format!(
+            "Queue {} is not a registered static queue",
+            form.queue
+        )));
+    }
+
+    let job = catalog
+        .on_demand_jobs
+        .iter()
+        .find(|job| job.name == form.name)
+        .ok_or_else(|| {
+            oxana::OxanaError::GenericError(format!(
+                "Job {} is not registered for on-demand enqueue",
+                form.name
+            ))
+        })?;
+
+    job.enqueue_envelope(form.queue.clone(), parse_json(&form.args)?)
+}
+
+fn cron_envelope_from_form(
+    catalog: &oxana::Catalog,
+    form: &CronEnqueueJobForm,
+) -> Result<oxana::JobEnvelope, oxana::OxanaError> {
+    let job = catalog
+        .cron_workers
+        .iter()
+        .find(|job| job.name == form.name)
+        .ok_or_else(|| {
+            oxana::OxanaError::GenericError(format!("Cron job {} is not registered", form.name))
+        })?;
+
+    Ok(immediate_envelope(
+        job.queue_key.clone(),
+        job.name.clone(),
+        serde_json::json!({}),
+        None,
+        job.resurrect,
+    ))
+}
+
+fn parse_json(input: &str) -> Result<serde_json::Value, oxana::OxanaError> {
+    serde_json::from_str(input).map_err(oxana::OxanaError::from)
+}
+
+fn parse_optional_json(
+    input: Option<&str>,
+) -> Result<Option<serde_json::Value>, oxana::OxanaError> {
+    input
+        .filter(|value| !value.is_empty())
+        .map(parse_json)
+        .transpose()
+}
+
+fn cron_enqueued_redirect(base_path: &str) -> SeeOther {
+    see_other(format!("{base_path}/cron?enqueued=1"))
+}
+
+fn immediate_envelope(
+    queue: String,
+    name: String,
+    args: serde_json::Value,
+    state: Option<serde_json::Value>,
+    resurrect: bool,
+) -> oxana::JobEnvelope {
+    let now = chrono::Utc::now().timestamp_micros();
+    let id = uuid::Uuid::new_v4().to_string();
+
+    oxana::JobEnvelope {
+        id: id.clone(),
+        queue,
+        job: oxana::JobData { name, args },
+        meta: oxana::JobMeta {
+            id,
+            retries: 0,
+            unique: false,
+            on_conflict: None,
+            created_at: now,
+            scheduled_at: now,
+            started_at: None,
+            state,
+            resurrect,
+            error: None,
+            throttle_cost: None,
+        },
+    }
+}
+
+struct TypeTreeNode<T> {
+    children: BTreeMap<String, TypeTreeNode<T>>,
+    entries: Vec<T>,
+}
+
+impl<T> TypeTreeNode<T> {
+    fn new() -> Self {
+        Self {
+            children: BTreeMap::new(),
+            entries: Vec::new(),
+        }
+    }
+}
+
+fn type_tree_parts(name: &str) -> (Vec<&str>, String) {
+    let segments: Vec<&str> = name.split("::").collect();
+    let split = segments.len().saturating_sub(2);
+
+    (segments[..split].to_vec(), segments[split..].join("::"))
+}
+
+fn insert_type_tree_entry<T>(root: &mut TypeTreeNode<T>, group_segments: &[&str], entry: T) {
+    let mut node = root;
+    for seg in group_segments {
+        node = node
+            .children
+            .entry((*seg).to_string())
+            .or_insert_with(TypeTreeNode::new);
+    }
+
+    node.entries.push(entry);
+}
+
+fn build_cron_rows(
+    cron_workers: &[oxana::CronWorkerInfo],
+    now: &chrono::DateTime<chrono::Utc>,
+) -> Vec<CronRow> {
+    let mut root = TypeTreeNode::new();
+
+    for cw in cron_workers {
+        let (group_segments, leaf_name) = type_tree_parts(&cw.name);
+        insert_type_tree_entry(
+            &mut root,
+            &group_segments,
+            CronWorkerView {
+                name: cw.name.clone(),
+                short_name: leaf_name,
+                schedule: cw.schedule.to_string(),
+                queue_key: cw.queue_key.clone(),
+                next_run_micros: cw
+                    .schedule
+                    .after(now)
+                    .next()
+                    .map(|dt| dt.timestamp_micros()),
+            },
+        );
+    }
+
+    fn flatten(node: &TypeTreeNode<CronWorkerView>, depth: usize, rows: &mut Vec<CronRow>) {
+        for (name, child) in &node.children {
+            rows.push(CronRow::Group {
+                name: name.clone(),
+                depth,
+            });
+            flatten(child, depth + 1, rows);
+        }
+        for worker in &node.entries {
+            rows.push(CronRow::Worker {
+                view: worker.clone(),
+                depth,
+            });
+        }
+    }
+
+    let mut rows = Vec::new();
+    flatten(&root, 0, &mut rows);
+    rows
+}
+
+fn build_on_demand_rows(on_demand_jobs: &[oxana::OnDemandJobInfo]) -> Vec<OnDemandRow> {
+    let mut root = TypeTreeNode::new();
+
+    for job in on_demand_jobs {
+        let (group_segments, leaf_name) = type_tree_parts(&job.name);
+        insert_type_tree_entry(
+            &mut root,
+            &group_segments,
+            OnDemandJobView {
+                name: job.name.clone(),
+                short_name: leaf_name,
+                args_template_json: serde_json::to_string_pretty(&job.args_template)
+                    .unwrap_or_else(|_| job.args_template.to_string()),
+            },
+        );
+    }
+
+    fn flatten(node: &TypeTreeNode<OnDemandJobView>, depth: usize, rows: &mut Vec<OnDemandRow>) {
+        for (name, child) in &node.children {
+            rows.push(OnDemandRow::Group {
+                name: name.clone(),
+                depth,
+            });
+            flatten(child, depth + 1, rows);
+        }
+        for job in &node.entries {
+            rows.push(OnDemandRow::Job {
+                view: job.clone(),
+                depth,
+            });
+        }
+    }
+
+    let mut rows = Vec::new();
+    flatten(&root, 0, &mut rows);
+    rows
+}
+
+fn build_on_demand_queue_views(queues: &[oxana::QueueInfo]) -> Vec<OnDemandQueueView> {
+    let selected_queue = ["on_demand", "default", "main"]
+        .into_iter()
+        .find(|candidate| {
+            queues
+                .iter()
+                .any(|queue| !queue.dynamic && queue.key == *candidate)
+        });
+
+    queues
+        .iter()
+        .filter(|queue| !queue.dynamic)
+        .map(|queue| OnDemandQueueView {
+            key: queue.key.clone(),
+            selected: selected_queue == Some(queue.key.as_str()),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CronEnqueueJobForm, OnDemandEnqueueJobForm, RawQueue, build_on_demand_queue_views,
+        cron_enqueued_redirect, cron_envelope_from_form, enqueue_on_demand_job,
+        is_dynamic_parent_queue, on_demand_envelope_from_form, queue_concurrency_status_from_map,
+        queue_detail_queue_stats, queue_runtime_config_from_map,
+        queue_runtime_config_view_from_map, sort_queues, sorted_worker_metrics,
+    };
+    use crate::OxanaWebState;
+    use crate::models::{QueueConcurrencyStatus, QueueRuntimeConfigView};
+    use axum::http::{StatusCode, header};
+    use oxana::Queue as _;
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+    use std::io::Error as WorkerError;
+    use topcoat::{context::Cx, router::response::IntoResponse};
+
+    const CRON_WORKER_NAME: &str = "test::CleanupCronWorker";
+
+    #[test]
+    fn queues_default_sort_is_enqueued_descending() {
+        let mut lightly_loaded = queue_with_eta("lightly-loaded", None);
+        lightly_loaded.enqueued = 2;
+        let mut beta = queue_with_eta("beta", None);
+        beta.enqueued = 20;
+        let mut alpha = queue_with_eta("alpha", None);
+        alpha.enqueued = 20;
+        let mut queues = vec![lightly_loaded, beta, alpha];
+        let params = super::QueuesParams {
+            sort: None,
+            dir: None,
+            minutes: None,
+        };
+
+        let (sort, dir) = super::sort_queues_for_params(&mut queues, &HashMap::new(), &params);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!((sort, dir), ("enqueued", "desc"));
+        assert_eq!(keys, vec!["alpha", "beta", "lightly-loaded"]);
+    }
+
+    #[test]
+    fn explicit_queue_sort_without_direction_remains_ascending() {
+        let mut queues = vec![queue_with_eta("beta", None), queue_with_eta("alpha", None)];
+        let params = super::QueuesParams {
+            sort: Some("key".to_string()),
+            dir: None,
+            minutes: None,
+        };
+
+        let (sort, dir) = super::sort_queues_for_params(&mut queues, &HashMap::new(), &params);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!((sort, dir), ("key", "asc"));
+        assert_eq!(keys, vec!["alpha", "beta"]);
+    }
+
+    #[derive(Serialize)]
+    struct StaticQueue;
+
+    impl oxana::Queue for StaticQueue {
+        fn to_config() -> oxana::QueueConfig {
+            oxana::QueueConfig::as_static("default")
+        }
+    }
+
+    #[derive(Serialize)]
+    struct DynamicQueue {
+        tenant: String,
+    }
+
+    impl oxana::Queue for DynamicQueue {
+        fn key(&self) -> String {
+            format!(
+                "tenant#{}",
+                oxana::value_to_queue_key(serde_json::to_value(self).unwrap_or_default())
+            )
+        }
+
+        fn to_config() -> oxana::QueueConfig {
+            oxana::QueueConfig::as_dynamic("tenant")
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize, oxana::Job)]
+    #[oxana(on_demand)]
+    #[oxana(unique_id = "on_demand_{id}")]
+    struct OnDemandJob {
+        id: u64,
+        payload: String,
+    }
+
+    struct OnDemandWorker;
+
+    impl oxana::FromContext<()> for OnDemandWorker {
+        fn from_context(_ctx: &()) -> Self {
+            Self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl oxana::Worker<OnDemandJob> for OnDemandWorker {
+        type Error = WorkerError;
+
+        async fn run_batch(
+            &self,
+            _jobs: Vec<oxana::BatchItem<OnDemandJob>>,
+        ) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn on_demand_catalog() -> oxana::Catalog {
+        let storage = oxana::Storage::builder()
+            .build_from_redis_url("redis://127.0.0.1/0")
+            .expect("test storage should build");
+
+        storage
+            .runtime(())
+            .queue::<StaticQueue>()
+            .queue::<DynamicQueue>()
+            .worker::<OnDemandWorker, OnDemandJob>()
+            .catalog()
+    }
+
+    fn cron_catalog() -> oxana::Catalog {
+        oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: vec![oxana::CronWorkerInfo {
+                name: CRON_WORKER_NAME.to_string(),
+                schedule: "*/5 * * * * *".parse().unwrap(),
+                queue_key: "default".to_string(),
+                resurrect: false,
+            }],
+            queues: Vec::new(),
+            on_demand_jobs: Vec::new(),
+        }
+    }
+
+    fn queue_with_eta(key: &str, eta_s: Option<f64>) -> oxana::QueueStats {
+        oxana::QueueStats {
+            key: key.to_string(),
+            enqueued: 0,
+            processed: 0,
+            succeeded: 0,
+            panicked: 0,
+            failed: 0,
+            latency_s: 0.0,
+            rate: oxana::QueueRateStats {
+                eta_s,
+                ..oxana::QueueRateStats::default()
+            },
+            queues: Vec::new(),
+        }
+    }
+
+    fn stats_with_queues(queues: Vec<oxana::QueueStats>) -> oxana::Stats {
+        oxana::Stats {
+            global: oxana::StatsGlobal {
+                jobs: 0,
+                enqueued: 0,
+                processed: 0,
+                failed: 0,
+                dead: 0,
+                scheduled: 0,
+                retries: 0,
+                latency_s_max: 0.0,
+            },
+            processes: Vec::new(),
+            processing: Vec::new(),
+            queues,
+        }
+    }
+
+    fn queue_info(key: &str, dynamic: bool) -> oxana::QueueInfo {
+        oxana::QueueInfo {
+            key: key.to_string(),
+            dynamic,
+            concurrency: 1,
+            dynamic_concurrency: false,
+            throttle: None,
+        }
+    }
+
+    fn queue_config_view(config: oxana::QueueRuntimeConfig) -> QueueRuntimeConfigView {
+        QueueRuntimeConfigView {
+            config,
+            concurrency_status: QueueConcurrencyStatus::Fixed,
+        }
+    }
+
+    #[test]
+    fn dynamic_parent_queue_detail_redirect_only_applies_to_parent() {
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![queue_info("default", false), queue_info("tenant", true)],
+            on_demand_jobs: Vec::new(),
+        };
+
+        assert!(is_dynamic_parent_queue(&catalog, "tenant"));
+        assert!(!is_dynamic_parent_queue(&catalog, "tenant#acme"));
+        assert!(!is_dynamic_parent_queue(&catalog, "default"));
+    }
+
+    #[test]
+    fn queue_detail_queue_stats_uses_live_enqueued_for_static_queue() {
+        let mut queue = queue_with_eta("default", None);
+        queue.enqueued = 42;
+        queue.processed = 7;
+        queue.rate.effective_drain_per_minute = 2.0;
+        queue.rate.eta_s = Some(1_260.0);
+        let stats = stats_with_queues(vec![queue]);
+
+        let detail_stats = queue_detail_queue_stats(&stats, "default", 2)
+            .expect("static queue stats should exist");
+
+        assert_eq!(detail_stats.key, "default");
+        assert_eq!(detail_stats.enqueued, 2);
+        assert_eq!(detail_stats.processed, 7);
+        assert_eq!(detail_stats.rate.eta_s, Some(60.0));
+    }
+
+    #[test]
+    fn queue_detail_queue_stats_uses_live_enqueued_for_dynamic_child_queue() {
+        let mut parent = queue_with_eta("tenant", None);
+        parent.enqueued = 42;
+        parent.queues.push(oxana::DynamicQueueStats {
+            suffix: "acme".to_string(),
+            enqueued: 42,
+            processed: 11,
+            succeeded: 10,
+            panicked: 0,
+            failed: 1,
+            latency_s: 3.5,
+            rate: oxana::QueueRateStats::default(),
+        });
+        let stats = stats_with_queues(vec![parent]);
+
+        let detail_stats = queue_detail_queue_stats(&stats, "tenant#acme", 3)
+            .expect("dynamic child queue stats should exist");
+
+        assert_eq!(detail_stats.key, "tenant#acme");
+        assert_eq!(detail_stats.enqueued, 3);
+        assert_eq!(detail_stats.processed, 11);
+        assert_eq!(detail_stats.succeeded, 10);
+        assert_eq!(detail_stats.failed, 1);
+        assert_eq!(detail_stats.latency_s, 3.5);
+        assert!(detail_stats.queues.is_empty());
+    }
+
+    #[test]
+    fn raw_queue_from_catalog_preserves_dynamic_concurrency_mode() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 7;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+
+        let queue = RawQueue::from_catalog(&catalog, "tenant#acme");
+        assert_eq!(queue.key(), "tenant#acme");
+        assert_eq!(
+            queue.config().concurrency,
+            oxana::QueueConcurrency::Dynamic { default: 7 }
+        );
+        assert!(matches!(
+            queue.config().kind,
+            oxana::QueueKind::Dynamic { ref prefix, .. } if prefix == "tenant"
+        ));
+    }
+
+    #[test]
+    fn dynamic_child_queue_inherits_base_runtime_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([(
+            "tenant".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(5),
+                state: oxana::QueueState::Paused,
+            },
+        )]);
+
+        let config = queue_runtime_config_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(config.concurrency, Some(5));
+        assert_eq!(config.state, oxana::QueueState::Paused);
+    }
+
+    #[test]
+    fn dynamic_child_queue_override_wins_over_base_runtime_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([
+            (
+                "tenant".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(5),
+                    state: oxana::QueueState::Paused,
+                },
+            ),
+            (
+                "tenant#acme".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(9),
+                    state: oxana::QueueState::Active,
+                },
+            ),
+        ]);
+
+        let config = queue_runtime_config_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(config.concurrency, Some(9));
+        assert_eq!(config.state, oxana::QueueState::Active);
+    }
+
+    #[test]
+    fn dynamic_base_queue_reports_runtime_concurrency_override() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([(
+            "tenant".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(5),
+                state: oxana::QueueState::Active,
+            },
+        )]);
+
+        let view = queue_runtime_config_view_from_map(&catalog, &stored_configs, "tenant");
+
+        assert_eq!(view.config.concurrency, Some(5));
+        assert_eq!(
+            view.concurrency_status,
+            QueueConcurrencyStatus::Override { default: 3 }
+        );
+    }
+
+    #[test]
+    fn dynamic_child_queue_treats_inherited_base_concurrency_as_default() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([(
+            "tenant".to_string(),
+            oxana::QueueRuntimeConfig {
+                concurrency: Some(5),
+                state: oxana::QueueState::Active,
+            },
+        )]);
+
+        let status = queue_concurrency_status_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(status, QueueConcurrencyStatus::Default { default: 5 });
+    }
+
+    #[test]
+    fn dynamic_child_queue_reports_direct_override_defaulting_to_base_concurrency() {
+        let mut dynamic_queue = queue_info("tenant", true);
+        dynamic_queue.concurrency = 3;
+        dynamic_queue.dynamic_concurrency = true;
+        let catalog = oxana::Catalog {
+            workers: Vec::new(),
+            cron_workers: Vec::new(),
+            queues: vec![dynamic_queue],
+            on_demand_jobs: Vec::new(),
+        };
+        let stored_configs = HashMap::from([
+            (
+                "tenant".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(5),
+                    state: oxana::QueueState::Active,
+                },
+            ),
+            (
+                "tenant#acme".to_string(),
+                oxana::QueueRuntimeConfig {
+                    concurrency: Some(9),
+                    state: oxana::QueueState::Active,
+                },
+            ),
+        ]);
+
+        let status = queue_concurrency_status_from_map(&catalog, &stored_configs, "tenant#acme");
+
+        assert_eq!(status, QueueConcurrencyStatus::Override { default: 5 });
+    }
+
+    #[test]
+    fn eta_sort_ascending_places_unknown_last() {
+        let mut queues = vec![
+            queue_with_eta("never", None),
+            queue_with_eta("slow", Some(30.0)),
+            queue_with_eta("fast", Some(10.0)),
+        ];
+
+        sort_queues(&mut queues, &HashMap::new(), "eta", false);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["fast", "slow", "never"]);
+    }
+
+    #[test]
+    fn eta_sort_descending_places_unknown_first() {
+        let mut queues = vec![
+            queue_with_eta("fast", Some(10.0)),
+            queue_with_eta("never", None),
+            queue_with_eta("slow", Some(30.0)),
+        ];
+
+        sort_queues(&mut queues, &HashMap::new(), "eta", true);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["never", "slow", "fast"]);
+    }
+
+    #[test]
+    fn state_sort_uses_runtime_queue_config() {
+        let mut queues = vec![
+            queue_with_eta("active", None),
+            queue_with_eta("paused", None),
+            queue_with_eta("missing", None),
+        ];
+        let mut queue_configs = HashMap::new();
+        queue_configs.insert(
+            "active".to_string(),
+            queue_config_view(oxana::QueueRuntimeConfig::new(1)),
+        );
+        queue_configs.insert(
+            "paused".to_string(),
+            queue_config_view(oxana::QueueRuntimeConfig {
+                concurrency: Some(1),
+                state: oxana::QueueState::Paused,
+            }),
+        );
+
+        sort_queues(&mut queues, &queue_configs, "state", false);
+
+        let keys = queues
+            .iter()
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(keys, vec!["active", "missing", "paused"]);
+    }
+
+    fn worker_metrics(
+        worker: &str,
+        processed: u64,
+        succeeded: u64,
+        failed: u64,
+        execution_ms: u64,
+        successful_executions: u64,
+    ) -> oxana::WorkerMetricsSummary {
+        oxana::WorkerMetricsSummary {
+            identity: oxana::MetricIdentity {
+                worker: worker.to_string(),
+            },
+            totals: oxana::JobMetricsTotals {
+                processed,
+                succeeded,
+                failed,
+                execution_ms,
+                successful_executions,
+                ..oxana::JobMetricsTotals::default()
+            },
+            series: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn worker_metrics_sort_defaults_to_descending_metric_values() {
+        let workers = vec![
+            worker_metrics("fast", 5, 5, 0, 100, 5),
+            worker_metrics("busy", 20, 18, 2, 90, 10),
+            worker_metrics("idle", 1, 1, 0, 500, 1),
+        ];
+
+        let sorted = sorted_worker_metrics(&workers, "processed", true);
+
+        let names = sorted
+            .iter()
+            .map(|worker| worker.identity.worker.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["busy", "fast", "idle"]);
+        assert_eq!(workers[0].identity.worker, "fast");
+    }
+
+    #[test]
+    fn worker_metrics_sort_uses_average_execution_time() {
+        let workers = vec![
+            worker_metrics("quick", 5, 5, 0, 100, 5),
+            worker_metrics("slow", 2, 2, 0, 600, 2),
+            worker_metrics("medium", 3, 3, 0, 300, 3),
+        ];
+
+        let sorted = sorted_worker_metrics(&workers, "avg_time", true);
+
+        let names = sorted
+            .iter()
+            .map(|worker| worker.identity.worker.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["slow", "medium", "quick"]);
+    }
+
+    #[test]
+    fn cron_form_rejects_unknown_jobs() {
+        let catalog = cron_catalog();
+
+        let err = cron_envelope_from_form(
+            &catalog,
+            &CronEnqueueJobForm {
+                name: "missing".to_string(),
+            },
+        )
+        .expect_err("unknown cron jobs should not be accepted");
+
+        assert!(matches!(err, oxana::OxanaError::GenericError(_)));
+    }
+
+    #[test]
+    fn cron_form_builds_immediate_envelope() {
+        let catalog = cron_catalog();
+        let envelope = cron_envelope_from_form(
+            &catalog,
+            &CronEnqueueJobForm {
+                name: CRON_WORKER_NAME.to_string(),
+            },
+        )
+        .expect("valid cron form should build an envelope");
+
+        assert_eq!(envelope.queue, "default");
+        assert_eq!(envelope.job.name, CRON_WORKER_NAME);
+        assert_eq!(envelope.job.args, serde_json::json!({}));
+        assert!(!envelope.meta.unique);
+        assert!(envelope.meta.on_conflict.is_none());
+        assert!(!envelope.meta.resurrect);
+        assert_eq!(envelope.meta.scheduled_at, envelope.meta.created_at);
+    }
+
+    #[test]
+    fn cron_enqueue_redirects_to_cron_notice() {
+        let redirect = cron_enqueued_redirect("/admin");
+        let response = redirect.into_response(&Cx::default()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/admin/cron?enqueued=1"
+        );
+    }
+
+    #[test]
+    fn on_demand_form_rejects_dynamic_or_unknown_queues() {
+        let catalog = on_demand_catalog();
+
+        let err = on_demand_envelope_from_form(
+            &catalog,
+            &OnDemandEnqueueJobForm {
+                queue: "tenant#tenant=acme".to_string(),
+                name: std::any::type_name::<OnDemandJob>().to_string(),
+                args: serde_json::json!({
+                    "id": 1,
+                    "payload": "hello",
+                })
+                .to_string(),
+            },
+        )
+        .expect_err("dynamic queues should not be accepted");
+
+        assert!(matches!(err, oxana::OxanaError::GenericError(_)));
+    }
+
+    #[test]
+    fn on_demand_queue_views_preselect_on_demand_queue() {
+        let views = build_on_demand_queue_views(&[
+            queue_info("alpha", false),
+            queue_info("on_demand", false),
+            queue_info("default", false),
+            queue_info("main", false),
+        ]);
+
+        let selected_keys = views
+            .iter()
+            .filter(|queue| queue.selected)
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected_keys, vec!["on_demand"]);
+    }
+
+    #[test]
+    fn on_demand_queue_views_preselect_default_when_on_demand_is_missing() {
+        let views = build_on_demand_queue_views(&[
+            queue_info("alpha", false),
+            queue_info("default", false),
+            queue_info("main", false),
+        ]);
+
+        let selected_keys = views
+            .iter()
+            .filter(|queue| queue.selected)
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected_keys, vec!["default"]);
+    }
+
+    #[test]
+    fn on_demand_queue_views_preselect_main_when_default_is_missing() {
+        let views = build_on_demand_queue_views(&[
+            queue_info("default", true),
+            queue_info("main", false),
+            queue_info("worker", false),
+        ]);
+
+        let selected_keys = views
+            .iter()
+            .filter(|queue| queue.selected)
+            .map(|queue| queue.key.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(selected_keys, vec!["main"]);
+    }
+
+    #[test]
+    fn on_demand_queue_views_do_not_preselect_other_queues() {
+        let views =
+            build_on_demand_queue_views(&[queue_info("alpha", false), queue_info("worker", false)]);
+
+        assert!(views.iter().all(|queue| !queue.selected));
+    }
+
+    #[test]
+    fn on_demand_form_rejects_unknown_jobs() {
+        let catalog = on_demand_catalog();
+
+        let err = on_demand_envelope_from_form(
+            &catalog,
+            &OnDemandEnqueueJobForm {
+                queue: "default".to_string(),
+                name: "missing".to_string(),
+                args: "{}".to_string(),
+            },
+        )
+        .expect_err("unknown jobs should not be accepted");
+
+        assert!(matches!(err, oxana::OxanaError::GenericError(_)));
+    }
+
+    #[tokio::test]
+    async fn on_demand_enqueue_redirects_after_invalid_json() {
+        let storage = oxana::Storage::builder()
+            .build_from_redis_url("redis://127.0.0.1/0")
+            .expect("test storage pool should build");
+        let state = OxanaWebState::new(storage, on_demand_catalog(), "/admin".to_string());
+
+        let redirect = enqueue_on_demand_job(
+            state,
+            OnDemandEnqueueJobForm {
+                queue: "default".to_string(),
+                name: std::any::type_name::<OnDemandJob>().to_string(),
+                args: "{".to_string(),
+            },
+        )
+        .await
+        .expect("invalid JSON should redirect back to on-demand");
+
+        let response = redirect.into_response(&Cx::default()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/admin/on-demand?invalid_json=1"
+        );
+    }
+
+    #[test]
+    fn on_demand_form_builds_typed_envelope() {
+        let catalog = on_demand_catalog();
+        let envelope = on_demand_envelope_from_form(
+            &catalog,
+            &OnDemandEnqueueJobForm {
+                queue: "default".to_string(),
+                name: std::any::type_name::<OnDemandJob>().to_string(),
+                args: serde_json::json!({
+                    "id": 42,
+                    "payload": "hello",
+                })
+                .to_string(),
+            },
+        )
+        .expect("valid on-demand form should build an envelope");
+
+        assert_eq!(envelope.queue, "default");
+        assert_eq!(
+            envelope.id,
+            format!("{}/on_demand_42", std::any::type_name::<OnDemandJob>())
+        );
+        assert_eq!(
+            envelope.job.args,
+            serde_json::json!({
+                "id": 42,
+                "payload": "hello",
+            })
+        );
+    }
+}

--- a/oxana-web-topcoat/src/lib.rs
+++ b/oxana-web-topcoat/src/lib.rs
@@ -1,0 +1,50 @@
+//! The Oxana dashboard rendered and routed with Topcoat.
+//!
+//! [`router`] mounts in an Axum application in the same way as `oxana-web`.
+//! [`topcoat_router`] exposes the native Topcoat router for other hosts.
+
+mod filters;
+mod handlers;
+mod models;
+mod pagination;
+mod routes;
+mod views;
+
+const JOBS_PER_PAGE: usize = 50;
+
+/// Storage, registered components, and the dashboard's public URL prefix.
+#[derive(Clone)]
+pub struct OxanaWebState {
+    pub storage: oxana::Storage,
+    pub catalog: oxana::Catalog,
+    pub base_path: String,
+}
+
+impl OxanaWebState {
+    pub fn new(storage: oxana::Storage, catalog: oxana::Catalog, base_path: String) -> Self {
+        Self {
+            storage,
+            catalog,
+            base_path: base_path.trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+/// Creates the dashboard for mounting with `axum::Router::nest`.
+///
+/// Set `state.base_path` to the mount path, or to an empty string at the root.
+/// Topcoat handles all dashboard requests; Axum provides the hosting adapter.
+pub fn router(state: OxanaWebState) -> axum::Router {
+    axum::Router::new().fallback_service(topcoat::router::tower::TowerService::new(topcoat_router(
+        state,
+    )))
+}
+
+/// Creates the native Topcoat router with paths relative to the dashboard root.
+///
+/// When hosting at the root, use an empty `base_path`. Hosts mounting it below
+/// a prefix must strip that prefix from incoming paths and set `base_path` to
+/// the public mount path. Views and redirects include that public prefix.
+pub fn topcoat_router(state: OxanaWebState) -> topcoat::router::Router {
+    routes::router(state)
+}

--- a/oxana-web-topcoat/src/models.rs
+++ b/oxana-web-topcoat/src/models.rs
@@ -1,0 +1,1467 @@
+use std::collections::HashMap;
+
+use crate::pagination::JobPage;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum QueueConcurrencyStatus {
+    Fixed,
+    Default { default: usize },
+    Override { default: usize },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueueRuntimeConfigView {
+    pub config: oxana::QueueRuntimeConfig,
+    pub concurrency_status: QueueConcurrencyStatus,
+}
+
+impl QueueRuntimeConfigView {
+    fn concurrency_label(&self) -> String {
+        self.config
+            .concurrency
+            .map_or_else(|| "-".to_string(), |concurrency| concurrency.to_string())
+    }
+
+    fn concurrency_default_label(&self) -> String {
+        match self.concurrency_status {
+            QueueConcurrencyStatus::Fixed => self.concurrency_label(),
+            QueueConcurrencyStatus::Default { default }
+            | QueueConcurrencyStatus::Override { default } => default.to_string(),
+        }
+    }
+
+    fn can_change_concurrency(&self) -> bool {
+        !matches!(self.concurrency_status, QueueConcurrencyStatus::Fixed)
+    }
+
+    fn has_concurrency_override(&self) -> bool {
+        matches!(
+            self.concurrency_status,
+            QueueConcurrencyStatus::Override { .. }
+        )
+    }
+}
+
+fn busy_for(stats: &oxana::Stats, key: &str) -> usize {
+    stats
+        .processing
+        .iter()
+        .filter(|p| p.job_envelope.queue == key)
+        .count()
+}
+
+fn busy_for_process(stats: &oxana::Stats, process: &oxana::Process) -> usize {
+    let id = process.id();
+    stats
+        .processing
+        .iter()
+        .filter(|p| p.process_id == id)
+        .count()
+}
+
+fn concurrency_for(queue_configs: &HashMap<String, QueueRuntimeConfigView>, key: &str) -> String {
+    queue_configs.get(key).map_or_else(
+        || "-".to_string(),
+        QueueRuntimeConfigView::concurrency_label,
+    )
+}
+
+fn default_concurrency_for(
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
+    key: &str,
+) -> String {
+    queue_configs
+        .get(key)
+        .map_or_else(String::new, |config| config.concurrency_default_label())
+}
+
+fn has_concurrency_override_for(
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
+    key: &str,
+) -> bool {
+    queue_configs
+        .get(key)
+        .is_some_and(QueueRuntimeConfigView::has_concurrency_override)
+}
+
+fn state_for(queue_configs: &HashMap<String, QueueRuntimeConfigView>, key: &str) -> String {
+    queue_configs.get(key).map_or_else(
+        || "Active".to_string(),
+        |config| config.config.state.label().to_string(),
+    )
+}
+
+fn state_class_for(
+    queue_configs: &HashMap<String, QueueRuntimeConfigView>,
+    key: &str,
+) -> &'static str {
+    match queue_configs.get(key).map(|config| config.config.state) {
+        Some(oxana::QueueState::Paused) => "text-yellow-300",
+        _ => "text-green-300",
+    }
+}
+
+fn queue_action_path(base_path: &str, key: &str, action: &str) -> String {
+    format!(
+        "{}/queues/{}/{}",
+        base_path,
+        urlencoding::encode(key),
+        action
+    )
+}
+
+fn metrics_chart_bucket_minutes(window_minutes: usize) -> usize {
+    match window_minutes {
+        0..=120 => 1,
+        121..=480 => 5,
+        _ => 15,
+    }
+}
+
+fn downsample_job_metrics_points(
+    points: &[oxana::JobMetricsPoint],
+    window_minutes: usize,
+) -> Vec<oxana::JobMetricsPoint> {
+    let bucket_minutes = metrics_chart_bucket_minutes(window_minutes);
+    if bucket_minutes == 1 {
+        return points.to_vec();
+    }
+
+    points
+        .chunks(bucket_minutes)
+        .map(|chunk| {
+            let timestamp = chunk.first().map_or(0, |point| point.timestamp);
+            chunk.iter().fold(
+                oxana::JobMetricsPoint {
+                    timestamp,
+                    ..Default::default()
+                },
+                |mut sum, point| {
+                    sum.processed = sum.processed.saturating_add(point.processed);
+                    sum.succeeded = sum.succeeded.saturating_add(point.succeeded);
+                    sum.failed = sum.failed.saturating_add(point.failed);
+                    sum.panicked = sum.panicked.saturating_add(point.panicked);
+                    sum.successful_executions = sum
+                        .successful_executions
+                        .saturating_add(point.successful_executions);
+                    sum.failed_executions = sum
+                        .failed_executions
+                        .saturating_add(point.failed_executions);
+                    sum.panicked_executions = sum
+                        .panicked_executions
+                        .saturating_add(point.panicked_executions);
+                    sum.execution_ms = sum.execution_ms.saturating_add(point.execution_ms);
+                    sum
+                },
+            )
+        })
+        .collect()
+}
+
+macro_rules! impl_queue_view_helpers {
+    ($($ty:ty),* $(,)?) => {$(
+        impl $ty {
+            pub fn concurrency_for(&self, key: &str) -> String {
+                concurrency_for(&self.queue_configs, key)
+            }
+
+            pub fn default_concurrency_for(&self, key: &str) -> String {
+                default_concurrency_for(&self.queue_configs, key)
+            }
+
+            pub fn has_concurrency_override_for(&self, key: &str) -> bool {
+                has_concurrency_override_for(&self.queue_configs, key)
+            }
+
+            pub fn state_for(&self, key: &str) -> String {
+                state_for(&self.queue_configs, key)
+            }
+
+            pub fn state_class_for(&self, key: &str) -> &'static str {
+                state_class_for(&self.queue_configs, key)
+            }
+
+            pub fn dynamic_queue_key(&self, key: &str, suffix: &str) -> String {
+                format!("{key}#{suffix}")
+            }
+        }
+    )*};
+}
+
+macro_rules! impl_busy_helpers {
+    ($($ty:ty),* $(,)?) => {$(
+        impl $ty {
+            pub fn busy_for(&self, key: &str) -> usize {
+                busy_for(&self.stats, key)
+            }
+
+            pub fn busy_for_process(&self, process: &oxana::Process) -> usize {
+                busy_for_process(&self.stats, process)
+            }
+        }
+    )*};
+}
+
+impl_queue_view_helpers!(DashboardTemplate, BusyTemplate, QueuesTemplate);
+impl_busy_helpers!(DashboardTemplate, BusyTemplate);
+
+pub(crate) struct DashboardTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub stats: oxana::Stats,
+    pub queue_configs: HashMap<String, QueueRuntimeConfigView>,
+}
+
+pub(crate) struct BusyTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub stats: oxana::Stats,
+    pub queue_configs: HashMap<String, QueueRuntimeConfigView>,
+}
+
+pub(crate) struct QueuesTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub stats: oxana::Stats,
+    pub queue_configs: HashMap<String, QueueRuntimeConfigView>,
+    pub queue_lengths: oxana::QueueLengthMetricsSnapshot,
+    pub sort: String,
+    pub dir: String,
+}
+
+impl QueuesTemplate {
+    pub fn next_dir(&self, col: &str) -> &'static str {
+        if self.sort == col {
+            if self.dir == "desc" { "asc" } else { "desc" }
+        } else {
+            "desc"
+        }
+    }
+
+    pub fn sort_arrow(&self, col: &str) -> &'static str {
+        if self.sort == col {
+            if self.dir == "asc" {
+                " \u{25B2}"
+            } else {
+                " \u{25BC}"
+            }
+        } else {
+            ""
+        }
+    }
+
+    pub fn sort_href(&self, col: &str) -> String {
+        format!(
+            "{}/queues?sort={}&dir={}&minutes={}",
+            self.base_path,
+            col,
+            self.next_dir(col),
+            self.queue_lengths.minutes
+        )
+    }
+
+    pub fn queue_length_chart_data_json(&self) -> String {
+        let timestamps: Vec<i64> = self.queue_lengths.queues.first().map_or_else(
+            || {
+                (0..self.queue_lengths.minutes)
+                    .map(|idx| self.queue_lengths.starts_at + i64::try_from(idx).unwrap_or(0) * 60)
+                    .collect()
+            },
+            |queue| queue.series.iter().map(|point| point.timestamp).collect(),
+        );
+        let series: Vec<serde_json::Value> = self
+            .queue_lengths
+            .queues
+            .iter()
+            .map(|queue| {
+                let data: Vec<u64> = queue.series.iter().map(|point| point.enqueued).collect();
+                serde_json::json!({
+                    "label": queue.queue.clone(),
+                    "data": data,
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "timestamps": timestamps,
+            "series": series,
+        })
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QueueConcurrencyStatus, QueueRuntimeConfigView, QueuesTemplate};
+    use std::collections::HashMap;
+    use topcoat::{context::Cx, view::ViewExt};
+
+    fn queues_template(queue_lengths: oxana::QueueLengthMetricsSnapshot) -> QueuesTemplate {
+        QueuesTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/queues",
+            stats: oxana::Stats {
+                global: oxana::StatsGlobal {
+                    jobs: 0,
+                    enqueued: 0,
+                    processed: 0,
+                    failed: 0,
+                    dead: 0,
+                    scheduled: 0,
+                    retries: 0,
+                    latency_s_max: 0.0,
+                },
+                processes: Vec::new(),
+                processing: Vec::new(),
+                queues: Vec::new(),
+            },
+            queue_configs: HashMap::new(),
+            queue_lengths,
+            sort: "key".to_string(),
+            dir: "asc".to_string(),
+        }
+    }
+
+    fn queue_stats(key: &str) -> oxana::QueueStats {
+        oxana::QueueStats {
+            key: key.to_string(),
+            enqueued: 0,
+            processed: 0,
+            succeeded: 0,
+            panicked: 0,
+            failed: 0,
+            latency_s: 0.0,
+            rate: oxana::QueueRateStats::default(),
+            queues: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn queue_sort_href_preserves_chart_window() {
+        let template = queues_template(oxana::QueueLengthMetricsSnapshot {
+            starts_at: 0,
+            ends_at: 0,
+            minutes: 120,
+            queues: Vec::new(),
+        });
+
+        assert_eq!(
+            template.sort_href("enqueued"),
+            "/admin/queues?sort=enqueued&dir=desc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn queue_length_chart_data_json_uses_window_when_no_queues_exist() {
+        let template = queues_template(oxana::QueueLengthMetricsSnapshot {
+            starts_at: 60,
+            ends_at: 120,
+            minutes: 2,
+            queues: Vec::new(),
+        });
+        let payload: serde_json::Value =
+            serde_json::from_str(&template.queue_length_chart_data_json()).unwrap();
+
+        assert_eq!(payload["timestamps"], serde_json::json!([60, 120]));
+        assert_eq!(payload["series"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn queue_length_chart_data_json_serializes_queue_series() {
+        let template = queues_template(oxana::QueueLengthMetricsSnapshot {
+            starts_at: 60,
+            ends_at: 120,
+            minutes: 2,
+            queues: vec![oxana::QueueLengthMetricsSeries {
+                queue: "default".to_string(),
+                series: vec![
+                    oxana::QueueLengthMetricsPoint {
+                        timestamp: 60,
+                        enqueued: 2,
+                    },
+                    oxana::QueueLengthMetricsPoint {
+                        timestamp: 120,
+                        enqueued: 5,
+                    },
+                ],
+            }],
+        });
+        let payload: serde_json::Value =
+            serde_json::from_str(&template.queue_length_chart_data_json()).unwrap();
+
+        assert_eq!(payload["timestamps"], serde_json::json!([60, 120]));
+        assert_eq!(
+            payload["series"],
+            serde_json::json!([{ "label": "default", "data": [2, 5] }])
+        );
+    }
+
+    #[tokio::test]
+    async fn queues_template_renders_compact_concurrency_override_without_change_form() {
+        let mut template = queues_template(oxana::QueueLengthMetricsSnapshot {
+            starts_at: 0,
+            ends_at: 0,
+            minutes: 60,
+            queues: Vec::new(),
+        });
+        template.stats.queues = vec![queue_stats("emails")];
+        template.queue_configs.insert(
+            "emails".to_string(),
+            QueueRuntimeConfigView {
+                config: oxana::QueueRuntimeConfig::new(5),
+                concurrency_status: QueueConcurrencyStatus::Override { default: 2 },
+            },
+        );
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains(
+            "5 <span class=\"text-gray-500\">(<span class=\"line-through\">2</span>)</span>"
+        ));
+        assert!(!rendered.contains("action=\"/admin/queues/emails/concurrency\""));
+        assert!(!rendered.contains("data-default-concurrency=\"2\""));
+    }
+}
+
+pub(crate) struct MetricsTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub metrics: oxana::JobMetricsSnapshot,
+    pub table_workers: Vec<oxana::WorkerMetricsSummary>,
+    pub sort: String,
+    pub dir: String,
+}
+
+impl MetricsTemplate {
+    pub fn has_sort(&self) -> bool {
+        !self.sort.is_empty()
+    }
+
+    fn effective_sort(&self) -> &str {
+        if self.sort.is_empty() {
+            "total_time"
+        } else {
+            &self.sort
+        }
+    }
+
+    pub fn next_dir(&self, col: &str) -> &'static str {
+        if self.effective_sort() == col {
+            if self.dir == "desc" { "asc" } else { "desc" }
+        } else {
+            "desc"
+        }
+    }
+
+    pub fn sort_arrow(&self, col: &str) -> &'static str {
+        if self.effective_sort() == col {
+            if self.dir == "asc" {
+                " \u{25B2}"
+            } else {
+                " \u{25BC}"
+            }
+        } else {
+            ""
+        }
+    }
+
+    pub fn sort_href(&self, col: &str) -> String {
+        format!(
+            "{}/metrics?sort={}&dir={}&minutes={}",
+            self.base_path,
+            col,
+            self.next_dir(col),
+            self.metrics.minutes
+        )
+    }
+
+    pub fn metric_identity_label(&self, identity: &oxana::MetricIdentity) -> String {
+        metric_identity_label(identity)
+    }
+
+    pub fn execution_chart_data_json(&self) -> String {
+        self.summary_chart_data_json(|point| point.execution_ms as f64 / 1000.0)
+    }
+
+    pub fn processed_chart_data_json(&self) -> String {
+        self.summary_chart_data_json(|point| point.processed as f64)
+    }
+
+    fn summary_chart_data_json(&self, value: impl Fn(&oxana::JobMetricsPoint) -> f64) -> String {
+        let summary_points =
+            downsample_job_metrics_points(&self.metrics.series, self.metrics.minutes);
+        let timestamps: Vec<i64> = summary_points.iter().map(|point| point.timestamp).collect();
+        let series: Vec<serde_json::Value> = self
+            .metrics
+            .workers
+            .iter()
+            .map(|worker| {
+                let points = downsample_job_metrics_points(&worker.series, self.metrics.minutes);
+                let data: Vec<f64> = points.iter().map(&value).collect();
+                serde_json::json!({
+                    "label": metric_identity_label(&worker.identity),
+                    "fullLabel": worker.identity.worker,
+                    "data": data,
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "timestamps": timestamps,
+            "series": series,
+        })
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod metrics_template_tests {
+    use super::{MetricDetailTemplate, MetricsTemplate, metrics_chart_bucket_minutes};
+
+    fn metrics_template(sort: &str, dir: &str) -> MetricsTemplate {
+        MetricsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/metrics",
+            metrics: oxana::JobMetricsSnapshot {
+                starts_at: 0,
+                ends_at: 0,
+                minutes: 120,
+                totals: oxana::JobMetricsTotals::default(),
+                series: Vec::new(),
+                workers: Vec::new(),
+            },
+            table_workers: Vec::new(),
+            sort: sort.to_string(),
+            dir: dir.to_string(),
+        }
+    }
+
+    fn metric_detail_template(
+        minutes: usize,
+        series: Vec<oxana::JobMetricsPoint>,
+    ) -> MetricDetailTemplate {
+        MetricDetailTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/metrics",
+            metrics: oxana::JobMetricsDetail {
+                identity: oxana::MetricIdentity {
+                    worker: "Worker".to_string(),
+                },
+                starts_at: 0,
+                ends_at: 0,
+                minutes,
+                totals: oxana::JobMetricsTotals::default(),
+                series,
+                histogram: Vec::new(),
+            },
+        }
+    }
+
+    fn metric_point(
+        idx: usize,
+        processed: u64,
+        successful_executions: u64,
+        failed_executions_without_panics: u64,
+        panicked_executions: u64,
+        execution_ms: u64,
+    ) -> oxana::JobMetricsPoint {
+        let failed_executions =
+            failed_executions_without_panics.saturating_add(panicked_executions);
+        oxana::JobMetricsPoint {
+            timestamp: 60 + i64::try_from(idx).unwrap_or(0) * 60,
+            processed,
+            succeeded: processed.saturating_sub(failed_executions),
+            failed: failed_executions,
+            panicked: panicked_executions,
+            successful_executions,
+            failed_executions,
+            panicked_executions,
+            execution_ms,
+        }
+    }
+
+    fn worker_metrics(worker: &str, execution_ms: u64) -> oxana::WorkerMetricsSummary {
+        oxana::WorkerMetricsSummary {
+            identity: oxana::MetricIdentity {
+                worker: worker.to_string(),
+            },
+            totals: oxana::JobMetricsTotals {
+                execution_ms,
+                successful_executions: 1,
+                ..oxana::JobMetricsTotals::default()
+            },
+            series: vec![metric_point(0, 1, 1, 0, 0, execution_ms)],
+        }
+    }
+
+    #[test]
+    fn metrics_chart_bucket_policy_matches_selected_windows() {
+        assert_eq!(metrics_chart_bucket_minutes(60), 1);
+        assert_eq!(metrics_chart_bucket_minutes(120), 1);
+        assert_eq!(metrics_chart_bucket_minutes(240), 5);
+        assert_eq!(metrics_chart_bucket_minutes(480), 5);
+        assert_eq!(metrics_chart_bucket_minutes(1440), 15);
+    }
+
+    #[test]
+    fn metrics_sort_href_preserves_chart_window_and_defaults_descending() {
+        let template = metrics_template("", "desc");
+
+        assert_eq!(
+            template.sort_href("processed"),
+            "/admin/metrics?sort=processed&dir=desc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn metrics_sort_href_toggles_current_column() {
+        let template = metrics_template("processed", "desc");
+
+        assert_eq!(
+            template.sort_href("processed"),
+            "/admin/metrics?sort=processed&dir=asc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn metrics_default_sort_shows_total_time_indicator() {
+        let template = metrics_template("", "desc");
+
+        assert_eq!(template.sort_arrow("total_time"), " \u{25BC}");
+        assert_eq!(
+            template.sort_href("total_time"),
+            "/admin/metrics?sort=total_time&dir=asc&minutes=120"
+        );
+    }
+
+    #[test]
+    fn metrics_chart_data_uses_snapshot_worker_order() {
+        let mut template = metrics_template("processed", "desc");
+        template.metrics.series = vec![oxana::JobMetricsPoint {
+            timestamp: 60,
+            ..oxana::JobMetricsPoint::default()
+        }];
+        template.metrics.workers = vec![
+            worker_metrics("ChartFirst", 100),
+            worker_metrics("ChartSecond", 200),
+        ];
+        template.table_workers = vec![
+            worker_metrics("TableFirst", 300),
+            worker_metrics("TableSecond", 400),
+        ];
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&template.execution_chart_data_json()).unwrap();
+
+        assert_eq!(payload["series"][0]["fullLabel"], "ChartFirst");
+        assert_eq!(payload["series"][1]["fullLabel"], "ChartSecond");
+    }
+
+    #[test]
+    fn metrics_chart_data_downsamples_four_hour_window_to_five_minute_buckets() {
+        let mut template = metrics_template("processed", "desc");
+        template.metrics.minutes = 240;
+        let series: Vec<oxana::JobMetricsPoint> = (0..10)
+            .map(|idx| {
+                let value = u64::try_from(idx + 1).unwrap_or(0);
+                metric_point(idx, value, 1, 0, 0, value * 1000)
+            })
+            .collect();
+        template.metrics.series = series.clone();
+        template.metrics.workers = vec![oxana::WorkerMetricsSummary {
+            identity: oxana::MetricIdentity {
+                worker: "Worker".to_string(),
+            },
+            totals: oxana::JobMetricsTotals::default(),
+            series,
+        }];
+
+        let execution_payload: serde_json::Value =
+            serde_json::from_str(&template.execution_chart_data_json()).unwrap();
+        let processed_payload: serde_json::Value =
+            serde_json::from_str(&template.processed_chart_data_json()).unwrap();
+
+        assert_eq!(
+            execution_payload["timestamps"],
+            serde_json::json!([60, 360])
+        );
+        assert_eq!(
+            processed_payload["timestamps"],
+            serde_json::json!([60, 360])
+        );
+        assert_eq!(
+            execution_payload["series"][0]["data"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|value| value.as_f64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![15.0, 40.0]
+        );
+        assert_eq!(
+            processed_payload["series"][0]["data"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|value| value.as_f64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![15.0, 40.0]
+        );
+    }
+
+    #[test]
+    fn metric_detail_chart_data_downsamples_24_hour_window_to_fifteen_minute_buckets() {
+        let template = metric_detail_template(
+            1440,
+            (0..30)
+                .map(|idx| {
+                    if idx < 15 {
+                        metric_point(idx, 1, 1, 0, 0, 100)
+                    } else {
+                        metric_point(idx, 2, 2, 0, 0, 600)
+                    }
+                })
+                .collect(),
+        );
+
+        let average_payload: serde_json::Value =
+            serde_json::from_str(&template.detail_average_chart_data_json()).unwrap();
+        let total_payload: serde_json::Value =
+            serde_json::from_str(&template.detail_total_chart_data_json()).unwrap();
+
+        assert_eq!(average_payload[0], serde_json::json!([60, 960]));
+        assert_eq!(
+            average_payload[1]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|value| value.as_f64().unwrap())
+                .collect::<Vec<_>>(),
+            vec![100.0, 300.0]
+        );
+        assert_eq!(total_payload[0], serde_json::json!([60, 960]));
+        assert_eq!(total_payload[1], serde_json::json!([15, 30]));
+        assert_eq!(total_payload[2], serde_json::json!([0, 0]));
+        assert_eq!(total_payload[3], serde_json::json!([0, 0]));
+    }
+}
+
+fn metric_identity_label(identity: &oxana::MetricIdentity) -> String {
+    identity
+        .worker
+        .rsplit("::")
+        .next()
+        .unwrap_or(&identity.worker)
+        .to_string()
+}
+
+pub(crate) struct MetricDetailTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub metrics: oxana::JobMetricsDetail,
+}
+
+impl MetricDetailTemplate {
+    pub fn detail_average_chart_data_json(&self) -> String {
+        let points = downsample_job_metrics_points(&self.metrics.series, self.metrics.minutes);
+        let timestamps: Vec<i64> = points.iter().map(|point| point.timestamp).collect();
+        let average_ms: Vec<f64> = points
+            .iter()
+            .map(oxana::JobMetricsPoint::average_execution_ms)
+            .collect();
+
+        serde_json::json!([timestamps, average_ms]).to_string()
+    }
+
+    pub fn detail_total_chart_data_json(&self) -> String {
+        let points = downsample_job_metrics_points(&self.metrics.series, self.metrics.minutes);
+        let timestamps: Vec<i64> = points.iter().map(|point| point.timestamp).collect();
+        let succeeded: Vec<u64> = points
+            .iter()
+            .map(|point| point.successful_executions)
+            .collect();
+        let failed_without_panics: Vec<u64> = points
+            .iter()
+            .map(oxana::JobMetricsPoint::failed_executions_without_panics)
+            .collect();
+        let panicked: Vec<u64> = points
+            .iter()
+            .map(|point| point.panicked_executions)
+            .collect();
+
+        serde_json::json!([timestamps, succeeded, failed_without_panics, panicked]).to_string()
+    }
+
+    pub fn max_histogram_count(&self) -> u64 {
+        self.metrics
+            .histogram
+            .iter()
+            .map(|bucket| bucket.count)
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn histogram_width(&self, count: &u64) -> String {
+        let max = self.max_histogram_count();
+        if max == 0 {
+            "0%".to_string()
+        } else {
+            format!("{:.1}%", (*count as f64 / max as f64) * 100.0)
+        }
+    }
+}
+
+pub(crate) enum CronRow {
+    Group { name: String, depth: usize },
+    Worker { view: CronWorkerView, depth: usize },
+}
+
+impl CronRow {
+    fn depth(&self) -> usize {
+        match self {
+            Self::Group { depth, .. } | Self::Worker { depth, .. } => *depth,
+        }
+    }
+
+    pub fn indent_px(&self) -> usize {
+        self.depth() * 20
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CronWorkerView {
+    pub name: String,
+    pub short_name: String,
+    pub schedule: String,
+    pub queue_key: String,
+    pub next_run_micros: Option<i64>,
+}
+
+pub(crate) struct CronTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub rows: Vec<CronRow>,
+    pub total: usize,
+    pub enqueued: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct OnDemandJobView {
+    pub name: String,
+    pub short_name: String,
+    pub args_template_json: String,
+}
+
+pub(crate) enum OnDemandRow {
+    Group { name: String, depth: usize },
+    Job { view: OnDemandJobView, depth: usize },
+}
+
+impl OnDemandRow {
+    fn depth(&self) -> usize {
+        match self {
+            Self::Group { depth, .. } | Self::Job { depth, .. } => *depth,
+        }
+    }
+
+    pub fn indent_px(&self) -> usize {
+        self.depth() * 20
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct OnDemandQueueView {
+    pub key: String,
+    pub selected: bool,
+}
+
+pub(crate) struct OnDemandTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub rows: Vec<OnDemandRow>,
+    pub queues: Vec<OnDemandQueueView>,
+    pub total: usize,
+    pub scheduled: bool,
+    pub invalid_json: bool,
+}
+
+pub(crate) struct QueueDetailTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub queue_key: String,
+    pub queue_stats: Option<oxana::QueueStats>,
+    pub queue_config: QueueRuntimeConfigView,
+    pub active_jobs: Vec<oxana::StatsProcessing>,
+    pub busy: usize,
+    pub page: JobPage,
+}
+
+impl QueueDetailTemplate {
+    pub fn state_label(&self) -> &'static str {
+        self.queue_config.config.state.label()
+    }
+
+    pub fn state_class(&self) -> &'static str {
+        match self.queue_config.config.state {
+            oxana::QueueState::Active => "text-green-300 border-green-800 bg-green-900/30",
+            oxana::QueueState::Paused => "text-yellow-300 border-yellow-800 bg-yellow-900/30",
+        }
+    }
+
+    pub fn is_paused(&self) -> bool {
+        matches!(self.queue_config.config.state, oxana::QueueState::Paused)
+    }
+
+    pub fn concurrency_label(&self) -> String {
+        self.queue_config.concurrency_label()
+    }
+
+    pub fn concurrency_default_label(&self) -> String {
+        self.queue_config.concurrency_default_label()
+    }
+
+    pub fn can_change_concurrency(&self) -> bool {
+        self.queue_config.can_change_concurrency()
+    }
+
+    pub fn has_concurrency_override(&self) -> bool {
+        self.queue_config.has_concurrency_override()
+    }
+
+    pub fn queue_action_path(&self, action: &str) -> String {
+        queue_action_path(&self.base_path, &self.queue_key, action)
+    }
+}
+
+pub(crate) enum JobListKind {
+    Dead,
+    Retries,
+    Scheduled,
+}
+
+impl JobListKind {
+    pub fn path(&self) -> &'static str {
+        match self {
+            Self::Dead => "/dead",
+            Self::Retries => "/retries",
+            Self::Scheduled => "/scheduled",
+        }
+    }
+
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Dead => "Dead Jobs",
+            Self::Retries => "Retries",
+            Self::Scheduled => "Scheduled",
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Dead => "dead jobs",
+            Self::Retries => "retrying jobs",
+            Self::Scheduled => "scheduled jobs",
+        }
+    }
+
+    pub fn empty_label(&self) -> &'static str {
+        match self {
+            Self::Dead => "No dead jobs",
+            Self::Retries => "No retrying jobs",
+            Self::Scheduled => "No scheduled jobs",
+        }
+    }
+
+    pub fn border_class(&self) -> &'static str {
+        match self {
+            Self::Dead => "border-red-900/50",
+            Self::Retries => "border-orange-900/50",
+            Self::Scheduled => "border-yellow-900/50",
+        }
+    }
+
+    pub fn is_dead(&self) -> bool {
+        matches!(self, Self::Dead)
+    }
+
+    pub fn is_retries(&self) -> bool {
+        matches!(self, Self::Retries)
+    }
+
+    pub fn dot_class(&self) -> &'static str {
+        match self {
+            Self::Dead => "bg-red-400",
+            Self::Retries => "bg-orange-400",
+            Self::Scheduled => "bg-yellow-400",
+        }
+    }
+}
+
+pub(crate) struct GlobalJobsTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub kind: JobListKind,
+    pub page: JobPage,
+}
+
+pub(crate) struct JobDetailTemplate {
+    pub base_path: String,
+    pub active_tab: &'static str,
+    pub job_id: String,
+    pub job: Option<oxana::JobEnvelope>,
+    pub is_dead: bool,
+}
+
+#[cfg(test)]
+mod job_card_tests {
+    use super::{GlobalJobsTemplate, JobListKind};
+    use crate::pagination::JobPage;
+    use serde_json::json;
+    use topcoat::{context::Cx, view::ViewExt};
+
+    fn job_envelope(args: serde_json::Value) -> oxana::JobEnvelope {
+        job_envelope_with_id("job-1", args)
+    }
+
+    fn job_envelope_with_id(id: &str, args: serde_json::Value) -> oxana::JobEnvelope {
+        oxana::JobEnvelope {
+            id: id.to_string(),
+            queue: "default".to_string(),
+            job: oxana::JobData {
+                name: "crate::ImportGame".to_string(),
+                args,
+            },
+            meta: oxana::JobMeta {
+                id: id.to_string(),
+                retries: 0,
+                unique: false,
+                on_conflict: None,
+                created_at: 1_000_000,
+                scheduled_at: 1_000_000,
+                started_at: None,
+                state: None,
+                resurrect: true,
+                error: None,
+                throttle_cost: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn global_job_pagination_uses_lookahead_and_preserves_links() {
+        for kind in [
+            JobListKind::Scheduled,
+            JobListKind::Dead,
+            JobListKind::Retries,
+        ] {
+            let jobs = (1..=51)
+                .map(|id| job_envelope_with_id(&format!("job-{id}"), json!({})))
+                .collect();
+            let path = kind.path();
+            let template = GlobalJobsTemplate {
+                base_path: "/admin".to_string(),
+                active_tab: path,
+                kind,
+                page: JobPage::new(2, 101, jobs),
+            };
+            let rendered = template
+                .into_view(&Cx::default())
+                .single()
+                .await
+                .unwrap()
+                .render(&Cx::default());
+
+            assert!(rendered.contains("href=\"/admin/jobs/job-50\""));
+            assert!(!rendered.contains("href=\"/admin/jobs/job-51\""));
+            assert!(rendered.contains("href=\"?page=1\""));
+            assert!(rendered.contains("href=\"?page=3\""));
+            assert!(rendered.contains("51–100 of 101"));
+        }
+    }
+
+    #[test]
+    fn pagination_normalizes_zero_and_does_not_infer_next_page_from_total() {
+        let opts = JobPage::list_opts(0);
+        assert_eq!((opts.offset, opts.count), (0, 51));
+        assert_eq!(JobPage::list_opts(2).offset, 50);
+
+        let page = JobPage::new(0, 100, vec![job_envelope(json!({}))]);
+        assert_eq!(page.number, 1);
+        assert_eq!((page.range_start(), page.range_end()), (1, 1));
+        assert!(!page.has_next);
+
+        let page = JobPage::new(2, 50, vec![job_envelope(json!({}))]);
+        assert_eq!(page.range_end(), 50);
+    }
+
+    #[tokio::test]
+    async fn global_job_cards_escape_progress_notes_and_keep_other_state_visible() {
+        for (state, expected) in [
+            (json!([1, 4, "<b>Importing</b>"]), "1 / 4 (25%)"),
+            (json!({"checkpoint": "resume-here"}), "resume-here"),
+        ] {
+            let mut job = job_envelope(json!({}));
+            job.meta.state = Some(state);
+            let template = GlobalJobsTemplate {
+                base_path: "/admin".to_string(),
+                active_tab: "/scheduled",
+                kind: JobListKind::Scheduled,
+                page: JobPage::new(1, 1, vec![job]),
+            };
+            let rendered = template
+                .into_view(&Cx::default())
+                .single()
+                .await
+                .unwrap()
+                .render(&Cx::default());
+            assert!(rendered.contains(expected));
+            assert!(!rendered.contains("<b>Importing</b>"));
+            if expected == "1 / 4 (25%)" {
+                assert!(rendered.contains("&lt;b&gt;Importing&lt;/b&gt;"));
+                assert!(rendered.contains("style=\"width: 25%\""));
+                assert!(rendered.contains("ETA —"));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn global_job_cards_render_simple_arg_pills() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/scheduled",
+            kind: JobListKind::Scheduled,
+            page: JobPage::new(
+                1,
+                1,
+                vec![job_envelope(json!({
+                    "game_id": 12345,
+                    "dry_run": false,
+                }))],
+            ),
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("title=\"game_id: 12345\""));
+        assert!(rendered.contains("title=\"dry_run: false\""));
+        assert!(
+            !rendered.contains(
+                "<summary class=\"text-xs text-gray-500 cursor-pointer hover:text-gray-300\">Arguments</summary>"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn global_job_cards_render_pills_and_json_args_when_any_arg_is_complex() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/scheduled",
+            kind: JobListKind::Scheduled,
+            page: JobPage::new(
+                1,
+                1,
+                vec![job_envelope(json!({
+                    "game_id": 12345,
+                    "metadata": { "season": 2026 },
+                }))],
+            ),
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("title=\"game_id: 12345\""));
+        assert!(!rendered.contains("title=\"metadata:"));
+        assert!(
+            rendered.contains(
+                "<summary class=\"text-xs text-gray-500 cursor-pointer hover:text-gray-300\">Arguments</summary>"
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn global_job_cards_encode_slashes_in_job_links() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/scheduled",
+            kind: JobListKind::Scheduled,
+            page: JobPage::new(
+                1,
+                1,
+                vec![job_envelope_with_id("crate::Worker/type-123", json!({}))],
+            ),
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("href=\"/admin/jobs/crate%3A%3AWorker%2Ftype-123\""));
+    }
+
+    #[tokio::test]
+    async fn dead_jobs_template_renders_revive_all_action() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/dead",
+            kind: JobListKind::Dead,
+            page: JobPage::new(1, 1, vec![job_envelope(json!({}))]),
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("action=\"/admin/dead/revive_all\""));
+        assert!(rendered.contains(">Revive All</button>"));
+        assert!(rendered.contains("confirmReviveAllDead()"));
+    }
+
+    #[tokio::test]
+    async fn retries_template_renders_retry_all_now_action() {
+        let template = GlobalJobsTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/retries",
+            kind: JobListKind::Retries,
+            page: JobPage::new(1, 1, vec![job_envelope(json!({}))]),
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("action=\"/admin/retries/retry_all_now\""));
+        assert!(rendered.contains(">Retry All Now</button>"));
+        assert!(rendered.contains("confirmRetryAllNow()"));
+    }
+}
+
+#[cfg(test)]
+mod cron_tests {
+    use super::{CronRow, CronTemplate, CronWorkerView};
+    use topcoat::{context::Cx, view::ViewExt};
+
+    #[tokio::test]
+    async fn cron_template_renders_enqueue_now_form_at_end_of_row() {
+        let template = CronTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/cron",
+            rows: vec![CronRow::Worker {
+                view: CronWorkerView {
+                    name: "crate::workers::EmailCronWorker".to_string(),
+                    short_name: "EmailCronWorker".to_string(),
+                    schedule: "0 * * * * *".to_string(),
+                    queue_key: "default".to_string(),
+                    next_run_micros: None,
+                },
+                depth: 0,
+            }],
+            total: 1,
+            enqueued: false,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("<th class=\"pb-3 text-right\">Action</th>"));
+        assert!(rendered.contains("action=\"/admin/cron/enqueue\""));
+        assert!(rendered.contains("name=\"name\" value=\"crate::workers::EmailCronWorker\""));
+        assert!(rendered.contains("Enqueue now"));
+    }
+
+    #[tokio::test]
+    async fn cron_template_shows_notice_after_successful_enqueue() {
+        let template = CronTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/cron",
+            rows: Vec::new(),
+            total: 0,
+            enqueued: true,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("Cron job enqueued."));
+        assert!(rendered.contains("data-auto-dismiss-notice"));
+    }
+}
+
+#[cfg(test)]
+mod on_demand_tests {
+    use super::{OnDemandJobView, OnDemandQueueView, OnDemandRow, OnDemandTemplate};
+    use topcoat::{context::Cx, view::ViewExt};
+
+    #[tokio::test]
+    async fn on_demand_template_renders_empty_state() {
+        let template = OnDemandTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/on-demand",
+            rows: Vec::new(),
+            queues: vec![OnDemandQueueView {
+                key: "default".to_string(),
+                selected: true,
+            }],
+            total: 0,
+            scheduled: false,
+            invalid_json: false,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("No on-demand jobs registered"));
+    }
+
+    #[tokio::test]
+    async fn on_demand_template_renders_no_static_queues_state() {
+        let template = OnDemandTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/on-demand",
+            rows: vec![OnDemandRow::Job {
+                view: OnDemandJobView {
+                    name: "crate::EmailWorker".to_string(),
+                    short_name: "EmailWorker".to_string(),
+                    args_template_json: "{}".to_string(),
+                },
+                depth: 0,
+            }],
+            queues: Vec::new(),
+            total: 1,
+            scheduled: false,
+            invalid_json: false,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("No static queues registered"));
+    }
+
+    #[tokio::test]
+    async fn on_demand_template_prefills_enqueue_form() {
+        let template = OnDemandTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/on-demand",
+            rows: vec![
+                OnDemandRow::Group {
+                    name: "crate".to_string(),
+                    depth: 0,
+                },
+                OnDemandRow::Job {
+                    view: OnDemandJobView {
+                        name: "crate::email::EmailWorker".to_string(),
+                        short_name: "email::EmailWorker".to_string(),
+                        args_template_json: "{\n  \"payload\": \"\"\n}".to_string(),
+                    },
+                    depth: 1,
+                },
+            ],
+            queues: vec![OnDemandQueueView {
+                key: "default".to_string(),
+                selected: true,
+            }],
+            total: 1,
+            scheduled: false,
+            invalid_json: false,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("action=\"/admin/on-demand/enqueue\""));
+        assert!(rendered.contains("<option value=\"default\" selected=\"\">default</option>"));
+        assert!(rendered.contains("crate"));
+        assert!(rendered.contains("email::EmailWorker"));
+        assert!(rendered.contains("payload"));
+    }
+
+    #[tokio::test]
+    async fn on_demand_template_shows_notice_after_successful_enqueue() {
+        let template = OnDemandTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/on-demand",
+            rows: Vec::new(),
+            queues: Vec::new(),
+            total: 0,
+            scheduled: true,
+            invalid_json: false,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("Job scheduled."));
+        assert!(rendered.contains("data-auto-dismiss-notice"));
+    }
+
+    #[tokio::test]
+    async fn on_demand_template_shows_notice_after_invalid_json() {
+        let template = OnDemandTemplate {
+            base_path: "/admin".to_string(),
+            active_tab: "/on-demand",
+            rows: Vec::new(),
+            queues: Vec::new(),
+            total: 0,
+            scheduled: false,
+            invalid_json: true,
+        };
+
+        let rendered = template
+            .into_view(&Cx::default())
+            .single()
+            .await
+            .unwrap()
+            .render(&Cx::default());
+
+        assert!(rendered.contains("Invalid JSON."));
+        assert!(rendered.contains("data-auto-dismiss-notice"));
+    }
+}

--- a/oxana-web-topcoat/src/pagination.rs
+++ b/oxana-web-topcoat/src/pagination.rs
@@ -1,0 +1,36 @@
+use crate::JOBS_PER_PAGE;
+
+pub(crate) struct JobPage {
+    pub jobs: Vec<oxana::JobEnvelope>,
+    pub number: usize,
+    pub total: usize,
+    pub has_next: bool,
+}
+
+impl JobPage {
+    pub fn list_opts(page: usize) -> oxana::QueueListOpts {
+        oxana::QueueListOpts {
+            count: JOBS_PER_PAGE + 1,
+            offset: (page.max(1) - 1) * JOBS_PER_PAGE,
+        }
+    }
+
+    pub fn new(page: usize, total: usize, mut jobs: Vec<oxana::JobEnvelope>) -> Self {
+        let has_next = jobs.len() > JOBS_PER_PAGE;
+        jobs.truncate(JOBS_PER_PAGE);
+        Self {
+            jobs,
+            number: page.max(1),
+            total,
+            has_next,
+        }
+    }
+
+    pub fn range_start(&self) -> usize {
+        (self.number - 1) * JOBS_PER_PAGE + 1
+    }
+
+    pub fn range_end(&self) -> usize {
+        ((self.number - 1) * JOBS_PER_PAGE + self.jobs.len()).min(self.total)
+    }
+}

--- a/oxana-web-topcoat/src/routes.rs
+++ b/oxana-web-topcoat/src/routes.rs
@@ -1,0 +1,220 @@
+use crate::{
+    OxanaWebState,
+    handlers::{self, *},
+};
+use topcoat::{
+    Result,
+    context::{Cx, app_context},
+    router::{Router, content::Form, error::SeeOther, page, path_param, route},
+    view::{BoxView, View, ViewExt, view},
+};
+
+path_param!(queue_key);
+path_param!(job_id);
+path_param!(*detail_job_id);
+
+pub(crate) fn router(state: OxanaWebState) -> Router {
+    Router::builder()
+        .app_context(state)
+        .page(dashboard)
+        .page(busy)
+        .page(queues_list)
+        .page(metrics)
+        .page(metric_detail)
+        .page(cron_jobs)
+        .page(on_demand_jobs)
+        .page(scheduled_jobs)
+        .page(dead_jobs)
+        .page(retry_jobs)
+        .page(job_detail)
+        .page(queue_detail)
+        .route(enqueue_cron_job)
+        .route(enqueue_on_demand_job)
+        .route(revive_all_dead)
+        .route(wipe_dead)
+        .route(retry_all_now)
+        .route(enqueue_job)
+        .route(pause_queue)
+        .route(unpause_queue)
+        .route(set_queue_concurrency)
+        .route(wipe_queue)
+        .route(delete_job)
+        .build()
+}
+
+#[page("/")]
+async fn dashboard(cx: &Cx) -> Result<impl View + '_> {
+    let data = handlers::dashboard(app_context::<OxanaWebState>(cx).clone()).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/busy")]
+async fn busy(cx: &Cx) -> Result<impl View + '_> {
+    let data = handlers::busy(app_context::<OxanaWebState>(cx).clone()).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/queues")]
+async fn queues_list(cx: &Cx, Form(params): Form<QueuesParams>) -> Result<impl View + '_> {
+    let data = handlers::queues_list(app_context::<OxanaWebState>(cx).clone(), params).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/metrics")]
+async fn metrics(cx: &Cx, Form(params): Form<MetricsParams>) -> Result<impl View + '_> {
+    let data = handlers::metrics(app_context::<OxanaWebState>(cx).clone(), params).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/metrics/job")]
+async fn metric_detail(cx: &Cx, Form(params): Form<MetricDetailParams>) -> Result<impl View + '_> {
+    let data = handlers::metric_detail(app_context::<OxanaWebState>(cx).clone(), params).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/cron")]
+async fn cron_jobs(cx: &Cx, Form(params): Form<CronParams>) -> Result<impl View + '_> {
+    let data = handlers::cron_jobs(app_context::<OxanaWebState>(cx).clone(), params).await;
+    Ok(data.into_view(cx))
+}
+
+#[page("/on-demand")]
+async fn on_demand_jobs(cx: &Cx, Form(params): Form<OnDemandParams>) -> Result<impl View + '_> {
+    let data = handlers::on_demand_jobs(app_context::<OxanaWebState>(cx).clone(), params).await;
+    Ok(data.into_view(cx))
+}
+
+#[page("/scheduled")]
+async fn scheduled_jobs(cx: &Cx, Form(params): Form<PaginationParams>) -> Result<impl View + '_> {
+    let data = handlers::scheduled_jobs(app_context::<OxanaWebState>(cx).clone(), params).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/dead")]
+async fn dead_jobs(cx: &Cx, Form(params): Form<PaginationParams>) -> Result<impl View + '_> {
+    let data = handlers::dead_jobs(app_context::<OxanaWebState>(cx).clone(), params).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/retries")]
+async fn retry_jobs(cx: &Cx, Form(params): Form<PaginationParams>) -> Result<impl View + '_> {
+    let data = handlers::retry_jobs(app_context::<OxanaWebState>(cx).clone(), params).await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/jobs/{*detail_job_id}")]
+async fn job_detail(cx: &Cx) -> Result<impl View + '_> {
+    let data = handlers::job_detail(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<DetailJobId>(cx).collect::<Vec<_>>().join("/"),
+    )
+    .await?;
+    Ok(data.into_view(cx))
+}
+
+#[page("/queues/{queue_key}")]
+async fn queue_detail(cx: &Cx, Form(params): Form<PaginationParams>) -> Result<BoxView<'_>> {
+    let data = handlers::queue_detail(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<QueueKey>(cx).to_string(),
+        params,
+    )
+    .await?;
+    match data {
+        Some(data) => Ok(data.into_view(cx).boxed()),
+        None => {
+            let location = axum::http::HeaderValue::from_str(&format!(
+                "{}/queues",
+                app_context::<OxanaWebState>(cx).base_path,
+            ))?;
+            Ok(view! {
+                (axum::http::StatusCode::SEE_OTHER)
+                ((axum::http::header::LOCATION, location))
+            }
+            .boxed())
+        }
+    }
+}
+
+#[route(POST "/cron/enqueue")]
+async fn enqueue_cron_job(cx: &Cx, Form(form): Form<CronEnqueueJobForm>) -> Result<SeeOther> {
+    handlers::enqueue_cron_job(app_context::<OxanaWebState>(cx).clone(), form).await
+}
+
+#[route(POST "/on-demand/enqueue")]
+async fn enqueue_on_demand_job(
+    cx: &Cx,
+    Form(form): Form<OnDemandEnqueueJobForm>,
+) -> Result<SeeOther> {
+    handlers::enqueue_on_demand_job(app_context::<OxanaWebState>(cx).clone(), form).await
+}
+
+#[route(POST "/dead/revive_all")]
+async fn revive_all_dead(cx: &Cx) -> Result<SeeOther> {
+    handlers::revive_all_dead(app_context::<OxanaWebState>(cx).clone()).await
+}
+
+#[route(POST "/dead/wipe")]
+async fn wipe_dead(cx: &Cx) -> Result<SeeOther> {
+    handlers::wipe_dead(app_context::<OxanaWebState>(cx).clone()).await
+}
+
+#[route(POST "/retries/retry_all_now")]
+async fn retry_all_now(cx: &Cx) -> Result<SeeOther> {
+    handlers::retry_all_now(app_context::<OxanaWebState>(cx).clone()).await
+}
+
+#[route(POST "/enqueue")]
+async fn enqueue_job(cx: &Cx, Form(form): Form<EnqueueJobForm>) -> Result<SeeOther> {
+    handlers::enqueue_job(app_context::<OxanaWebState>(cx).clone(), form).await
+}
+
+#[route(POST "/queues/{queue_key}/pause")]
+async fn pause_queue(cx: &Cx) -> Result<SeeOther> {
+    handlers::pause_queue(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<QueueKey>(cx).to_string(),
+    )
+    .await
+}
+
+#[route(POST "/queues/{queue_key}/unpause")]
+async fn unpause_queue(cx: &Cx) -> Result<SeeOther> {
+    handlers::unpause_queue(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<QueueKey>(cx).to_string(),
+    )
+    .await
+}
+
+#[route(POST "/queues/{queue_key}/concurrency")]
+async fn set_queue_concurrency(
+    cx: &Cx,
+    Form(form): Form<QueueConcurrencyForm>,
+) -> Result<SeeOther> {
+    handlers::set_queue_concurrency(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<QueueKey>(cx).to_string(),
+        form,
+    )
+    .await
+}
+
+#[route(POST "/queues/{queue_key}/wipe")]
+async fn wipe_queue(cx: &Cx) -> Result<SeeOther> {
+    handlers::wipe_queue(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<QueueKey>(cx).to_string(),
+    )
+    .await
+}
+
+#[route(POST "/queues/{queue_key}/jobs/{job_id}/delete")]
+async fn delete_job(cx: &Cx) -> Result<SeeOther> {
+    handlers::delete_job(
+        app_context::<OxanaWebState>(cx).clone(),
+        path_param::<QueueKey>(cx).to_string(),
+        path_param::<JobId>(cx).to_string(),
+    )
+    .await
+}

--- a/oxana-web-topcoat/src/views/busy.rs
+++ b/oxana-web-topcoat/src/views/busy.rs
@@ -1,0 +1,389 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl BusyTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let stats = &self.stats;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>"Oxana Dashboard - Busy"</title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        <section class="mb-10">
+                            <h2 class="text-lg font-semibold mb-4">
+                                "Active Processes ("
+                                (stats.processes.len())
+                                ")"
+                            </h2>
+                            if stats.processes.is_empty() {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No active processes "
+                                </div>
+                            } else {
+                                <div class="overflow-x-auto">
+                                    <table class="w-full text-sm">
+                                        <thead>
+                                            <tr
+                                                class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                            >
+                                                <th class="pb-3 pr-4">"Hostname"</th>
+                                                <th class="pb-3 pr-4">"PID"</th>
+                                                <th class="pb-3 pr-4 text-right">"Busy"</th>
+                                                <th class="pb-3 pr-4">"Started"</th>
+                                                <th class="pb-3">"Last Heartbeat"</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            for process in stats.processes.iter() {
+                                                <tr
+                                                    class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                                >
+                                                    <td class="py-3 pr-4 font-mono text-sm">
+                                                        (&process.hostname)
+                                                    </td>
+                                                    <td class="py-3 pr-4 font-mono">(&process.pid)</td>
+                                                    <td class="py-3 pr-4 text-right text-purple-400">
+                                                        (self.busy_for_process(process))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-gray-400">
+                                                        (filters::relative_time(&process.started_at))
+                                                    </td>
+                                                    <td class="py-3 text-gray-400">
+                                                        (filters::relative_time(&process.heartbeat_at))
+                                                    </td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+                        <section class="mb-10">
+                            <h2 class="text-lg font-semibold mb-4">"Active Queues"</h2>
+                            if stats.queues.is_empty() {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No active queues "
+                                </div>
+                            } else {
+                                <div class="overflow-x-auto">
+                                    <table class="w-full text-sm">
+                                        <thead>
+                                            <tr
+                                                class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                            >
+                                                <th class="pb-3 pr-4">"Queue"</th>
+                                                <th class="pb-3 pr-4 text-right">"Concurrency"</th>
+                                                <th class="pb-3 pr-4 text-right">"State"</th>
+                                                <th class="pb-3 pr-4 text-right">"Busy"</th>
+                                                <th class="pb-3 pr-4 text-right">"Enqueued"</th>
+                                                <th class="pb-3 text-right">"Latency"</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            for queue in stats.queues.iter() {
+                                                let busy = self.busy_for(&queue.key);
+                                                if queue.enqueued > 0 || busy > 0 {
+                                                    <tr
+                                                        class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                                    >
+                                                        <td class="py-3 pr-4 font-mono text-sm">
+                                                            if queue.queues.is_empty() {
+                                                                <a
+                                                                    href=(format!(
+                                                                        "{}/queues/{}",
+                                                                        base_path,
+                                                                        urlencoding::encode(&queue.key),
+                                                                    ))
+                                                                    class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                                >
+                                                                    (&queue.key)
+                                                                </a>
+                                                            } else {
+                                                                (&queue.key)
+                                                            }
+                                                        </td>
+                                                        <td class="py-3 pr-4 text-right text-gray-300">
+                                                            (self.concurrency_for(&queue.key))
+                                                            if self.has_concurrency_override_for(&queue.key) {
+                                                                " "
+                                                                <span class="text-gray-500">
+                                                                    "("
+                                                                    <span class="line-through">
+                                                                        (self.default_concurrency_for(&queue.key))
+                                                                    </span>
+                                                                    ")"
+                                                                </span>
+                                                            }
+                                                        </td>
+                                                        <td
+                                                            class=(format!(
+                                                                "py-3 pr-4 text-right {}",
+                                                                self.state_class_for(&queue.key),
+                                                            ))
+                                                        >
+                                                            (self.state_for(&queue.key))
+                                                        </td>
+                                                        <td class="py-3 pr-4 text-right text-purple-400">
+                                                            (busy)
+                                                        </td>
+                                                        <td class="py-3 pr-4 text-right text-blue-400">
+                                                            (&queue.enqueued)
+                                                        </td>
+                                                        <td class="py-3 text-right text-purple-400">
+                                                            (filters::format_latency(&queue.latency_s))
+                                                        </td>
+                                                    </tr>
+                                                    for dq in queue.queues.iter() {
+                                                        if dq.enqueued > 0 {
+                                                            let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix);
+                                                            <tr
+                                                                class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500"
+                                                            >
+                                                                <td class="py-2 pr-4 pl-10 font-mono text-xs">
+                                                                    "↳ "
+                                                                    <a
+                                                                        href=(format!(
+                                                                            "{}/queues/{}%23{}",
+                                                                            base_path,
+                                                                            queue.key,
+                                                                            urlencoding::encode(&dq.suffix),
+                                                                        ))
+                                                                        class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                                    >
+                                                                        (&dq.suffix)
+                                                                    </a>
+                                                                </td>
+                                                                <td class="py-2 pr-4 text-right text-xs text-gray-400">
+                                                                    (self.concurrency_for(&dq_key))
+                                                                    if self.has_concurrency_override_for(&dq_key) {
+                                                                        " "
+                                                                        <span class="text-gray-600">
+                                                                            "("
+                                                                            <span class="line-through">
+                                                                                (self.default_concurrency_for(&dq_key))
+                                                                            </span>
+                                                                            ")"
+                                                                        </span>
+                                                                    }
+                                                                </td>
+                                                                <td
+                                                                    class=(format!(
+                                                                        "py-2 pr-4 text-right text-xs {}",
+                                                                        self.state_class_for(&dq_key),
+                                                                    ))
+                                                                >
+                                                                    (self.state_for(&dq_key))
+                                                                </td>
+                                                                <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
+                                                                <td class="py-2 pr-4 text-right text-xs text-blue-400">
+                                                                    (&dq.enqueued)
+                                                                </td>
+                                                                <td class="py-2 text-right text-xs text-purple-400">
+                                                                    (filters::format_latency(&dq.latency_s))
+                                                                </td>
+                                                            </tr>
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+                        <section class="mb-10">
+                            <h2 class="text-lg font-semibold mb-4">
+                                "Currently Processing ("
+                                (stats.processing.len())
+                                ")"
+                            </h2>
+                            if stats.processing.is_empty() {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No jobs currently being processed "
+                                </div>
+                            } else {
+                                <div class="space-y-3">
+                                    for item in stats.processing.iter() {
+                                        <div
+                                            class="bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                        >
+                                            <div class="flex items-start justify-between mb-2">
+                                                <div class="flex items-center gap-2">
+                                                    <span
+                                                        class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"
+                                                    ></span>
+                                                    <span class="font-semibold text-sm">
+                                                        (&item.job_envelope.job.name)
+                                                    </span>
+                                                </div>
+                                                <a
+                                                    href=(format!(
+                                                        "{}/jobs/{}",
+                                                        base_path,
+                                                        urlencoding::encode(&item.job_envelope.id),
+                                                    ))
+                                                    class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono"
+                                                >
+                                                    (&item.job_envelope.id)
+                                                </a>
+                                            </div>
+                                            <div
+                                                class="grid grid-cols-1 sm:grid-cols-5 gap-2 text-xs text-gray-400 mt-2"
+                                            >
+                                                <div>
+                                                    <span class="text-gray-500">"Process:"</span>
+                                                    <span class="ml-1 text-gray-300 font-mono">
+                                                        (&item.process_id)
+                                                    </span>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Queue:"</span>
+                                                    <a
+                                                        href=(format!(
+                                                            "{}/queues/{}",
+                                                            base_path,
+                                                            urlencoding::encode(&item.job_envelope.queue),
+                                                        ))
+                                                        class="ml-1 text-blue-400 hover:text-blue-300 hover:underline"
+                                                    >
+                                                        (&item.job_envelope.queue)
+                                                    </a>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Started:"</span>
+                                                    <span class="ml-1 text-gray-300">
+                                                        (filters::relative_time_micros_opt(
+                                                            &item.job_envelope.meta.started_at,
+                                                        ))
+                                                    </span>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Scheduled:"</span>
+                                                    <span class="ml-1 text-gray-300">
+                                                        (filters::relative_time_micros(
+                                                            &item.job_envelope.meta.scheduled_at,
+                                                        ))
+                                                    </span>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Retries:"</span>
+                                                    <span class="ml-1 text-gray-300">
+                                                        (&item.job_envelope.meta.retries)
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            let arg_pills = filters::simple_args(
+                                                &item.job_envelope.job.args,
+                                            );
+                                            partials::argument_pills(arg_pills: &arg_pills)
+                                            if filters::show_args_json(&item.job_envelope.job.args) {
+                                                <div class="mt-3">
+                                                    <details>
+                                                        <summary
+                                                            class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                        >
+                                                            "Arguments"
+                                                        </summary>
+                                                        <pre
+                                                            class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                        >
+                                                            (filters::pretty_json(&item.job_envelope.job.args))
+                                                        </pre>
+                                                    </details>
+                                                </div>
+                                            }
+                                            match &item.job_envelope.meta.state {
+                                                Some(state) => {
+                                                    if filters::has_args(state) {
+                                                        let progress_started_at = item.job_envelope.meta.started_at;
+                                                        if let Some(progress) = filters::job_progress(
+                                                            state,
+                                                            &progress_started_at,
+                                                        ) {
+                                                            partials::job_progress(progress: &progress)
+                                                        } else {
+                                                            <div class="mt-3">
+                                                                <details>
+                                                                    <summary
+                                                                        class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                                    >
+                                                                        "State"
+                                                                    </summary>
+                                                                    <pre
+                                                                        class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                                    >
+                                                                        (filters::pretty_json(state))
+                                                                    </pre>
+                                                                </details>
+                                                            </div>
+                                                        }
+                                                    }
+                                                }
+                                                None => {
+
+                                                }
+                                            }
+                                            <div class="mt-3 flex justify-end">
+                                                <form
+                                                    method="POST"
+                                                    action=(format!(
+                                                        "{}/queues/{}/jobs/{}/delete",
+                                                        base_path,
+                                                        urlencoding::encode(&item.job_envelope.queue),
+                                                        urlencoding::encode(&item.job_envelope.id),
+                                                    ))
+                                                    onsubmit=(format!(
+                                                        "return confirmDeleteJob('{}')",
+                                                        item.job_envelope.id,
+                                                    ))
+                                                >
+                                                    <button
+                                                        type="submit"
+                                                        class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors"
+                                                    >
+                                                        "Delete Job"
+                                                    </button>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+                            }
+                        </section>
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/busy.js")))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/cron.rs
+++ b/oxana-web-topcoat/src/views/cron.rs
@@ -1,0 +1,134 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl CronTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let rows = &self.rows;
+            let total = self.total;
+            let enqueued = self.enqueued;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>"Cron - Oxana"</title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        if enqueued {
+                            <div
+                                data-auto-dismiss-notice=(true)
+                                class="mb-4 rounded border border-green-800 bg-green-950/40 px-4 py-3 text-sm text-green-300"
+                            >
+                                " Cron job enqueued. "
+                            </div>
+                        }
+                        <h2 class="text-lg font-semibold mb-4">
+                            "Cron Workers ("
+                            (total)
+                            ")"
+                        </h2>
+                        if rows.is_empty() {
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                            >
+                                " No cron workers registered "
+                            </div>
+                        } else {
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-sm">
+                                    <thead>
+                                        <tr
+                                            class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                        >
+                                            <th class="pb-3 pr-4">"Worker"</th>
+                                            <th class="pb-3 pr-4">"Queue"</th>
+                                            <th class="pb-3 pr-4">"Schedule"</th>
+                                            <th class="pb-3">"Next Run"</th>
+                                            <th class="pb-3 text-right">"Action"</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        for row in rows {
+                                            match &row {
+                                                CronRow::Group { name, depth: _ } => {
+                                                    <tr class="border-b border-gray-800/50">
+                                                        <td
+                                                            colspan="5"
+                                                            class="py-2 pt-4 font-mono text-xs text-gray-500 font-semibold"
+                                                            style=(format!("padding-left: {}px", row.indent_px()))
+                                                        >
+                                                            (name)
+                                                        </td>
+                                                    </tr>
+                                                }
+                                                CronRow::Worker { view: cw, depth: _ } => {
+                                                    <tr
+                                                        class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                                    >
+                                                        <td
+                                                            class="py-3 pr-4 font-mono text-sm"
+                                                            style=(format!("padding-left: {}px", row.indent_px()))
+                                                        >
+                                                            <span class="text-gray-600">"↳ "</span>
+                                                            (&cw.short_name)
+                                                        </td>
+                                                        <td class="py-3 pr-4 font-mono text-sm text-gray-400">
+                                                            (&cw.queue_key)
+                                                        </td>
+                                                        <td class="py-3 pr-4 font-mono text-sm text-yellow-400">
+                                                            (&cw.schedule)
+                                                        </td>
+                                                        <td class="py-3 text-gray-300">
+                                                            (filters::relative_time_micros_opt(&cw.next_run_micros))
+                                                        </td>
+                                                        <td class="py-3 text-right">
+                                                            <form
+                                                                method="POST"
+                                                                action=(format!("{}/cron/enqueue", base_path))
+                                                                class="inline"
+                                                            >
+                                                                <input type="hidden" name="name" value=(&cw.name)>
+                                                                <button
+                                                                    type="submit"
+                                                                    class="whitespace-nowrap rounded bg-green-900/50 border border-green-800 px-2.5 py-1 text-xs text-green-300 hover:bg-green-800 transition-colors"
+                                                                >
+                                                                    "Enqueue now"
+                                                                </button>
+                                                            </form>
+                                                        </td>
+                                                    </tr>
+                                                }
+                                            }
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/notices.js")))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/dashboard.rs
+++ b/oxana-web-topcoat/src/views/dashboard.rs
@@ -1,0 +1,227 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{View, view},
+};
+
+impl DashboardTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let stats = &self.stats;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>"Oxana Dashboard"</title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        partials::stats_cards(base_path: base_path, stats: stats)
+                        <section class="mb-10">
+                            <h2 class="text-lg font-semibold mb-4">
+                                "Active Processes ("
+                                (stats.processes.len())
+                                ")"
+                            </h2>
+                            if stats.processes.is_empty() {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No active processes "
+                                </div>
+                            } else {
+                                <div class="overflow-x-auto">
+                                    <table class="w-full text-sm">
+                                        <thead>
+                                            <tr
+                                                class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                            >
+                                                <th class="pb-3 pr-4">"Hostname"</th>
+                                                <th class="pb-3 pr-4">"PID"</th>
+                                                <th class="pb-3 pr-4 text-right">"Busy"</th>
+                                                <th class="pb-3 pr-4">"Started"</th>
+                                                <th class="pb-3">"Last Heartbeat"</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            for process in stats.processes.iter() {
+                                                <tr
+                                                    class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                                >
+                                                    <td class="py-3 pr-4 font-mono text-sm">
+                                                        (&process.hostname)
+                                                    </td>
+                                                    <td class="py-3 pr-4 font-mono">(&process.pid)</td>
+                                                    <td class="py-3 pr-4 text-right text-purple-400">
+                                                        (self.busy_for_process(process))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-gray-400">
+                                                        (filters::relative_time(&process.started_at))
+                                                    </td>
+                                                    <td class="py-3 text-gray-400">
+                                                        (filters::relative_time(&process.heartbeat_at))
+                                                    </td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+                        <section>
+                            <h2 class="text-lg font-semibold mb-4">
+                                "Queues ("
+                                (stats.queues.len())
+                                ")"
+                            </h2>
+                            if stats.queues.is_empty() {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No queues "
+                                </div>
+                            } else {
+                                <div class="overflow-x-auto">
+                                    <table class="w-full text-sm">
+                                        <thead>
+                                            <tr
+                                                class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                            >
+                                                <th class="pb-3 pr-4">"Queue"</th>
+                                                <th class="pb-3 pr-4 text-right">"Concurrency"</th>
+                                                <th class="pb-3 pr-4 text-right">"State"</th>
+                                                <th class="pb-3 pr-4 text-right">"Busy"</th>
+                                                <th class="pb-3 pr-4 text-right">"Enqueued"</th>
+                                                <th class="pb-3 text-right">"Latency"</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            for queue in stats.queues.iter() {
+                                                <tr
+                                                    class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                                >
+                                                    <td class="py-3 pr-4 font-mono text-sm">
+                                                        if queue.queues.is_empty() {
+                                                            <a
+                                                                href=(format!(
+                                                                    "{}/queues/{}",
+                                                                    base_path,
+                                                                    urlencoding::encode(&queue.key),
+                                                                ))
+                                                                class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                            >
+                                                                (&queue.key)
+                                                            </a>
+                                                        } else {
+                                                            (&queue.key)
+                                                        }
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-gray-300">
+                                                        (self.concurrency_for(&queue.key))
+                                                        if self.has_concurrency_override_for(&queue.key) {
+                                                            " "
+                                                            <span class="text-gray-500">
+                                                                "("
+                                                                <span class="line-through">
+                                                                    (self.default_concurrency_for(&queue.key))
+                                                                </span>
+                                                                ")"
+                                                            </span>
+                                                        }
+                                                    </td>
+                                                    <td
+                                                        class=(format!(
+                                                            "py-3 pr-4 text-right {}",
+                                                            self.state_class_for(&queue.key),
+                                                        ))
+                                                    >
+                                                        (self.state_for(&queue.key))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-purple-400">
+                                                        (self.busy_for(&queue.key))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-blue-400">
+                                                        (&queue.enqueued)
+                                                    </td>
+                                                    <td class="py-3 text-right text-purple-400">
+                                                        (filters::format_latency(&queue.latency_s))
+                                                    </td>
+                                                </tr>
+                                                for dq in queue.queues.iter() {
+                                                    if dq.enqueued > 0 {
+                                                        let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix);
+                                                        <tr
+                                                            class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500"
+                                                        >
+                                                            <td class="py-2 pr-4 pl-10 font-mono text-xs">
+                                                                "↳ "
+                                                                <a
+                                                                    href=(format!(
+                                                                        "{}/queues/{}%23{}",
+                                                                        base_path,
+                                                                        queue.key,
+                                                                        urlencoding::encode(&dq.suffix),
+                                                                    ))
+                                                                    class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                                >
+                                                                    (&dq.suffix)
+                                                                </a>
+                                                            </td>
+                                                            <td class="py-2 pr-4 text-right text-xs text-gray-400">
+                                                                (self.concurrency_for(&dq_key))
+                                                                if self.has_concurrency_override_for(&dq_key) {
+                                                                    " "
+                                                                    <span class="text-gray-600">
+                                                                        "("
+                                                                        <span class="line-through">
+                                                                            (self.default_concurrency_for(&dq_key))
+                                                                        </span>
+                                                                        ")"
+                                                                    </span>
+                                                                }
+                                                            </td>
+                                                            <td
+                                                                class=(format!(
+                                                                    "py-2 pr-4 text-right text-xs {}",
+                                                                    self.state_class_for(&dq_key),
+                                                                ))
+                                                            >
+                                                                (self.state_for(&dq_key))
+                                                            </td>
+                                                            <td class="py-2 pr-4 text-right text-xs text-purple-400"></td>
+                                                            <td class="py-2 pr-4 text-right text-xs text-blue-400">
+                                                                (&dq.enqueued)
+                                                            </td>
+                                                            <td class="py-2 text-right text-xs text-purple-400">
+                                                                (filters::format_latency(&dq.latency_s))
+                                                            </td>
+                                                        </tr>
+                                                    }
+                                                }
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+                    </div>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/global_jobs.rs
+++ b/oxana-web-topcoat/src/views/global_jobs.rs
@@ -1,0 +1,374 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl GlobalJobsTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let kind = self.kind;
+            let page = &self.page;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>
+                        (kind.title())
+                        " - Oxana"
+                    </title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="flex items-center justify-between mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        <div class="flex items-center justify-between mb-4">
+                            <h2 class="text-lg font-semibold">
+                                if page.total > 0 {
+                                    (page.range_start())
+                                    "–"
+                                    (page.range_end())
+                                    " of "
+                                    (&page.total)
+                                    " "
+                                    (kind.label())
+                                } else {
+                                    " 0 "
+                                    (kind.label())
+                                }
+                            </h2>
+                            <div class="flex items-center gap-2 text-sm">
+                                if kind.is_dead() {
+                                    if page.total > 0 {
+                                        <form
+                                            method="POST"
+                                            action=(format!("{}/dead/revive_all", base_path))
+                                            onsubmit="return confirmReviveAllDead()"
+                                        >
+                                            <button
+                                                type="submit"
+                                                class="px-3 py-1 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 transition-colors"
+                                            >
+                                                "Revive All"
+                                            </button>
+                                        </form>
+                                        <form
+                                            method="POST"
+                                            action=(format!("{}/dead/wipe", base_path))
+                                            onsubmit="return confirmWipeDead()"
+                                        >
+                                            <button
+                                                type="submit"
+                                                class="px-3 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 transition-colors"
+                                            >
+                                                "Wipe"
+                                            </button>
+                                        </form>
+                                    }
+                                }
+                                if kind.is_retries() {
+                                    if page.total > 0 {
+                                        <form
+                                            method="POST"
+                                            action=(format!("{}/retries/retry_all_now", base_path))
+                                            onsubmit="return confirmRetryAllNow()"
+                                        >
+                                            <button
+                                                type="submit"
+                                                class="px-3 py-1 rounded bg-orange-900/50 border border-orange-800 hover:bg-orange-800 text-orange-300 transition-colors"
+                                            >
+                                                "Retry All Now"
+                                            </button>
+                                        </form>
+                                    }
+                                }
+                                if page.number > 1 {
+                                    <a
+                                        href=(format!("?page={}", page.number - 1))
+                                        class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                    >
+                                        "← Prev"
+                                    </a>
+                                } else {
+                                    <span
+                                        class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed"
+                                    >
+                                        "← Prev"
+                                    </span>
+                                }
+                                if page.has_next {
+                                    <a
+                                        href=(format!("?page={}", page.number + 1))
+                                        class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                    >
+                                        "Next →"
+                                    </a>
+                                } else {
+                                    <span
+                                        class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed"
+                                    >
+                                        "Next →"
+                                    </span>
+                                }
+                            </div>
+                        </div>
+                        if page.jobs.is_empty() {
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                            >
+                                (kind.empty_label())
+                            </div>
+                        } else {
+                            <div class="space-y-3">
+                                for job in page.jobs.iter() {
+                                    <div
+                                        class=(format!(
+                                            "bg-gray-900 border {} rounded-lg p-4",
+                                            kind.border_class(),
+                                        ))
+                                    >
+                                        <div class="flex items-start justify-between mb-2">
+                                            <div class="flex items-center gap-2">
+                                                <span
+                                                    class=(format!(
+                                                        "inline-block w-2 h-2 rounded-full {}",
+                                                        kind.dot_class(),
+                                                    ))
+                                                ></span>
+                                                <span class="font-semibold text-sm">(&job.job.name)</span>
+                                            </div>
+                                            <a
+                                                href=(format!(
+                                                    "{}/jobs/{}",
+                                                    base_path,
+                                                    urlencoding::encode(&job.id),
+                                                ))
+                                                class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono"
+                                            >
+                                                (&job.id)
+                                            </a>
+                                        </div>
+                                        <div
+                                            class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2"
+                                        >
+                                            <div>
+                                                <span class="text-gray-500">"Queue:"</span>
+                                                <a
+                                                    href=(format!(
+                                                        "{}/queues/{}",
+                                                        base_path,
+                                                        urlencoding::encode(&job.queue),
+                                                    ))
+                                                    class="ml-1 text-blue-400 hover:text-blue-300 hover:underline"
+                                                >
+                                                    (&job.queue)
+                                                </a>
+                                            </div>
+                                            <div>
+                                                <span class="text-gray-500">"Retries:"</span>
+                                                <span class="ml-1 text-gray-300">(&job.meta.retries)</span>
+                                            </div>
+                                            <div>
+                                                <span class="text-gray-500">"Created:"</span>
+                                                <span class="ml-1 text-gray-300">
+                                                    (filters::relative_time_micros(&job.meta.created_at))
+                                                </span>
+                                            </div>
+                                            <div>
+                                                <span class="text-gray-500">"Scheduled:"</span>
+                                                <span class="ml-1 text-gray-300">
+                                                    (filters::relative_time_micros(&job.meta.scheduled_at))
+                                                </span>
+                                            </div>
+                                        </div>
+                                        let arg_pills = filters::simple_args(&job.job.args);
+                                        partials::argument_pills(arg_pills: &arg_pills)
+                                        if filters::show_args_json(&job.job.args) {
+                                            <details class="mt-3" open=(true)>
+                                                <summary
+                                                    class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                >
+                                                    "Arguments"
+                                                </summary>
+                                                <pre
+                                                    class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                >
+                                                    (filters::pretty_json(&job.job.args))
+                                                </pre>
+                                            </details>
+                                        }
+                                        match &job.meta.error {
+                                            Some(error) => {
+                                                <details class="mt-3" open=(true)>
+                                                    <summary
+                                                        class="text-xs text-red-400 cursor-pointer hover:text-red-300"
+                                                    >
+                                                        "Error"
+                                                    </summary>
+                                                    if error.lines().count() > 10 {
+                                                        <pre
+                                                            class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50 error-truncated"
+                                                        >
+                                                            (error.lines().take(10).collect::<Vec<_>>().join("\n"))
+                                                        </pre>
+                                                        <pre
+                                                            class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50 error-full"
+                                                            style="display:none"
+                                                        >
+                                                            (error)
+                                                        </pre>
+                                                        <button
+                                                            onclick="toggleFullError(this)"
+                                                            class="mt-1 text-xs text-red-400 hover:text-red-300 cursor-pointer underline"
+                                                        >
+                                                            "View full error"
+                                                        </button>
+                                                    } else {
+                                                        <pre
+                                                            class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50"
+                                                        >
+                                                            (error)
+                                                        </pre>
+                                                    }
+                                                </details>
+                                            }
+                                            None => {
+
+                                            }
+                                        }
+                                        match &job.meta.state {
+                                            Some(state) => {
+                                                if filters::has_args(state) {
+                                                    let progress_started_at = job.meta.started_at;
+                                                    if let Some(progress) = filters::job_progress(
+                                                        state,
+                                                        &progress_started_at,
+                                                    ) {
+                                                        partials::job_progress(progress: &progress)
+                                                    } else {
+                                                        <details class="mt-3">
+                                                            <summary
+                                                                class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                            >
+                                                                "State"
+                                                            </summary>
+                                                            <pre
+                                                                class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                            >
+                                                                (filters::pretty_json(state))
+                                                            </pre>
+                                                        </details>
+                                                    }
+                                                }
+                                            }
+                                            None => {
+
+                                            }
+                                        }
+                                        if kind.is_dead() {
+                                            <div class="mt-3 flex justify-end gap-2">
+                                                <button
+                                                    onclick="copyErrorInfo(this)"
+                                                    class="px-2.5 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300 text-xs transition-colors"
+                                                    data-job-name=(&job.job.name)
+                                                    data-queue=(&job.queue)
+                                                    data-created=(filters::relative_time_micros(
+                                                        &job.meta.created_at,
+                                                    ))
+                                                    data-args=(job.job.args.to_string())
+                                                    data-error=(job.meta.error.as_deref().unwrap_or(""))
+                                                >
+                                                    "Copy Error Info"
+                                                </button>
+                                                <form
+                                                    method="POST"
+                                                    action=(format!("{}/enqueue", base_path))
+                                                    onsubmit=(format!(
+                                                        "return confirm('Revive job {}?')",
+                                                        job.job.name,
+                                                    ))
+                                                >
+                                                    <input type="hidden" name="queue" value=(&job.queue)>
+                                                    <input type="hidden" name="name" value=(&job.job.name)>
+                                                    <input
+                                                        type="hidden"
+                                                        name="args"
+                                                        value=(job.job.args.to_string())
+                                                    >
+                                                    match &job.meta.state {
+                                                        Some(state) => {
+                                                            <input
+                                                                type="hidden"
+                                                                name="state"
+                                                                value=(state.to_string())
+                                                            >
+                                                        }
+                                                        None => {
+
+                                                        }
+                                                    }
+                                                    <input type="hidden" name="redirect" value="/dead">
+                                                    <button
+                                                        type="submit"
+                                                        class="px-2.5 py-1 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 text-xs transition-colors"
+                                                    >
+                                                        "Revive"
+                                                    </button>
+                                                </form>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                            </div>
+                            <div class="flex items-center justify-between mt-6 text-sm">
+                                <span class="text-gray-500">
+                                    (page.range_start())
+                                    "–"
+                                    (page.range_end())
+                                    " of "
+                                    (&page.total)
+                                </span>
+                                <div class="flex items-center gap-2">
+                                    if page.number > 1 {
+                                        <a
+                                            href=(format!("?page={}", page.number - 1))
+                                            class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                        >
+                                            "← Prev"
+                                        </a>
+                                    }
+                                    if page.has_next {
+                                        <a
+                                            href=(format!("?page={}", page.number + 1))
+                                            class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                        >
+                                            "Next →"
+                                        </a>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(
+                            include_str!("../assets/global_jobs.js"),
+                        ))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/job_detail.rs
+++ b/oxana-web-topcoat/src/views/job_detail.rs
@@ -1,0 +1,213 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{View, view},
+};
+
+impl JobDetailTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let job_id = &self.job_id;
+            let job = &self.job;
+            let is_dead = self.is_dead;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>
+                        "Job: "
+                        (job_id)
+                        " - Oxana"
+                    </title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="flex items-center justify-between mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        match &job {
+                            Some(job) => {
+                                <div class="flex items-center justify-between mb-4">
+                                    <div>
+                                        <h2 class="text-lg font-semibold">
+                                            <a
+                                                href=(format!(
+                                                    "{}/metrics/job?worker={}",
+                                                    base_path,
+                                                    urlencoding::encode(&job.job.name),
+                                                ))
+                                                class="text-blue-400 hover:text-blue-300 hover:underline"
+                                            >
+                                                (&job.job.name)
+                                            </a>
+                                        </h2>
+                                        <div
+                                            class="mt-1 text-xs text-gray-500 font-mono break-all"
+                                        >
+                                            (&job.id)
+                                        </div>
+                                    </div>
+                                    if is_dead {
+                                        <span
+                                            class="px-2 py-1 rounded bg-red-900/50 border border-red-800 text-red-300 text-xs"
+                                        >
+                                            "Dead"
+                                        </span>
+                                    }
+                                </div>
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                >
+                                    <div
+                                        class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400"
+                                    >
+                                        <div>
+                                            <span class="text-gray-500">"Queue:"</span>
+                                            <a
+                                                href=(format!(
+                                                    "{}/queues/{}",
+                                                    base_path,
+                                                    urlencoding::encode(&job.queue),
+                                                ))
+                                                class="ml-1 text-blue-400 hover:text-blue-300 hover:underline"
+                                            >
+                                                (&job.queue)
+                                            </a>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Retries:"</span>
+                                            <span class="ml-1 text-gray-300">(&job.meta.retries)</span>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Created:"</span>
+                                            <span class="ml-1 text-gray-300">
+                                                (filters::relative_time_micros(&job.meta.created_at))
+                                            </span>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Scheduled:"</span>
+                                            <span class="ml-1 text-gray-300">
+                                                (filters::relative_time_micros(&job.meta.scheduled_at))
+                                            </span>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Started:"</span>
+                                            <span class="ml-1 text-gray-300">
+                                                (filters::relative_time_micros_opt(&job.meta.started_at))
+                                            </span>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Unique:"</span>
+                                            <span class="ml-1 text-gray-300">(&job.meta.unique)</span>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Resurrect:"</span>
+                                            <span class="ml-1 text-gray-300">
+                                                (&job.meta.resurrect)
+                                            </span>
+                                        </div>
+                                        <div>
+                                            <span class="text-gray-500">"Throttle cost:"</span>
+                                            <span class="ml-1 text-gray-300">
+                                                match &job.meta.throttle_cost {
+                                                    Some(cost) => {
+                                                        (cost)
+                                                    }
+                                                    None => {
+                                                        "— "
+                                                    }
+                                                }
+                                            </span>
+                                        </div>
+                                    </div>
+                                    let arg_pills = filters::simple_args(&job.job.args);
+                                    partials::argument_pills(arg_pills: &arg_pills)
+                                    if filters::show_args_json(&job.job.args) {
+                                        <details class="mt-3" open=(true)>
+                                            <summary
+                                                class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                            >
+                                                "Arguments"
+                                            </summary>
+                                            <pre
+                                                class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                            >
+                                                (filters::pretty_json(&job.job.args))
+                                            </pre>
+                                        </details>
+                                    }
+                                    match &job.meta.state {
+                                        Some(state) => {
+                                            let progress_started_at = job.meta.started_at;
+                                            if let Some(progress) = filters::job_progress(
+                                                state,
+                                                &progress_started_at,
+                                            ) {
+                                                partials::job_progress(progress: &progress)
+                                            } else {
+                                                <details class="mt-3" open=(true)>
+                                                    <summary
+                                                        class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                    >
+                                                        "State"
+                                                    </summary>
+                                                    <pre
+                                                        class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                    >
+                                                        (filters::pretty_json(state))
+                                                    </pre>
+                                                </details>
+                                            }
+                                        }
+                                        None => {
+
+                                        }
+                                    }
+                                    match &job.meta.error {
+                                        Some(error) => {
+                                            <details class="mt-3" open=(true)>
+                                                <summary
+                                                    class="text-xs text-red-400 cursor-pointer hover:text-red-300"
+                                                >
+                                                    "Error"
+                                                </summary>
+                                                <pre
+                                                    class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-red-300 border border-red-900/50"
+                                                >
+                                                    (error)
+                                                </pre>
+                                            </details>
+                                        }
+                                        None => {
+
+                                        }
+                                    }
+                                </div>
+                            }
+                            None => {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No job found for "
+                                    <span class="font-mono">(job_id)</span>
+                                </div>
+                            }
+                        }
+                    </div>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/metric_detail.rs
+++ b/oxana-web-topcoat/src/views/metric_detail.rs
@@ -1,0 +1,273 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl MetricDetailTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let metrics = &self.metrics;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>
+                        "Metric: "
+                        (&metrics.identity.worker)
+                        " - Oxana"
+                    </title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                    let tooltip_min_width = 10;
+                    partials::chart_head(tooltip_min_width: tooltip_min_width)
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        <div
+                            class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4 mb-6"
+                        >
+                            <div>
+                                <a
+                                    href=(format!(
+                                        "{}/metrics?minutes={}",
+                                        base_path,
+                                        metrics.minutes,
+                                    ))
+                                    class="text-sm text-gray-400 hover:text-gray-200"
+                                >
+                                    "← Metrics"
+                                </a>
+                                <h2 class="mt-2 text-lg font-semibold font-mono break-all">
+                                    (&metrics.identity.worker)
+                                </h2>
+                            </div>
+                            <form
+                                method="GET"
+                                action=(format!("{}/metrics/job", base_path))
+                                class="flex items-center gap-2 text-sm"
+                            >
+                                <input
+                                    type="hidden"
+                                    name="worker"
+                                    value=(&metrics.identity.worker)
+                                >
+                                <label for="minutes" class="text-gray-400">"Window"</label>
+                                <select
+                                    id="minutes"
+                                    name="minutes"
+                                    class="bg-gray-900 border border-gray-800 rounded px-3 py-1.5 text-gray-200"
+                                    onchange="this.form.submit()"
+                                >
+                                    <option
+                                        value="60"
+                                        if metrics.minutes == 60 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "60 minutes"
+                                    </option>
+                                    <option
+                                        value="120"
+                                        if metrics.minutes == 120 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "2 hours"
+                                    </option>
+                                    <option
+                                        value="240"
+                                        if metrics.minutes == 240 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "4 hours"
+                                    </option>
+                                    <option
+                                        value="480"
+                                        if metrics.minutes == 480 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "8 hours"
+                                    </option>
+                                    <option
+                                        value="1440"
+                                        if metrics.minutes == 1440 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "24 hours"
+                                    </option>
+                                </select>
+                            </form>
+                        </div>
+                        <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-8">
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Processed"
+                                </div>
+                                <div class="text-2xl font-semibold text-green-400">
+                                    (filters::format_number_u64(&metrics.totals.processed))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Failed"
+                                </div>
+                                <div class="text-2xl font-semibold text-red-400">
+                                    (filters::format_number_u64(&metrics.totals.failed))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Succeeded"
+                                </div>
+                                <div class="text-2xl font-semibold text-emerald-400">
+                                    (filters::format_number_u64(&metrics.totals.succeeded))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Total Time"
+                                </div>
+                                <div class="text-2xl font-semibold text-blue-400">
+                                    (filters::format_duration_ms(&metrics.totals.execution_ms))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Avg Time"
+                                </div>
+                                <div class="text-2xl font-semibold text-purple-400">
+                                    (filters::format_duration_ms_f64(
+                                        metrics.totals.average_execution_ms(),
+                                    ))
+                                </div>
+                            </div>
+                        </div>
+                        <section class="space-y-6 mb-10">
+                            <div>
+                                <h2 class="text-lg font-semibold mb-4">"Average Time"</h2>
+                                <div
+                                    class="relative bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                >
+                                    <div id="average-chart" class="w-full h-[300px]"></div>
+                                </div>
+                            </div>
+                            <div>
+                                <div
+                                    class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4"
+                                >
+                                    <h2 class="text-lg font-semibold">"Total Executions"</h2>
+                                    <div
+                                        class="flex flex-wrap gap-x-4 gap-y-2 text-xs text-gray-400"
+                                    >
+                                        <span class="inline-flex items-center gap-2">
+                                            <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                                            "Succeeded"
+                                        </span>
+                                        <span class="inline-flex items-center gap-2">
+                                            <span class="h-2 w-2 rounded-full bg-red-500"></span>
+                                            "Failed"
+                                        </span>
+                                        <span class="inline-flex items-center gap-2">
+                                            <span
+                                                class="h-2 w-2 rounded-full bg-black ring-1 ring-gray-500"
+                                            ></span>
+                                            "Panicked"
+                                        </span>
+                                    </div>
+                                </div>
+                                <div
+                                    class="relative bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                >
+                                    <div id="executions-chart" class="w-full h-[300px]"></div>
+                                </div>
+                            </div>
+                        </section>
+                        <section>
+                            <h2 class="text-lg font-semibold mb-4">"Histogram"</h2>
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-4"
+                            >
+                                <div class="space-y-2">
+                                    for bucket in metrics.histogram.iter() {
+                                        <div
+                                            class="grid grid-cols-[4.5rem_1fr_5rem] items-center gap-3 text-sm"
+                                        >
+                                            <div class="text-gray-400 font-mono text-xs">
+                                                (&bucket.label)
+                                            </div>
+                                            <div
+                                                class="h-5 bg-gray-950 rounded border border-gray-800 overflow-hidden"
+                                            >
+                                                <div
+                                                    class="h-full bg-blue-500/70"
+                                                    style=(format!(
+                                                        "width: {}",
+                                                        self.histogram_width(&bucket.count),
+                                                    ))
+                                                ></div>
+                                            </div>
+                                            <div class="text-right text-gray-300 font-mono text-xs">
+                                                (filters::format_number_u64(&bucket.count))
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/charts.js")))
+                    </script>
+                    <script type="application/json" id="metric-detail-data-0">
+                        (partials::chart_json(self.detail_average_chart_data_json()))
+                    </script>
+                    <script type="application/json" id="metric-detail-data-1">
+                        (partials::chart_json(self.detail_total_chart_data_json()))
+                    </script>
+                    <script>
+                        (Unescaped::new_unchecked(
+                            include_str!("../assets/metric_detail.js"),
+                        ))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/metrics.rs
+++ b/oxana-web-topcoat/src/views/metrics.rs
@@ -1,0 +1,311 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl MetricsTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let metrics = &self.metrics;
+            let table_workers = &self.table_workers;
+            let sort = &self.sort;
+            let dir = &self.dir;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>"Metrics - Oxana"</title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                    let tooltip_min_width = 9;
+                    partials::chart_head(tooltip_min_width: tooltip_min_width)
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        <div
+                            class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6"
+                        >
+                            <h2 class="text-lg font-semibold">"Metrics"</h2>
+                            <form
+                                method="GET"
+                                action=(format!("{}/metrics", base_path))
+                                class="flex items-center gap-2 text-sm"
+                            >
+                                if self.has_sort() {
+                                    <input type="hidden" name="sort" value=(sort)>
+                                    <input type="hidden" name="dir" value=(dir)>
+                                }
+                                <label for="minutes" class="text-gray-400">"Window"</label>
+                                <select
+                                    id="minutes"
+                                    name="minutes"
+                                    class="bg-gray-900 border border-gray-800 rounded px-3 py-1.5 text-gray-200"
+                                    onchange="this.form.submit()"
+                                >
+                                    <option
+                                        value="60"
+                                        if metrics.minutes == 60 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "60 minutes"
+                                    </option>
+                                    <option
+                                        value="120"
+                                        if metrics.minutes == 120 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "2 hours"
+                                    </option>
+                                    <option
+                                        value="240"
+                                        if metrics.minutes == 240 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "4 hours"
+                                    </option>
+                                    <option
+                                        value="480"
+                                        if metrics.minutes == 480 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "8 hours"
+                                    </option>
+                                    <option
+                                        value="1440"
+                                        if metrics.minutes == 1440 {
+                                            selected=(true)
+                                        }
+                                    >
+                                        "24 hours"
+                                    </option>
+                                </select>
+                            </form>
+                        </div>
+                        <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-8">
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Processed"
+                                </div>
+                                <div class="text-2xl font-semibold text-green-400">
+                                    (filters::format_number_u64(&metrics.totals.processed))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Failed"
+                                </div>
+                                <div class="text-2xl font-semibold text-red-400">
+                                    (filters::format_number_u64(&metrics.totals.failed))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Succeeded"
+                                </div>
+                                <div class="text-2xl font-semibold text-emerald-400">
+                                    (filters::format_number_u64(&metrics.totals.succeeded))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Total Time"
+                                </div>
+                                <div class="text-2xl font-semibold text-blue-400">
+                                    (filters::format_duration_ms(&metrics.totals.execution_ms))
+                                </div>
+                            </div>
+                            <div
+                                class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                            >
+                                <div
+                                    class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                >
+                                    "Avg Time"
+                                </div>
+                                <div class="text-2xl font-semibold text-purple-400">
+                                    (filters::format_duration_ms_f64(
+                                        metrics.totals.average_execution_ms(),
+                                    ))
+                                </div>
+                            </div>
+                        </div>
+                        <section class="space-y-6 mb-10">
+                            <div>
+                                <div class="flex items-center justify-between mb-4">
+                                    <h2 class="text-lg font-semibold">"Total Time"</h2>
+                                </div>
+                                <div
+                                    class="relative bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                >
+                                    <div id="execution-chart" class="w-full h-[300px]"></div>
+                                </div>
+                            </div>
+                            <div>
+                                <div class="flex items-center justify-between mb-4">
+                                    <h2 class="text-lg font-semibold">"Total Processed"</h2>
+                                </div>
+                                <div
+                                    class="relative bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                >
+                                    <div id="processed-chart" class="w-full h-[300px]"></div>
+                                </div>
+                            </div>
+                        </section>
+                        <section>
+                            <h2 class="text-lg font-semibold mb-4">"Workers"</h2>
+                            if table_workers.is_empty() {
+                                <div
+                                    class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                                >
+                                    " No metrics "
+                                </div>
+                            } else {
+                                <div class="overflow-x-auto">
+                                    <table class="w-full text-sm">
+                                        <thead>
+                                            <tr
+                                                class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                            >
+                                                <th class="pb-3 pr-4">"Worker"</th>
+                                                <th class="pb-3 pr-4 text-right">
+                                                    <a
+                                                        href=(self.sort_href("processed"))
+                                                        class="hover:text-gray-200"
+                                                    >
+                                                        "Processed"
+                                                        (self.sort_arrow("processed"))
+                                                    </a>
+                                                </th>
+                                                <th class="pb-3 pr-4 text-right">
+                                                    <a
+                                                        href=(self.sort_href("succeeded"))
+                                                        class="hover:text-gray-200"
+                                                    >
+                                                        "Succeeded"
+                                                        (self.sort_arrow("succeeded"))
+                                                    </a>
+                                                </th>
+                                                <th class="pb-3 pr-4 text-right">
+                                                    <a
+                                                        href=(self.sort_href("failed"))
+                                                        class="hover:text-gray-200"
+                                                    >
+                                                        "Failed"
+                                                        (self.sort_arrow("failed"))
+                                                    </a>
+                                                </th>
+                                                <th class="pb-3 pr-4 text-right">
+                                                    <a
+                                                        href=(self.sort_href("total_time"))
+                                                        class="hover:text-gray-200"
+                                                    >
+                                                        "Total Time"
+                                                        (self.sort_arrow("total_time"))
+                                                    </a>
+                                                </th>
+                                                <th class="pb-3 text-right">
+                                                    <a
+                                                        href=(self.sort_href("avg_time"))
+                                                        class="hover:text-gray-200"
+                                                    >
+                                                        "Avg Time"
+                                                        (self.sort_arrow("avg_time"))
+                                                    </a>
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            for row in table_workers.iter() {
+                                                <tr
+                                                    class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                                >
+                                                    <td class="py-3 pr-4 font-mono text-sm">
+                                                        <a
+                                                            href=(format!(
+                                                                "{}/metrics/job?worker={}&minutes={}",
+                                                                base_path,
+                                                                urlencoding::encode(&row.identity.worker),
+                                                                metrics.minutes,
+                                                            ))
+                                                            title=(&row.identity.worker)
+                                                            class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                        >
+                                                            (self.metric_identity_label(&row.identity))
+                                                        </a>
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-green-400">
+                                                        (filters::format_number_u64(&row.totals.processed))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-emerald-400">
+                                                        (filters::format_number_u64(&row.totals.succeeded))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-red-400">
+                                                        (filters::format_number_u64(&row.totals.failed))
+                                                    </td>
+                                                    <td class="py-3 pr-4 text-right text-blue-400">
+                                                        (filters::format_duration_ms(&row.totals.execution_ms))
+                                                    </td>
+                                                    <td class="py-3 text-right text-purple-400">
+                                                        (filters::format_duration_ms_f64(
+                                                            row.totals.average_execution_ms(),
+                                                        ))
+                                                    </td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                            }
+                        </section>
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/charts.js")))
+                    </script>
+                    <script type="application/json" id="metrics-data-0">
+                        (partials::chart_json(self.execution_chart_data_json()))
+                    </script>
+                    <script type="application/json" id="metrics-data-1">
+                        (partials::chart_json(self.processed_chart_data_json()))
+                    </script>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/metrics.js")))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/mod.rs
+++ b/oxana-web-topcoat/src/views/mod.rs
@@ -1,0 +1,11 @@
+mod busy;
+mod cron;
+mod dashboard;
+mod global_jobs;
+mod job_detail;
+mod metric_detail;
+mod metrics;
+mod on_demand;
+mod partials;
+mod queue_detail;
+mod queues;

--- a/oxana-web-topcoat/src/views/on_demand.rs
+++ b/oxana-web-topcoat/src/views/on_demand.rs
@@ -1,0 +1,182 @@
+use super::partials;
+use crate::models::*;
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl OnDemandTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let rows = &self.rows;
+            let queues = &self.queues;
+            let total = self.total;
+            let scheduled = self.scheduled;
+            let invalid_json = self.invalid_json;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>"On-Demand - Oxana"</title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                    <style>
+                        (Unescaped::new_unchecked(
+                            include_str!("../assets/on_demand.css"),
+                        ))
+                    </style>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        if scheduled {
+                            <div
+                                data-auto-dismiss-notice=(true)
+                                class="mb-4 rounded border border-green-800 bg-green-950/40 px-4 py-3 text-sm text-green-300"
+                            >
+                                " Job scheduled. "
+                            </div>
+                        }
+                        if invalid_json {
+                            <div
+                                data-auto-dismiss-notice=(true)
+                                class="mb-4 rounded border border-red-800 bg-red-950/40 px-4 py-3 text-sm text-red-300"
+                            >
+                                " Invalid JSON. "
+                            </div>
+                        }
+                        <h2 class="text-lg font-semibold mb-4">
+                            "On-Demand Jobs ("
+                            (total)
+                            ")"
+                        </h2>
+                        if rows.is_empty() {
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                            >
+                                " No on-demand jobs registered "
+                            </div>
+                        } else if queues.is_empty() {
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                            >
+                                " No static queues registered "
+                            </div>
+                        } else {
+                            <div class="w-full text-sm">
+                                <div
+                                    class="grid grid-cols-[minmax(16rem,1fr)_auto] gap-4 border-b border-gray-800 pb-3 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                >
+                                    <div>"Worker"</div>
+                                    <div>"Action"</div>
+                                </div>
+                                <div>
+                                    for (row_index, row) in rows.iter().enumerate() {
+                                        match &row {
+                                            OnDemandRow::Group { name, depth: _ } => {
+                                                <div class="border-b border-gray-800/50">
+                                                    <div
+                                                        class="py-2 pt-4 font-mono text-xs text-gray-500 font-semibold"
+                                                        style=(format!("padding-left: {}px", row.indent_px()))
+                                                    >
+                                                        (name)
+                                                    </div>
+                                                </div>
+                                            }
+                                            OnDemandRow::Job { view: job, depth: _ } => {
+                                                <details class="border-b border-gray-800/50">
+                                                    <summary
+                                                        class="grid cursor-pointer list-none grid-cols-[minmax(16rem,1fr)_auto] gap-4 py-3 hover:bg-gray-900/50"
+                                                    >
+                                                        <span
+                                                            class="font-mono text-sm"
+                                                            style=(format!("padding-left: {}px", row.indent_px()))
+                                                        >
+                                                            <span class="text-gray-600">"↳ "</span>
+                                                            (&job.short_name)
+                                                        </span>
+                                                        <span
+                                                            class="inline-flex w-fit select-none rounded bg-green-900/50 border border-green-800 px-2.5 py-1 text-xs text-green-300 hover:bg-green-800 transition-colors"
+                                                        >
+                                                            "Enqueue"
+                                                        </span>
+                                                    </summary>
+                                                    <form
+                                                        method="POST"
+                                                        action=(format!("{}/on-demand/enqueue", base_path))
+                                                        class="w-full pb-6 pt-3"
+                                                    >
+                                                        <input type="hidden" name="name" value=(&job.name)>
+                                                        <label
+                                                            class="block text-xs text-gray-500 mb-1"
+                                                            for=(format!("queue-{}", (row_index + 1)))
+                                                        >
+                                                            "Queue"
+                                                        </label>
+                                                        <select
+                                                            id=(format!("queue-{}", (row_index + 1)))
+                                                            name="queue"
+                                                            class="w-full sm:w-72 mb-3 rounded bg-gray-950 border border-gray-800 px-3 py-2 text-sm text-gray-200"
+                                                        >
+                                                            for queue in queues.iter() {
+                                                                <option
+                                                                    value=(&queue.key)
+                                                                    if queue.selected {
+                                                                        selected=(true)
+                                                                    }
+                                                                >
+                                                                    (&queue.key)
+                                                                </option>
+                                                            }
+                                                        </select>
+                                                        <label
+                                                            class="block text-xs text-gray-500 mb-1"
+                                                            for=(format!("args-{}", (row_index + 1)))
+                                                        >
+                                                            "Arguments"
+                                                        </label>
+                                                        <textarea
+                                                            id=(format!("args-{}", (row_index + 1)))
+                                                            name="args"
+                                                            rows="10"
+                                                            spellcheck="false"
+                                                            class="w-full rounded bg-gray-950 border border-gray-800 px-3 py-2 font-mono text-xs text-gray-200"
+                                                        >
+                                                            (&job.args_template_json)
+                                                        </textarea>
+                                                        <div class="mt-3 flex justify-end">
+                                                            <button
+                                                                type="submit"
+                                                                class="rounded bg-blue-900/50 border border-blue-800 px-3 py-1.5 text-xs text-blue-300 hover:bg-blue-800 transition-colors"
+                                                            >
+                                                                "Enqueue Job"
+                                                            </button>
+                                                        </div>
+                                                    </form>
+                                                </details>
+                                            }
+                                        }
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/notices.js")))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/partials.rs
+++ b/oxana-web-topcoat/src/views/partials.rs
@@ -1,0 +1,335 @@
+use crate::filters;
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, component, view},
+};
+
+#[component]
+pub(super) async fn tabs(cx: &Cx, base_path: &str, active_tab: &str) -> topcoat::Result<impl View> {
+    Ok(view! {
+        cx =>
+        <nav class="flex gap-1 mb-8 border-b border-gray-800">
+            <a
+                href=(if base_path.is_empty() { "/" } else { base_path })
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab.is_empty() {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Overview"
+            </a>
+            <a
+                href=(format!("{}/busy", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/busy" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Busy"
+            </a>
+            <a
+                href=(format!("{}/queues", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/queues" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Queues"
+            </a>
+            <a
+                href=(format!("{}/metrics", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/metrics" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Metrics"
+            </a>
+            <a
+                href=(format!("{}/cron", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/cron" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Cron"
+            </a>
+            <a
+                href=(format!("{}/on-demand", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/on-demand" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "On-Demand"
+            </a>
+            <a
+                href=(format!("{}/scheduled", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/scheduled" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Scheduled"
+            </a>
+            <a
+                href=(format!("{}/retries", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/retries" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Retries"
+            </a>
+            <a
+                href=(format!("{}/dead", base_path))
+                class=(format!(
+                    "px-4 py-2 text-sm font-medium {}",
+                    if active_tab == "/dead" {
+                        "text-white border-b-2 border-blue-500"
+                    } else {
+                        "text-gray-400 border-b-2 border-transparent hover:text-gray-200 hover:border-gray-600"
+                    },
+                ))
+            >
+                "Dead"
+            </a>
+        </nav>
+    })
+}
+
+#[component]
+pub(super) async fn stats_cards(
+    cx: &Cx,
+    base_path: &str,
+    stats: &oxana::Stats,
+) -> topcoat::Result<impl View> {
+    Ok(view! {
+        cx =>
+        " "
+        <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-10">
+            <a
+                href=(format!("{}/busy", base_path))
+                class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block"
+            >
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    "Busy"
+                </div>
+                <div class="text-2xl font-semibold text-purple-400">
+                    (stats.processing.len())
+                </div>
+            </a>
+            <a
+                href=(format!("{}/queues", base_path))
+                class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block"
+            >
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    "Enqueued"
+                </div>
+                <div class="text-2xl font-semibold text-blue-400">
+                    (filters::format_number(&stats.global.enqueued))
+                </div>
+            </a>
+            <a
+                href=(format!("{}/retries", base_path))
+                class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block"
+            >
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    "Retries"
+                </div>
+                <div class="text-2xl font-semibold text-orange-400">
+                    (filters::format_number(&stats.global.retries))
+                </div>
+            </a>
+            <a
+                href=(format!("{}/scheduled", base_path))
+                class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block"
+            >
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    "Scheduled"
+                </div>
+                <div class="text-2xl font-semibold text-yellow-400">
+                    (filters::format_number(&stats.global.scheduled))
+                </div>
+            </a>
+            <a
+                href=(format!("{}/dead", base_path))
+                class="bg-gray-900 rounded-lg p-4 border border-gray-800 hover:border-gray-600 transition-colors block"
+            >
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    "Dead"
+                </div>
+                <div class="text-2xl font-semibold text-red-400">
+                    (filters::format_number(&stats.global.dead))
+                </div>
+            </a>
+            <div class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+                <div class="text-xs text-gray-400 uppercase tracking-wide mb-1">
+                    "Latency"
+                </div>
+                <div class="text-2xl font-semibold text-yellow-400">
+                    (filters::format_latency(&stats.global.latency_s_max))
+                </div>
+            </div>
+        </div>
+    })
+}
+
+#[component]
+pub(super) async fn argument_pills(
+    cx: &Cx,
+    arg_pills: &[filters::SimpleArgPill],
+) -> topcoat::Result<impl View> {
+    Ok(view! {
+        cx =>
+        if !arg_pills.is_empty() {
+            <div class="mt-3 flex flex-wrap gap-2">
+                for arg in arg_pills.iter() {
+                    <span
+                        class="inline-flex max-w-full overflow-hidden rounded-full border border-gray-700 bg-gray-800/70 align-middle text-xs"
+                        title=(format!("{}: {}", arg.key, arg.value))
+                        aria-label=(format!("Argument {} {}", arg.key, arg.value))
+                    >
+                        <span
+                            class="shrink-0 border-r border-gray-700 px-2 py-1 text-gray-400"
+                        >
+                            (&arg.key)
+                        </span>
+                        <span
+                            class="min-w-0 truncate px-2 py-1 font-mono text-gray-100"
+                        >
+                            (&arg.value)
+                        </span>
+                    </span>
+                }
+            </div>
+        }
+    })
+}
+
+#[component]
+pub(super) async fn job_progress(
+    cx: &Cx,
+    progress: &filters::ProgressView,
+) -> topcoat::Result<impl View> {
+    Ok(view! {
+        cx =>
+        <div class="mt-3 rounded border border-cyan-900/60 bg-cyan-950/20 p-3">
+            <div class="flex items-start justify-between gap-3">
+                <div>
+                    <div class="text-xs font-medium text-cyan-200">"Progress"</div>
+                    <div class="mt-1 text-xs text-gray-400">(&progress.summary)</div>
+                </div>
+                <div class="shrink-0 text-right">
+                    <div class="text-sm font-semibold text-cyan-200">
+                        (&progress.percent)
+                        "%"
+                    </div>
+                    <div class="mt-1 text-[11px] text-cyan-200/70">
+                        "ETA "
+                        (&progress.eta)
+                    </div>
+                </div>
+            </div>
+            <div class="mt-3 h-2 overflow-hidden rounded-full bg-gray-800">
+                <div
+                    class="h-full rounded-full bg-cyan-400 transition-all"
+                    style=(format!("width: {}%", progress.percent))
+                ></div>
+            </div>
+            if !progress.note.is_empty() {
+                <div class="mt-2 text-xs text-gray-300">(&progress.note)</div>
+            }
+        </div>
+    })
+}
+
+#[component]
+pub(super) async fn chart_head(cx: &Cx, tooltip_min_width: usize) -> topcoat::Result<impl View> {
+    Ok(view! {
+        cx =>
+        " "
+        <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.min.css"
+        >
+        <script
+            defer=(true)
+            src="https://cdn.jsdelivr.net/npm/uplot@1.6.32/dist/uPlot.iife.min.js"
+        ></script>
+        <style>
+            (Unescaped::new_unchecked(include_str!("../assets/charts.css")))
+            (Unescaped::new_unchecked(
+                format!(":root {{ --chart-tooltip-min-width: {tooltip_min_width}rem; }}"),
+            ))
+        </style>
+    })
+}
+
+/// JSON in a script element must not be able to close that element.
+pub(super) fn chart_json(json: String) -> Unescaped<String> {
+    Unescaped::new_unchecked(json.replace('<', "\\u003c"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use topcoat::view::ViewExt;
+
+    #[tokio::test]
+    async fn chart_labels_cannot_close_the_json_script() {
+        let cx = &Cx::default();
+        let data = serde_json::json!({"label": "</script><script>alert('queue')</script>"});
+        let payload = data.to_string();
+        let rendered = view! {
+            cx =>
+            <script type="application/json">(chart_json(payload))</script>
+        }
+        .single()
+        .await
+        .unwrap()
+        .render(cx);
+        assert_eq!(rendered.matches("</script>").count(), 1);
+        let json = rendered
+            .strip_prefix("<script type=\"application/json\">")
+            .unwrap()
+            .strip_suffix("</script>")
+            .unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(json).unwrap(),
+            data
+        );
+    }
+}

--- a/oxana-web-topcoat/src/views/queue_detail.rs
+++ b/oxana-web-topcoat/src/views/queue_detail.rs
@@ -1,0 +1,639 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl QueueDetailTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let queue_key = &self.queue_key;
+            let queue_stats = &self.queue_stats;
+            let active_jobs = &self.active_jobs;
+            let busy = self.busy;
+            let page = &self.page;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>
+                        "Queue: "
+                        (queue_key)
+                        " - Oxana"
+                    </title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="flex items-center justify-between mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        <div
+                            class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6"
+                        >
+                            <div class="flex flex-wrap items-center gap-3">
+                                <h2 class="text-lg font-semibold font-mono">
+                                    (queue_key)
+                                </h2>
+                                <span
+                                    class=(format!(
+                                        "px-2.5 py-1 rounded border text-xs font-medium {}",
+                                        self.state_class(),
+                                    ))
+                                >
+                                    (self.state_label())
+                                </span>
+                                <span
+                                    class="px-2.5 py-1 rounded border border-gray-800 bg-gray-900 text-gray-300 text-xs"
+                                >
+                                    " Concurrency: "
+                                    (self.concurrency_label())
+                                    if self.has_concurrency_override() {
+                                        <span class="text-gray-500">
+                                            "("
+                                            <span class="line-through">
+                                                (self.concurrency_default_label())
+                                            </span>
+                                            ")"
+                                        </span>
+                                    }
+                                </span>
+                            </div>
+                            <div class="flex flex-wrap items-center gap-2">
+                                if self.can_change_concurrency() {
+                                    <form
+                                        method="POST"
+                                        action=(self.queue_action_path("concurrency"))
+                                        onsubmit="return promptConcurrency(this)"
+                                        data-queue-key=(queue_key)
+                                        data-current-concurrency=(self.concurrency_label())
+                                        data-default-concurrency=(self.concurrency_default_label())
+                                    >
+                                        <input type="hidden" name="concurrency" value="">
+                                        <button
+                                            type="submit"
+                                            class="px-3 py-1.5 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300 text-sm transition-colors"
+                                        >
+                                            "Change concurrency"
+                                        </button>
+                                    </form>
+                                }
+                                if self.is_paused() {
+                                    <form
+                                        method="POST"
+                                        action=(format!(
+                                            "{}/queues/{}/unpause",
+                                            base_path,
+                                            urlencoding::encode(queue_key),
+                                        ))
+                                    >
+                                        <button
+                                            type="submit"
+                                            class="px-3 py-1.5 rounded bg-green-900/50 border border-green-800 hover:bg-green-800 text-green-300 text-sm transition-colors"
+                                        >
+                                            "Unpause"
+                                        </button>
+                                    </form>
+                                } else {
+                                    <form
+                                        method="POST"
+                                        action=(format!(
+                                            "{}/queues/{}/pause",
+                                            base_path,
+                                            urlencoding::encode(queue_key),
+                                        ))
+                                    >
+                                        <button
+                                            type="submit"
+                                            class="px-3 py-1.5 rounded bg-yellow-900/50 border border-yellow-800 hover:bg-yellow-800 text-yellow-300 text-sm transition-colors"
+                                        >
+                                            "Pause"
+                                        </button>
+                                    </form>
+                                }
+                                <form
+                                    method="POST"
+                                    action=(format!(
+                                        "{}/queues/{}/wipe",
+                                        base_path,
+                                        urlencoding::encode(queue_key),
+                                    ))
+                                    onsubmit=(format!("return confirmWipe('{}')", queue_key))
+                                >
+                                    <button
+                                        type="submit"
+                                        class="px-3 py-1.5 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-sm transition-colors"
+                                    >
+                                        "Wipe"
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                        match &queue_stats {
+                            Some(qs) => {
+                                <div
+                                    class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-6 gap-4 mb-8"
+                                >
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Enqueued"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-blue-400">
+                                            (filters::format_number(&qs.enqueued))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Busy"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-purple-400">
+                                            (filters::format_number(&busy))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Processed"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-green-400">
+                                            (filters::format_number_i64(&qs.processed))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Succeeded"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-emerald-400">
+                                            (filters::format_number_i64(&qs.succeeded))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Failed"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-red-400">
+                                            (filters::format_number_i64(&qs.failed))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Panicked"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-orange-400">
+                                            (filters::format_number_i64(&qs.panicked))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Latency"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-yellow-400">
+                                            (filters::format_latency(&qs.latency_s))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Processed/min"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-cyan-400">
+                                            (filters::format_rate_per_minute(
+                                                &qs.rate.processed_per_minute,
+                                            ))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Succeeded/min"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-emerald-400">
+                                            (filters::format_rate_per_minute(
+                                                &qs.rate.succeeded_per_minute,
+                                            ))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Failed/min"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-red-400">
+                                            (filters::format_rate_per_minute(&qs.rate.failed_per_minute))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "Growth/min"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-orange-400">
+                                            (filters::format_signed_rate_per_minute(
+                                                &qs.rate.growth_per_minute,
+                                            ))
+                                        </div>
+                                    </div>
+                                    <div
+                                        class="bg-gray-900 rounded-lg p-4 border border-gray-800"
+                                    >
+                                        <div
+                                            class="text-xs text-gray-400 uppercase tracking-wide mb-1"
+                                        >
+                                            "ETA"
+                                        </div>
+                                        <div class="text-2xl font-semibold text-yellow-400">
+                                            (filters::format_eta_s(&qs.rate.eta_s))
+                                        </div>
+                                    </div>
+                                </div>
+                            }
+                            None => {
+
+                            }
+                        }
+                        if !active_jobs.is_empty() {
+                            <section class="mb-8">
+                                <h2 class="text-lg font-semibold mb-4">
+                                    "Currently Processing ("
+                                    (active_jobs.len())
+                                    ")"
+                                </h2>
+                                <div class="space-y-3">
+                                    for item in active_jobs.iter() {
+                                        <div
+                                            class="bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                        >
+                                            <div class="flex items-start justify-between mb-2">
+                                                <div class="flex items-center gap-2">
+                                                    <span
+                                                        class="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse"
+                                                    ></span>
+                                                    <span class="font-semibold text-sm">
+                                                        (&item.job_envelope.job.name)
+                                                    </span>
+                                                </div>
+                                                <a
+                                                    href=(format!(
+                                                        "{}/jobs/{}",
+                                                        base_path,
+                                                        urlencoding::encode(&item.job_envelope.id),
+                                                    ))
+                                                    class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono"
+                                                >
+                                                    (&item.job_envelope.id)
+                                                </a>
+                                            </div>
+                                            <div
+                                                class="grid grid-cols-1 sm:grid-cols-4 gap-2 text-xs text-gray-400 mt-2"
+                                            >
+                                                <div>
+                                                    <span class="text-gray-500">"Process:"</span>
+                                                    <span class="ml-1 text-gray-300 font-mono">
+                                                        (&item.process_id)
+                                                    </span>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Started:"</span>
+                                                    <span class="ml-1 text-gray-300">
+                                                        (filters::relative_time_micros_opt(
+                                                            &item.job_envelope.meta.started_at,
+                                                        ))
+                                                    </span>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Scheduled:"</span>
+                                                    <span class="ml-1 text-gray-300">
+                                                        (filters::relative_time_micros(
+                                                            &item.job_envelope.meta.scheduled_at,
+                                                        ))
+                                                    </span>
+                                                </div>
+                                                <div>
+                                                    <span class="text-gray-500">"Retries:"</span>
+                                                    <span class="ml-1 text-gray-300">
+                                                        (&item.job_envelope.meta.retries)
+                                                    </span>
+                                                </div>
+                                            </div>
+                                            let arg_pills = filters::simple_args(
+                                                &item.job_envelope.job.args,
+                                            );
+                                            partials::argument_pills(arg_pills: &arg_pills)
+                                            if filters::show_args_json(&item.job_envelope.job.args) {
+                                                <details class="mt-3">
+                                                    <summary
+                                                        class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                    >
+                                                        "Arguments"
+                                                    </summary>
+                                                    <pre
+                                                        class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                    >
+                                                        (filters::pretty_json(&item.job_envelope.job.args))
+                                                    </pre>
+                                                </details>
+                                            }
+                                            match &item.job_envelope.meta.state {
+                                                Some(state) => {
+                                                    if filters::has_args(state) {
+                                                        let progress_started_at = item.job_envelope.meta.started_at;
+                                                        if let Some(progress) = filters::job_progress(
+                                                            state,
+                                                            &progress_started_at,
+                                                        ) {
+                                                            partials::job_progress(progress: &progress)
+                                                        } else {
+                                                            <details class="mt-3">
+                                                                <summary
+                                                                    class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                                >
+                                                                    "State"
+                                                                </summary>
+                                                                <pre
+                                                                    class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                                >
+                                                                    (filters::pretty_json(state))
+                                                                </pre>
+                                                            </details>
+                                                        }
+                                                    }
+                                                }
+                                                None => {
+
+                                                }
+                                            }
+                                            <div class="mt-3 flex justify-end">
+                                                <form
+                                                    method="POST"
+                                                    action=(format!(
+                                                        "{}/queues/{}/jobs/{}/delete",
+                                                        base_path,
+                                                        urlencoding::encode(queue_key),
+                                                        urlencoding::encode(&item.job_envelope.id),
+                                                    ))
+                                                    onsubmit=(format!(
+                                                        "return confirmDeleteJob('{}')",
+                                                        item.job_envelope.id,
+                                                    ))
+                                                >
+                                                    <button
+                                                        type="submit"
+                                                        class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors"
+                                                    >
+                                                        "Delete Job"
+                                                    </button>
+                                                </form>
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+                            </section>
+                        }
+                        <div class="flex items-center justify-between mb-4">
+                            <div>
+                                <h2 class="text-lg font-semibold">"Enqueued"</h2>
+                                <div class="mt-1 text-sm text-gray-400">
+                                    if page.total > 0 {
+                                        (page.range_start())
+                                        "–"
+                                        (page.range_end())
+                                        " of "
+                                        (&page.total)
+                                        " jobs "
+                                    } else {
+                                        " 0 jobs "
+                                    }
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-2 text-sm">
+                                if page.number > 1 {
+                                    <a
+                                        href=(format!("?page={}", page.number - 1))
+                                        class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                    >
+                                        "← Prev"
+                                    </a>
+                                } else {
+                                    <span
+                                        class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed"
+                                    >
+                                        "← Prev"
+                                    </span>
+                                }
+                                if page.has_next {
+                                    <a
+                                        href=(format!("?page={}", page.number + 1))
+                                        class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                    >
+                                        "Next →"
+                                    </a>
+                                } else {
+                                    <span
+                                        class="px-3 py-1 rounded bg-gray-900 border border-gray-800 text-gray-600 cursor-not-allowed"
+                                    >
+                                        "Next →"
+                                    </span>
+                                }
+                            </div>
+                        </div>
+                        if page.jobs.is_empty() {
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                            >
+                                " No jobs in this queue "
+                            </div>
+                        } else {
+                            <div class="space-y-3">
+                                for job in page.jobs.iter() {
+                                    <div
+                                        class="bg-gray-900 border border-gray-800 rounded-lg p-4"
+                                    >
+                                        <div class="flex items-start justify-between mb-2">
+                                            <span class="font-semibold text-sm">(&job.job.name)</span>
+                                            <a
+                                                href=(format!(
+                                                    "{}/jobs/{}",
+                                                    base_path,
+                                                    urlencoding::encode(&job.id),
+                                                ))
+                                                class="text-xs text-gray-500 hover:text-blue-300 hover:underline font-mono"
+                                            >
+                                                (&job.id)
+                                            </a>
+                                        </div>
+                                        <div
+                                            class="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs text-gray-400 mt-2"
+                                        >
+                                            <div>
+                                                <span class="text-gray-500">"Retries:"</span>
+                                                <span class="ml-1 text-gray-300">(&job.meta.retries)</span>
+                                            </div>
+                                            <div>
+                                                <span class="text-gray-500">"Created:"</span>
+                                                <span class="ml-1 text-gray-300">
+                                                    (filters::relative_time_micros(&job.meta.created_at))
+                                                </span>
+                                            </div>
+                                            <div>
+                                                <span class="text-gray-500">"Scheduled:"</span>
+                                                <span class="ml-1 text-gray-300">
+                                                    (filters::relative_time_micros(&job.meta.scheduled_at))
+                                                </span>
+                                            </div>
+                                        </div>
+                                        let arg_pills = filters::simple_args(&job.job.args);
+                                        partials::argument_pills(arg_pills: &arg_pills)
+                                        if filters::show_args_json(&job.job.args) {
+                                            <details class="mt-3" open=(true)>
+                                                <summary
+                                                    class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                >
+                                                    "Arguments"
+                                                </summary>
+                                                <pre
+                                                    class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                >
+                                                    (filters::pretty_json(&job.job.args))
+                                                </pre>
+                                            </details>
+                                        }
+                                        match &job.meta.state {
+                                            Some(state) => {
+                                                if filters::has_args(state) {
+                                                    let progress_started_at = job.meta.started_at;
+                                                    if let Some(progress) = filters::job_progress(
+                                                        state,
+                                                        &progress_started_at,
+                                                    ) {
+                                                        partials::job_progress(progress: &progress)
+                                                    } else {
+                                                        <details class="mt-3">
+                                                            <summary
+                                                                class="text-xs text-gray-500 cursor-pointer hover:text-gray-300"
+                                                            >
+                                                                "State"
+                                                            </summary>
+                                                            <pre
+                                                                class="mt-2 text-xs bg-gray-950 rounded p-3 overflow-x-auto text-gray-300 border border-gray-800"
+                                                            >
+                                                                (filters::pretty_json(state))
+                                                            </pre>
+                                                        </details>
+                                                    }
+                                                }
+                                            }
+                                            None => {
+
+                                            }
+                                        }
+                                        <div class="mt-3 flex justify-end">
+                                            <form
+                                                method="POST"
+                                                action=(format!(
+                                                    "{}/queues/{}/jobs/{}/delete",
+                                                    base_path,
+                                                    urlencoding::encode(queue_key),
+                                                    urlencoding::encode(&job.id),
+                                                ))
+                                                onsubmit=(format!("return confirmDeleteJob('{}')", job.id))
+                                            >
+                                                <button
+                                                    type="submit"
+                                                    class="px-2.5 py-1 rounded bg-red-900/50 border border-red-800 hover:bg-red-800 text-red-300 text-xs transition-colors"
+                                                >
+                                                    "Delete Job"
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                            <div class="flex items-center justify-between mt-6 text-sm">
+                                <span class="text-gray-500">
+                                    (page.range_start())
+                                    "–"
+                                    (page.range_end())
+                                    " of "
+                                    (&page.total)
+                                </span>
+                                <div class="flex items-center gap-2">
+                                    if page.number > 1 {
+                                        <a
+                                            href=(format!("?page={}", page.number - 1))
+                                            class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                        >
+                                            "← Prev"
+                                        </a>
+                                    }
+                                    if page.has_next {
+                                        <a
+                                            href=(format!("?page={}", page.number + 1))
+                                            class="px-3 py-1 rounded bg-gray-800 border border-gray-700 hover:bg-gray-700 text-gray-300"
+                                        >
+                                            "Next →"
+                                        </a>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(
+                            include_str!("../assets/queue_detail.js"),
+                        ))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/src/views/queues.rs
+++ b/oxana-web-topcoat/src/views/queues.rs
@@ -1,0 +1,373 @@
+use super::partials;
+use crate::{filters, models::*};
+use topcoat::{
+    context::Cx,
+    view::{Unescaped, View, view},
+};
+
+impl QueuesTemplate {
+    pub(crate) fn into_view(self, cx: &Cx) -> impl View + '_ {
+        view! {
+            cx =>
+            let base_path = &self.base_path;
+            let active_tab = self.active_tab;
+            let stats = &self.stats;
+            let queue_lengths = &self.queue_lengths;
+            let sort = &self.sort;
+            let dir = &self.dir;
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta
+                        name="viewport"
+                        content="width=device-width, initial-scale=1.0"
+                    >
+                    <title>"Queues - Oxana"</title>
+                    <script src="https://cdn.tailwindcss.com"></script>
+                    let tooltip_min_width = 9;
+                    partials::chart_head(tooltip_min_width: tooltip_min_width)
+                </head>
+                <body class="bg-gray-950 text-gray-100 min-h-screen">
+                    <div class="max-w-[88rem] mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                        <div class="mb-6">
+                            <h1 class="text-2xl font-bold tracking-tight">
+                                "Oxana Dashboard"
+                            </h1>
+                        </div>
+                        partials::tabs(base_path: base_path, active_tab: active_tab)
+                        partials::stats_cards(base_path: base_path, stats: stats)
+                        <section class="mb-10">
+                            <div
+                                class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4"
+                            >
+                                <h2 class="text-lg font-semibold">"Queue Lengths"</h2>
+                                <form
+                                    method="GET"
+                                    action=(format!("{}/queues", base_path))
+                                    class="flex items-center gap-2 text-sm"
+                                >
+                                    <input type="hidden" name="sort" value=(sort)>
+                                    <input type="hidden" name="dir" value=(dir)>
+                                    <label for="minutes" class="text-gray-400">"Window"</label>
+                                    <select
+                                        id="minutes"
+                                        name="minutes"
+                                        class="bg-gray-900 border border-gray-800 rounded px-3 py-1.5 text-gray-200"
+                                        onchange="this.form.submit()"
+                                    >
+                                        <option
+                                            value="60"
+                                            if queue_lengths.minutes == 60 {
+                                                selected=(true)
+                                            }
+                                        >
+                                            "60 minutes"
+                                        </option>
+                                        <option
+                                            value="120"
+                                            if queue_lengths.minutes == 120 {
+                                                selected=(true)
+                                            }
+                                        >
+                                            "2 hours"
+                                        </option>
+                                        <option
+                                            value="240"
+                                            if queue_lengths.minutes == 240 {
+                                                selected=(true)
+                                            }
+                                        >
+                                            "4 hours"
+                                        </option>
+                                        <option
+                                            value="480"
+                                            if queue_lengths.minutes == 480 {
+                                                selected=(true)
+                                            }
+                                        >
+                                            "8 hours"
+                                        </option>
+                                    </select>
+                                </form>
+                            </div>
+                            <div
+                                class="relative bg-gray-900 border border-gray-800 rounded-lg p-4"
+                            >
+                                <div id="queue-length-chart" class="w-full h-[300px]"></div>
+                            </div>
+                        </section>
+                        <h2 class="text-lg font-semibold mb-4">
+                            "Queues ("
+                            (stats.queues.len())
+                            ")"
+                        </h2>
+                        if stats.queues.is_empty() {
+                            <div
+                                class="bg-gray-900 border border-gray-800 rounded-lg p-6 text-center text-gray-500"
+                            >
+                                " No queues "
+                            </div>
+                        } else {
+                            <div class="overflow-x-auto">
+                                <table class="w-full text-sm">
+                                    <thead>
+                                        <tr
+                                            class="border-b border-gray-800 text-left text-xs text-gray-400 uppercase tracking-wide"
+                                        >
+                                            <th class="pb-3 pr-4">
+                                                <a
+                                                    href=(self.sort_href("key"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Queue"
+                                                    (self.sort_arrow("key"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("concurrency"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Concurrency"
+                                                    (self.sort_arrow("concurrency"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("state"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "State"
+                                                    (self.sort_arrow("state"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("enqueued"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Enqueued"
+                                                    (self.sort_arrow("enqueued"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("rate"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Rate"
+                                                    (self.sort_arrow("rate"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("eta"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "ETA"
+                                                    (self.sort_arrow("eta"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("processed"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Processed"
+                                                    (self.sort_arrow("processed"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("succeeded"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Succeeded"
+                                                    (self.sort_arrow("succeeded"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("failed"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Failed"
+                                                    (self.sort_arrow("failed"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 pr-4 text-right">
+                                                <a
+                                                    href=(self.sort_href("panicked"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Panicked"
+                                                    (self.sort_arrow("panicked"))
+                                                </a>
+                                            </th>
+                                            <th class="pb-3 text-right">
+                                                <a
+                                                    href=(self.sort_href("latency"))
+                                                    class="hover:text-gray-200"
+                                                >
+                                                    "Latency"
+                                                    (self.sort_arrow("latency"))
+                                                </a>
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        for queue in stats.queues.iter() {
+                                            <tr
+                                                class="border-b border-gray-800/50 hover:bg-gray-900/50"
+                                            >
+                                                <td class="py-3 pr-4 font-mono text-sm">
+                                                    if queue.queues.is_empty() {
+                                                        <a
+                                                            href=(format!(
+                                                                "{}/queues/{}",
+                                                                base_path,
+                                                                urlencoding::encode(&queue.key),
+                                                            ))
+                                                            class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                        >
+                                                            (&queue.key)
+                                                        </a>
+                                                    } else {
+                                                        (&queue.key)
+                                                    }
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-gray-300">
+                                                    (self.concurrency_for(&queue.key))
+                                                    if self.has_concurrency_override_for(&queue.key) {
+                                                        " "
+                                                        <span class="text-gray-500">
+                                                            "("
+                                                            <span class="line-through">
+                                                                (self.default_concurrency_for(&queue.key))
+                                                            </span>
+                                                            ")"
+                                                        </span>
+                                                    }
+                                                </td>
+                                                <td
+                                                    class=(format!(
+                                                        "py-3 pr-4 text-right {}",
+                                                        self.state_class_for(&queue.key),
+                                                    ))
+                                                >
+                                                    (self.state_for(&queue.key))
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-blue-400">
+                                                    (&queue.enqueued)
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-cyan-400">
+                                                    (filters::format_rate_per_minute(
+                                                        &queue.rate.processed_per_minute,
+                                                    ))
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-yellow-400">
+                                                    (filters::format_eta_s(&queue.rate.eta_s))
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-green-400">
+                                                    (&queue.processed)
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-green-300">
+                                                    (&queue.succeeded)
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-red-400">
+                                                    (&queue.failed)
+                                                </td>
+                                                <td class="py-3 pr-4 text-right text-red-300">
+                                                    (&queue.panicked)
+                                                </td>
+                                                <td class="py-3 text-right text-purple-400">
+                                                    (filters::format_latency(&queue.latency_s))
+                                                </td>
+                                            </tr>
+                                            for dq in queue.queues.iter() {
+                                                let dq_key = self.dynamic_queue_key(&queue.key, &dq.suffix);
+                                                <tr
+                                                    class="border-b border-gray-800/50 hover:bg-gray-900/50 text-gray-500"
+                                                >
+                                                    <td class="py-2 pr-4 pl-10 font-mono text-xs">
+                                                        "↳ "
+                                                        <a
+                                                            href=(format!(
+                                                                "{}/queues/{}%23{}",
+                                                                base_path,
+                                                                queue.key,
+                                                                urlencoding::encode(&dq.suffix),
+                                                            ))
+                                                            class="text-blue-400 hover:text-blue-300 hover:underline"
+                                                        >
+                                                            (&dq.suffix)
+                                                        </a>
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs text-gray-400">
+                                                        (self.concurrency_for(&dq_key))
+                                                        if self.has_concurrency_override_for(&dq_key) {
+                                                            " "
+                                                            <span class="text-gray-600">
+                                                                "("
+                                                                <span class="line-through">
+                                                                    (self.default_concurrency_for(&dq_key))
+                                                                </span>
+                                                                ")"
+                                                            </span>
+                                                        }
+                                                    </td>
+                                                    <td
+                                                        class=(format!(
+                                                            "py-2 pr-4 text-right text-xs {}",
+                                                            self.state_class_for(&dq_key),
+                                                        ))
+                                                    >
+                                                        (self.state_for(&dq_key))
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs">
+                                                        (&dq.enqueued)
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs text-cyan-400">
+                                                        (filters::format_rate_per_minute(
+                                                            &dq.rate.processed_per_minute,
+                                                        ))
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs text-yellow-400">
+                                                        (filters::format_eta_s(&dq.rate.eta_s))
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs">
+                                                        (&dq.processed)
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs">
+                                                        (&dq.succeeded)
+                                                    </td>
+                                                    <td class="py-2 pr-4 text-right text-xs">(&dq.failed)</td>
+                                                    <td class="py-2 pr-4 text-right text-xs">
+                                                        (&dq.panicked)
+                                                    </td>
+                                                    <td class="py-2 text-right text-xs">
+                                                        (filters::format_latency(&dq.latency_s))
+                                                    </td>
+                                                </tr>
+                                            }
+                                        }
+                                    </tbody>
+                                </table>
+                            </div>
+                        }
+                    </div>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/charts.js")))
+                    </script>
+                    <script type="application/json" id="queues-data-0">
+                        (partials::chart_json(self.queue_length_chart_data_json()))
+                    </script>
+                    <script>
+                        (Unescaped::new_unchecked(include_str!("../assets/queues.js")))
+                    </script>
+                </body>
+            </html>
+        }
+    }
+}

--- a/oxana-web-topcoat/tests/dashboard.rs
+++ b/oxana-web-topcoat/tests/dashboard.rs
@@ -1,0 +1,379 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+    response::Response,
+};
+use oxana_web_topcoat::{OxanaWebState, router, topcoat_router};
+use serde::{Deserialize, Serialize};
+use tower::ServiceExt;
+
+#[derive(Serialize)]
+struct DefaultQueue;
+
+impl oxana::Queue for DefaultQueue {
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_static("default").dynamic_concurrency(2)
+    }
+}
+
+#[derive(Serialize)]
+struct TenantQueue;
+
+impl oxana::Queue for TenantQueue {
+    fn key(&self) -> String {
+        "tenant#acme/space & more".to_string()
+    }
+
+    fn to_config() -> oxana::QueueConfig {
+        oxana::QueueConfig::as_dynamic("tenant").dynamic_concurrency(1)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, oxana::Job)]
+#[oxana(on_demand)]
+#[oxana(unique_id = "item/{id}")]
+struct DemoJob {
+    id: u64,
+    payload: String,
+}
+
+struct DemoWorker;
+
+impl oxana::FromContext<()> for DemoWorker {
+    fn from_context(_: &()) -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl oxana::Worker<DemoJob> for DemoWorker {
+    type Error = std::io::Error;
+
+    async fn run_batch(&self, _: Vec<oxana::BatchItem<DemoJob>>) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+fn state(base_path: &str) -> OxanaWebState {
+    let storage = oxana::Storage::builder()
+        .namespace(format!("oxana-topcoat-test-{}", uuid::Uuid::new_v4()))
+        .build_from_redis_url(
+            std::env::var("REDIS_URL").expect("REDIS_URL must point to a test Redis"),
+        )
+        .unwrap();
+    let mut catalog = storage
+        .runtime(())
+        .queue::<DefaultQueue>()
+        .queue::<TenantQueue>()
+        .worker::<DemoWorker, DemoJob>()
+        .catalog();
+    catalog.cron_workers.push(oxana::CronWorkerInfo {
+        name: "demo::CronWorker".to_string(),
+        schedule: "*/5 * * * * *".parse().unwrap(),
+        queue_key: "default".to_string(),
+        resurrect: false,
+    });
+    OxanaWebState::new(storage, catalog, base_path.to_string())
+}
+
+async fn get(app: &Router, uri: &str) -> Response {
+    app.clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+}
+
+async fn post(app: &Router, uri: &str, fields: &[(&str, &str)]) -> Response {
+    let body = fields
+        .iter()
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                urlencoding::encode(key),
+                urlencoding::encode(value)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("&");
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn html(response: Response) -> String {
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()["content-type"],
+        "text/html; charset=utf-8"
+    );
+    String::from_utf8(
+        to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap()
+}
+
+fn assert_redirect(response: &Response, location: &str) {
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(response.headers()["location"], location);
+}
+
+#[tokio::test]
+async fn every_page_renders_when_mounted_and_links_keep_the_prefix() {
+    let state = state("/admin/oxana");
+    let app = Router::new().nest("/admin/oxana", router(state));
+    for path in [
+        "",
+        "/busy",
+        "/queues?sort=key&dir=asc&minutes=120",
+        "/queues/default",
+        "/metrics?minutes=240",
+        "/metrics/job?worker=demo%3A%3AWorker&minutes=1440",
+        "/cron",
+        "/on-demand",
+        "/scheduled?page=2",
+        "/retries",
+        "/dead",
+        "/jobs/missing%2Fjob",
+    ] {
+        let body = html(get(&app, &format!("/admin/oxana{path}")).await).await;
+        assert!(body.contains("Oxana Dashboard"), "{path}");
+        assert!(body.contains("href=\"/admin/oxana/queues\""), "{path}");
+        assert!(!body.contains("href=\"/queues"), "{path}");
+        assert!(!body.contains("{{"), "unconverted template on {path}");
+    }
+    assert_eq!(
+        get(&app, "/admin/oxana/unknown").await.status(),
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        get(&app, "/admin/oxana/dead/wipe").await.status(),
+        StatusCode::METHOD_NOT_ALLOWED
+    );
+    let redirect = get(&app, "/admin/oxana/queues/tenant").await;
+    assert_eq!(redirect.status(), StatusCode::SEE_OTHER);
+    assert_eq!(redirect.headers()["location"], "/admin/oxana/queues");
+}
+
+#[tokio::test]
+async fn native_router_and_axum_root_mount_render_without_empty_home_links() {
+    let state = state("");
+    let native = topcoat_router(state.clone());
+    let response = native
+        .handle(
+            Request::builder()
+                .uri("/cron")
+                .body(topcoat::router::Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = html(get(&router(state), "/on-demand").await).await;
+    assert!(body.contains("href=\"/\""));
+    assert!(body.contains("action=\"/on-demand/enqueue\""));
+}
+
+#[tokio::test]
+async fn queue_controls_and_encoded_job_links_operate_on_the_selected_queue() {
+    let state = state("/admin");
+    let storage = state.storage.clone();
+    let app = Router::new().nest("/admin", router(state));
+    let queue = "/admin/queues/tenant%23acme%2Fspace%20%26%20more";
+    let job_id = storage
+        .enqueue(
+            TenantQueue,
+            DemoJob {
+                id: 1,
+                payload: "<script>alert('job')</script>".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    let body = html(get(&app, queue).await).await;
+    assert!(body.contains("&lt;script&gt;"));
+    let job_link = format!("/admin/jobs/{}", urlencoding::encode(&job_id));
+    assert!(body.contains(&format!("href=\"{job_link}\"")));
+    let detail = html(get(&app, &job_link).await).await;
+    assert!(detail.contains(&job_id));
+    assert!(detail.contains("&lt;script&gt;"));
+
+    assert_redirect(&post(&app, &format!("{queue}/pause"), &[]).await, queue);
+    assert_eq!(
+        storage
+            .queue_config(TenantQueue)
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        oxana::QueueState::Paused
+    );
+    assert_redirect(&post(&app, &format!("{queue}/unpause"), &[]).await, queue);
+    assert_eq!(
+        storage
+            .queue_config(TenantQueue)
+            .await
+            .unwrap()
+            .unwrap()
+            .state,
+        oxana::QueueState::Active
+    );
+    assert_redirect(
+        &post(
+            &app,
+            &format!("{queue}/concurrency"),
+            &[("concurrency", "4")],
+        )
+        .await,
+        queue,
+    );
+    assert_eq!(
+        storage
+            .queue_config(TenantQueue)
+            .await
+            .unwrap()
+            .unwrap()
+            .concurrency,
+        Some(4)
+    );
+    let invalid = post(
+        &app,
+        &format!("{queue}/concurrency"),
+        &[("concurrency", "0")],
+    )
+    .await;
+    assert_eq!(invalid.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        storage
+            .queue_config(TenantQueue)
+            .await
+            .unwrap()
+            .unwrap()
+            .concurrency,
+        Some(4)
+    );
+
+    assert_redirect(
+        &post(
+            &app,
+            &format!("{queue}/jobs/{}/delete", urlencoding::encode(&job_id)),
+            &[],
+        )
+        .await,
+        queue,
+    );
+    assert_eq!(storage.enqueued_count(TenantQueue).await.unwrap(), 0);
+    storage
+        .enqueue(
+            TenantQueue,
+            DemoJob {
+                id: 2,
+                payload: "wipe me".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_redirect(&post(&app, &format!("{queue}/wipe"), &[]).await, queue);
+    assert_eq!(storage.enqueued_count(TenantQueue).await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn enqueue_forms_preserve_payloads_and_redirect_to_their_pages() {
+    let state = state("/admin");
+    let storage = state.storage.clone();
+    let app = Router::new().nest("/admin", router(state));
+    assert_redirect(
+        &post(&app, "/admin/cron/enqueue", &[("name", "demo::CronWorker")]).await,
+        "/admin/cron?enqueued=1",
+    );
+    assert_redirect(
+        &post(
+            &app,
+            "/admin/on-demand/enqueue",
+            &[
+                ("name", std::any::type_name::<DemoJob>()),
+                ("queue", "default"),
+                ("args", r#"{"id":42,"payload":"<hello> & friends"}"#),
+            ],
+        )
+        .await,
+        "/admin/on-demand?scheduled=1",
+    );
+    assert_eq!(storage.enqueued_count(DefaultQueue).await.unwrap(), 2);
+    assert_redirect(
+        &post(
+            &app,
+            "/admin/on-demand/enqueue",
+            &[
+                ("name", std::any::type_name::<DemoJob>()),
+                ("queue", "default"),
+                ("args", "{"),
+            ],
+        )
+        .await,
+        "/admin/on-demand?invalid_json=1",
+    );
+    assert_eq!(storage.enqueued_count(DefaultQueue).await.unwrap(), 2);
+
+    assert_redirect(
+        &post(
+            &app,
+            "/admin/enqueue",
+            &[
+                ("queue", "default"),
+                ("name", "demo::Revived"),
+                ("args", r#"{"id":7}"#),
+                ("state", r#"{"cursor":1,"total":10}"#),
+                ("redirect", "/dead"),
+            ],
+        )
+        .await,
+        "/admin/dead",
+    );
+    let jobs = storage
+        .list_queue_jobs(
+            DefaultQueue,
+            &oxana::QueueListOpts {
+                count: 10,
+                offset: 0,
+            },
+        )
+        .await
+        .unwrap();
+    let revived = jobs
+        .iter()
+        .find(|job| job.job.name == "demo::Revived")
+        .unwrap();
+    assert_eq!(revived.job.args, serde_json::json!({"id":7}));
+    assert_eq!(
+        revived.meta.state,
+        Some(serde_json::json!({"cursor":1,"total":10}))
+    );
+    let on_demand = jobs
+        .iter()
+        .find(|job| job.job.name == std::any::type_name::<DemoJob>())
+        .unwrap();
+    assert_eq!(on_demand.job.args["payload"], "<hello> & friends");
+
+    for (action, location) in [
+        ("dead/revive_all", "/admin/dead"),
+        ("dead/wipe", "/admin/dead"),
+        ("retries/retry_all_now", "/admin/retries"),
+    ] {
+        assert_redirect(
+            &post(&app, &format!("/admin/{action}"), &[]).await,
+            location,
+        );
+    }
+    storage.wipe_queue(DefaultQueue).await.unwrap();
+}

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -92,6 +92,10 @@ For more detailed usage examples, check out the [examples directory](https://git
 
 The `oxana-web` crate provides a built-in dashboard for monitoring jobs, queues, worker metrics, and cron schedules. It integrates as a nested axum router.
 
+[`oxana-web-topcoat`](../oxana-web-topcoat/README.md) provides the same dashboard
+with Topcoat routing and Rust views. It uses the same mounting API and requires
+Rust 1.98. Both dashboard crates can be used alongside each other.
+
 ```rust
 use oxana_web::OxanaWebState;
 


### PR DESCRIPTION
Add `oxana-web-topcoat` as a workspace crate alongside `oxana-web`, providing the existing dashboard through Topcoat routing and Rust views. Applications can use the same `OxanaWebState` and Axum mounting API, or host the native Topcoat router directly.

The implementation preserves the dashboard pages, queue controls, job actions, cron and on-demand forms, progress displays, metrics charts, and styling. It includes a runnable example, usage documentation, formatted `view!` blocks, and CI coverage for the new crate. Topcoat is pinned to 0.8.0 and requires Rust 1.98.

Validation:

- Topcoat view formatting, `cargo fmt --all -- --check`, and `git diff --check` pass.
- `cargo clippy --all-features --workspace --all-targets -- -D warnings` passes.
- `cargo test -p oxana-web-topcoat -p oxana-web --all-targets` passes against isolated Redis: 70 tests for the new crate and 67 for the existing dashboard.
- HTTP tests cover native and nested routing, encoded job and queue identifiers, queue controls, enqueue payloads, and redirects.
- Compared rendered body HTML across 12 page variants against the same Redis data; the only difference was a live latency value changing between requests. Embedded JavaScript and chart JSON parse successfully. Visual browser verification was unavailable on this host.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new HTTP/UI surface that performs queue and job mutations via storage APIs, but it parallels existing `oxana-web` behavior and does not alter core `oxana` job processing.
> 
> **Overview**
> Adds **`oxana-web-topcoat`**, a new workspace crate that reimplements the Oxana admin dashboard with **Topcoat** (Rust `view!` pages + Topcoat router) instead of the Askama/`oxana-web` stack, while keeping the same **`OxanaWebState` / `router` mounting model** for Axum and an optional **`topcoat_router`** for native Topcoat hosting.
> 
> The crate carries over dashboard behavior from `oxana-web`: queue listing/detail controls (pause, concurrency, wipe), global job lists and bulk actions, cron/on-demand enqueue, metrics charts, and embedded JS/CSS assets. **CI** now runs `cargo test -p oxana-web-topcoat --all-targets`; **Topcoat 0.8.0** is pinned and the crate requires **Rust 1.98**. `Cargo.lock` grows with the Topcoat dependency tree; **`oxana-web` is unchanged** as the default UI path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ef9880b3f664ea0d8b0c47bf0f72ef5858c317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->