### PR TITLE
chore: release oxana 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.5] - 2026-09-10
+
+### Changed
+
+- Share dashboard chart, pagination, and progress rendering.
+- Simplify Redis background polling, worker execution outcomes, batch concurrency permit ownership, and queue statistics aggregation.
+
+### Fixed
+
+- Preserve future scheduled jobs during cleanup and give them the full retention window after they become due.
+
 ## [2.1.4] - 2026-08-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oxana"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-macros"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "darling",
  "heck",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "oxana-web"
-version = "2.1.4"
+version = "2.1.5"
 dependencies = [
  "askama",
  "askama_web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ default-members = ["oxana"]
 rust-version = "1.75"
 
 [workspace.dependencies]
-oxana = { version = "2.1.4", path = "oxana" }
-oxana-macros = { version = "=2.1.4", path = "oxana-macros" }
+oxana = { version = "2.1.5", path = "oxana" }
+oxana-macros = { version = "=2.1.5", path = "oxana-macros" }

--- a/oxana-macros/Cargo.toml
+++ b/oxana-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-macros"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "MIT"
 description = "Macros for Oxana."

--- a/oxana-web/Cargo.toml
+++ b/oxana-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana-web"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "MIT"
 description = "Web UI for Oxana job queue system."

--- a/oxana/Cargo.toml
+++ b/oxana/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxana"
-version = "2.1.4"
+version = "2.1.5"
 edition = "2024"
 license = "MIT"
 description = "A simple & fast job queue system."

--- a/oxana/README.md
+++ b/oxana/README.md
@@ -35,7 +35,7 @@ Oxana focuses on simplicity and depth over breadth - one backend, done well.
 ## Quick Start
 
 ```bash
-cargo add oxana@2.1.4 --features registry
+cargo add oxana@2.1.5 --features registry
 ```
 
 The `registry` feature (not enabled by default) powers `#[derive(oxana::Registry)]` and `runtime.register::<...>()` used below; without it, register queues and workers explicitly with `runtime.queue::<...>()` and `runtime.worker::<...>()`.


### PR DESCRIPTION
Bump `oxana`, `oxana-macros`, and `oxana-web` from 2.1.4 to 2.1.5, keeping workspace dependency requirements, Cargo.lock, and the README installation command aligned.

Add the 2026-09-10 changelog entry covering the scheduled-job cleanup fix and dashboard/runtime refactors since 2.1.4.

Validation:
- Verified all crate versions, workspace dependency requirements, and lockfile entries are aligned at 2.1.5.
- `cargo check --workspace --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --workspace --all-targets --locked -- -D warnings`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime code in this diff.
> 
> **Overview**
> **Release 2.1.5** — aligns `oxana`, `oxana-macros`, and `oxana-web` (plus workspace deps, `Cargo.lock`, and the README `cargo add` example) on **2.1.5**.
> 
> Adds the **2026-09-10** changelog for work since 2.1.4: shared dashboard chart/pagination/progress UI; runtime/Redis simplifications (polling, worker outcomes, batch concurrency permits, queue stats); and a fix so **future scheduled jobs** are not dropped by cleanup and get the full retention window once due.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614259a31b46f054a0f2d30cae0b6a12a9a2b1ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->