### PR TITLE
fix: preserve future scheduled jobs during cleanup

### DIFF
--- a/oxana/src/storage_internal.rs
+++ b/oxana/src/storage_internal.rs
@@ -1583,7 +1583,13 @@ impl StorageInternal {
 
                     match parsed {
                         Ok(job_envelope) => {
-                            if job_envelope.meta.created_at_secs() < now - JOB_EXPIRE_TIME {
+                            // Give scheduled jobs the full retention window after they become due.
+                            let retention_start_secs = job_envelope
+                                .meta
+                                .created_at
+                                .max(job_envelope.meta.scheduled_at)
+                                / 1_000_000;
+                            if retention_start_secs < now - JOB_EXPIRE_TIME {
                                 job_ids.push(job_id);
                             }
                         }
@@ -2380,9 +2386,11 @@ mod tests {
         let mut expired_envelope1 = JobEnvelope::new(queue.clone(), TestJob {})?;
         expired_envelope1.meta.created_at =
             (chrono::Utc::now().timestamp() - JOB_EXPIRE_TIME - 1) * 1000000;
+        expired_envelope1.meta.scheduled_at = expired_envelope1.meta.created_at;
         let mut expired_envelope2 = JobEnvelope::new(queue.clone(), TestJob {})?;
         expired_envelope2.meta.created_at =
             (chrono::Utc::now().timestamp() - JOB_EXPIRE_TIME - 1) * 1000000;
+        expired_envelope2.meta.scheduled_at = 0;
 
         let active_envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
 
@@ -2399,6 +2407,71 @@ mod tests {
         assert!(storage.get_job(&expired_envelope1.id).await?.is_none());
         assert!(storage.get_job(&expired_envelope2.id).await?.is_none());
         assert!(storage.get_job(&active_envelope.id).await?.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_preserves_future_scheduled_job_until_due() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+        let now = chrono::Utc::now();
+        let created_at = now - chrono::Duration::days(8);
+        let scheduled_at = created_at + chrono::Duration::days(10);
+        let mut envelope = JobEnvelope::new_scheduled(queue.clone(), TestJob {}, scheduled_at)?;
+        envelope.meta.created_at = created_at.timestamp_micros();
+        storage.enqueue_at(envelope.clone()).await?;
+
+        assert_eq!(storage.cleanup().await?, 0);
+        assert!(storage.get_job(&envelope.id).await?.is_some());
+        assert_eq!(storage.scheduled_count().await?, 1);
+        assert_eq!(storage.enqueue_scheduled(&storage.keys.schedule).await?, 0);
+
+        // Move the scheduled time into the past to simulate the job becoming due.
+        envelope.meta.scheduled_at = (now - chrono::Duration::seconds(1)).timestamp_micros();
+        storage.update_jobs(std::slice::from_ref(&envelope)).await?;
+        let mut redis = storage.connection().await?;
+        let _: () = redis
+            .zadd(
+                &storage.keys.schedule,
+                &envelope.id,
+                envelope.meta.scheduled_at,
+            )
+            .await?;
+
+        assert_eq!(storage.cleanup().await?, 0);
+        assert_eq!(storage.enqueue_scheduled(&storage.keys.schedule).await?, 1);
+        assert_eq!(storage.scheduled_count().await?, 0);
+        assert_eq!(storage.cleanup().await?, 0);
+        assert_eq!(storage.dequeue(&queue).await?, Some(envelope.id.clone()));
+        assert!(storage.get_job(&envelope.id).await?.is_some());
+        storage.finish_with_success(&envelope).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_uses_later_creation_or_scheduled_time() -> TestResult {
+        let storage = StorageInternal::new(redis_pool().await?, Some(random_string()));
+        let queue = random_string();
+        let now = chrono::Utc::now();
+
+        for (created_days_ago, scheduled_days_ago, should_expire) in
+            [(10, 6, false), (6, 10, false), (10, 8, true)]
+        {
+            let mut envelope = JobEnvelope::new(queue.clone(), TestJob {})?;
+            envelope.meta.created_at =
+                (now - chrono::Duration::days(created_days_ago)).timestamp_micros();
+            envelope.meta.scheduled_at =
+                (now - chrono::Duration::days(scheduled_days_ago)).timestamp_micros();
+            storage.enqueue(envelope.clone()).await?;
+
+            assert_eq!(storage.cleanup().await?, usize::from(should_expire));
+            assert_eq!(
+                storage.get_job(&envelope.id).await?.is_none(),
+                should_expire
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Jobs scheduled more than seven days after creation could lose their payload during cleanup before becoming due. Cleanup now starts the seven-day retention window from the later of creation time and scheduled execution time, so a job scheduled ten days ahead survives until it can run.

Regression tests cover preservation of future jobs, delivery to the worker queue when due, expiration after the revised retention window, and jobs with no scheduled timestamp.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace --all-targets -- -D warnings`
- `cargo test --lib --no-default-features`: 110 passed
- `cargo nextest run --all-features --no-fail-fast`: 180 passed
- Both new regression tests failed before the fix and passed afterward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Redis deletes job hashes, which can leave more stale data briefly but prevents losing scheduled work; behavior is covered by new cleanup tests.
> 
> **Overview**
> Fixes a bug where **Redis job cleanup** could delete scheduled work before it ran because the 7-day TTL was measured only from **`created_at`**.
> 
> **`cleanup`** now starts retention from **`max(created_at, scheduled_at)`** (microseconds converted to seconds), so jobs scheduled far in the future keep their payload until at least seven days after they become due. Jobs with **`scheduled_at == 0`** behave as before.
> 
> Adds regression tests for long-future schedules, enqueue-after-due, mixed create/schedule ages, and updates **`test_cleanup`** fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1663c42ae6e4c166688beecd9005bb254878c2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->