### PR TITLE
chore: update Cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,9 +1652,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
+checksum = "ba467056f1b547ed52077911161fc86985becbc60e8e1857c8a144dab0def891"
 
 [[package]]
 name = "socket2"
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.5+spec-1.1.0"
+version = "1.1.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
 dependencies = [
  "indexmap",
  "serde_core",


### PR DESCRIPTION
Updates Cargo.lock to smallvec 1.16.1 and toml 1.1.6+spec-1.1.0 using Cargo's workspace dependency resolution.

Validation passed:
- `cargo check --all --locked`
- `cargo clippy --all-features --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Runtime tests were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level lockfile updates with no code changes; low risk assuming CI checks passed.
> 
> **Overview**
> **Cargo.lock** only: bumps transitive dependencies **smallvec** `1.16.0` → `1.16.1` and **toml** `1.1.5+spec-1.1.0` → `1.1.6+spec-1.1.0` via workspace resolution. No application source changes.
> 
> Validation noted in the PR: `cargo check`, `clippy`, and `fmt --check` with `--locked`; runtime tests were not run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c198368d1799af9fcde8a8bc7235d47408f42022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->